### PR TITLE
list.jsのパス修正

### DIFF
--- a/_core/skin/dx3/list-chara.html
+++ b/_core/skin/dx3/list-chara.html
@@ -29,7 +29,7 @@
           <input type="submit" value="検索">
         </p>
       </form>
-      <script src="../_core/skin/_common/js/list.js" defer></script>
+      <script src="<TMPL_VAR coreDir>/skin/_common/js/list.js" defer></script>
       <TMPL_LOOP Lists>
       <section class="list" id="group-<TMPL_VAR ID>">
         <h2><TMPL_VAR NAME> <small><TMPL_VAR TEXT> (<TMPL_VAR NUM-PC>)</small></h2>

--- a/_core/skin/dx3/list-chara.html
+++ b/_core/skin/dx3/list-chara.html
@@ -29,7 +29,7 @@
           <input type="submit" value="検索">
         </p>
       </form>
-      <script src="./skin/js/list.js" defer></script>
+      <script src="../_core/skin/_common/js/list.js" defer></script>
       <TMPL_LOOP Lists>
       <section class="list" id="group-<TMPL_VAR ID>">
         <h2><TMPL_VAR NAME> <small><TMPL_VAR TEXT> (<TMPL_VAR NUM-PC>)</small></h2>

--- a/_core/skin/sw2/list-chara.html
+++ b/_core/skin/sw2/list-chara.html
@@ -30,7 +30,7 @@
           <input type="submit" value="検索">
         </p>
       </form>
-      <script src="./skin/js/list.js" defer></script>
+      <script src="../_core/skin/_common/js/list.js" defer></script>
       <TMPL_LOOP Lists>
       <section class="list" id="group-<TMPL_VAR ID>">
         <h2><TMPL_VAR NAME> <small><TMPL_VAR TEXT> (<TMPL_VAR NUM-PC>)</small></h2>

--- a/_core/skin/sw2/list-chara.html
+++ b/_core/skin/sw2/list-chara.html
@@ -30,7 +30,7 @@
           <input type="submit" value="検索">
         </p>
       </form>
-      <script src="../_core/skin/_common/js/list.js" defer></script>
+      <script src="<TMPL_VAR coreDir>/skin/_common/js/list.js" defer></script>
       <TMPL_LOOP Lists>
       <section class="list" id="group-<TMPL_VAR ID>">
         <h2><TMPL_VAR NAME> <small><TMPL_VAR TEXT> (<TMPL_VAR NUM-PC>)</small></h2>

--- a/_core/skin/sw2/list-item.html
+++ b/_core/skin/sw2/list-item.html
@@ -16,7 +16,7 @@
           <input type="submit" value="検索">
         </p>
       </form>
-      <script src="../_core/skin/_common/js/list.js" defer></script>
+      <script src="<TMPL_VAR coreDir>/skin/_common/js/list.js" defer></script>
       <TMPL_LOOP Lists>
       <section class="list item">
         <h2><TMPL_VAR NAME> <small><TMPL_VAR TEXT> (<TMPL_VAR NUM>)</small></h2>

--- a/_core/skin/sw2/list-item.html
+++ b/_core/skin/sw2/list-item.html
@@ -16,7 +16,7 @@
           <input type="submit" value="検索">
         </p>
       </form>
-      <script src="./skin/js/list.js" defer></script>
+      <script src="../_core/skin/_common/js/list.js" defer></script>
       <TMPL_LOOP Lists>
       <section class="list item">
         <h2><TMPL_VAR NAME> <small><TMPL_VAR TEXT> (<TMPL_VAR NUM>)</small></h2>

--- a/_core/skin/sw2/list-mons.html
+++ b/_core/skin/sw2/list-mons.html
@@ -16,7 +16,7 @@
           <input type="submit" value="検索">
         </p>
       </form>
-      <script src="../_core/skin/_common/js/list.js" defer></script>
+      <script src="<TMPL_VAR coreDir>/skin/_common/js/list.js" defer></script>
       <TMPL_LOOP Lists>
       <section class="list list-monster">
         <h2><TMPL_VAR NAME> <small>(<TMPL_VAR NUM>)</small></h2>

--- a/_core/skin/sw2/list-mons.html
+++ b/_core/skin/sw2/list-mons.html
@@ -16,7 +16,7 @@
           <input type="submit" value="検索">
         </p>
       </form>
-      <script src="./skin/js/list.js" defer></script>
+      <script src="../_core/skin/_common/js/list.js" defer></script>
       <TMPL_LOOP Lists>
       <section class="list list-monster">
         <h2><TMPL_VAR NAME> <small>(<TMPL_VAR NUM>)</small></h2>


### PR DESCRIPTION
私のサーバで最新版のゆとシートを導入させていただきましたところ、一覧画面にて `./skin/js/list.js` が見つからない旨のエラーメッセージが出ているのを確認しました。
調査の結果パスを修正しましたので、PRを送らせていただきます。