### PR TITLE
fix download for Udonarium data in FireFox

### DIFF
--- a/_core/skin/_common/js/lib/ytsheetCommon.js
+++ b/_core/skin/_common/js/lib/ytsheetCommon.js
@@ -85,6 +85,7 @@ io.github.shunshun94.trpg.ytsheet.getPicture = (src) => {
 		xhr.responseType = "blob";
 		xhr.onload = (e) => {
 			const fileName = src.slice(src.lastIndexOf("/") + 1);
+			const currentTarget = e.currentTarget;
 			if(! Boolean(jsSHA)) {
 				console.warn('To calculate SHA256 value of the picture, jsSHA is required: https://github.com/Caligatio/jsSHA');
 				resolve({ event:e, data: e.currentTarget.response, fileName: fileName, hash: '' });
@@ -94,7 +95,7 @@ io.github.shunshun94.trpg.ytsheet.getPicture = (src) => {
 				const sha = new jsSHA("SHA-256", 'ARRAYBUFFER');
 				sha.update(arraybuffer);
 				const hash = sha.getHash("HEX");
-				resolve({ event:e, data: e.currentTarget.response, fileName: fileName, hash: hash });
+				resolve({ event:e, data: currentTarget.response, fileName: fileName, hash: hash });
 				return;
 			});
 		};

--- a/_core/skin/dx3/js/lib/ytsheetToUdonariumDX3.js
+++ b/_core/skin/dx3/js/lib/ytsheetToUdonariumDX3.js
@@ -26,33 +26,6 @@ io.github.shunshun94 = io.github.shunshun94 || {};
 io.github.shunshun94.trpg = io.github.shunshun94.trpg || {};
 io.github.shunshun94.trpg.udonarium = io.github.shunshun94.trpg.udonarium || {};
 
-io.github.shunshun94.trpg.udonarium.getPicture = (src) => {
-	return new Promise((resolve, reject) => {
-		let xhr = new XMLHttpRequest();
-		xhr.open('GET', src, true);
-		xhr.responseType = "blob";
-		xhr.onload = (e) => {
-			const fileName = src.slice(src.lastIndexOf("/") + 1);
-			if(! Boolean(jsSHA)) {
-				console.warn('To calculate SHA256 value of the picture, jsSHA is required: https://github.com/Caligatio/jsSHA');
-				resolve({ event:e, data: e.currentTarget.response, fileName: fileName, hash: '' });
-				return;
-			}
-			e.currentTarget.response.arrayBuffer().then((arraybuffer)=>{
-				const sha = new jsSHA("SHA-256", 'ARRAYBUFFER');
-				sha.update(arraybuffer);
-				const hash = sha.getHash("HEX");
-				resolve({ event:e, data: e.currentTarget.response, fileName: fileName, hash: hash });
-				return;
-			});
-		};
-		xhr.onerror = () => resolve({ data: null });
-		xhr.onabort = () => resolve({ data: null });
-		xhr.ontimeout = () => resolve({ data: null });
-		xhr.send();
-	});
-};
-
 io.github.shunshun94.trpg.udonarium.generateCharacterXmlFromYtSheet2DoubleCross3PC = async (json, opt_url='', opt_imageHash='')=>{
 	const defaultPalette = await io.github.shunshun94.trpg.ytsheet.getChatPalette(opt_url);
 	const data_character = {};

--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -82,7 +82,7 @@ function getAbsoluteUrl(path) {
 async function downloadAsUdonarium() {
   const characterDataJson = await getJsonData();
   const characterId = characterDataJson.birthTime;
-  const image = await io.github.shunshun94.trpg.udonarium.getPicture(characterDataJson.imageURL || '<TMPL_VAR coreDir>/skin/dx3/img/default.png');
+  const image = await io.github.shunshun94.trpg.ytsheet.getPicture(characterDataJson.imageURL || '<TMPL_VAR coreDir>/skin/dx3/img/default.png');
   const udonariumXml = io.github.shunshun94.trpg.udonarium.generateCharacterXmlFromYtSheet2DoubleCross3PC(characterDataJson, location.href, image.hash);
   const udonariumUrl = await generateUdonariumZipFile(characterDataJson.characterName, udonariumXml, image);
   downloadFile(`udonarium_data_${characterId}.zip`, udonariumUrl);

--- a/_core/skin/sw2/js/lib/ytsheetToUdonariumSW25.js
+++ b/_core/skin/sw2/js/lib/ytsheetToUdonariumSW25.js
@@ -26,33 +26,6 @@ io.github.shunshun94 = io.github.shunshun94 || {};
 io.github.shunshun94.trpg = io.github.shunshun94.trpg || {};
 io.github.shunshun94.trpg.udonarium = io.github.shunshun94.trpg.udonarium || {};
 
-io.github.shunshun94.trpg.udonarium.getPicture = (src) => {
-	return new Promise((resolve, reject) => {
-		let xhr = new XMLHttpRequest();
-		xhr.open('GET', src, true);
-		xhr.responseType = "blob";
-		xhr.onload = (e) => {
-			const fileName = src.slice(src.lastIndexOf("/") + 1);
-			if(! Boolean(jsSHA)) {
-				console.warn('To calculate SHA256 value of the picture, jsSHA is required: https://github.com/Caligatio/jsSHA');
-				resolve({ event:e, data: e.currentTarget.response, fileName: fileName, hash: '' });
-				return;
-			}
-			e.currentTarget.response.arrayBuffer().then((arraybuffer)=>{
-				const sha = new jsSHA("SHA-256", 'ARRAYBUFFER');
-				sha.update(arraybuffer);
-				const hash = sha.getHash("HEX");
-				resolve({ event:e, data: e.currentTarget.response, fileName: fileName, hash: hash });
-				return;
-			});
-		};
-		xhr.onerror = () => resolve({ data: null });
-		xhr.onabort = () => resolve({ data: null });
-		xhr.ontimeout = () => resolve({ data: null });
-		xhr.send();
-	});
-};
-
 io.github.shunshun94.trpg.udonarium.generateCharacterXmlFromYtSheet2SwordWorldEnemy = async (json, opt_url='', opt_imageHash='')=>{
 	const defaultPalette = await io.github.shunshun94.trpg.ytsheet.getChatPalette(opt_url);
 	const data_character = {};

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -82,7 +82,7 @@ function getAbsoluteUrl(path) {
 async function downloadAsUdonarium() {
   const characterDataJson = await getJsonData();
   const characterId = characterDataJson.birthTime;
-  const image = await io.github.shunshun94.trpg.udonarium.getPicture(characterDataJson.imageURL || '<TMPL_VAR coreDir>/skin/sw2/img/default_pc.png');
+  const image = await io.github.shunshun94.trpg.ytsheet.getPicture(characterDataJson.imageURL || '<TMPL_VAR coreDir>/skin/sw2/img/default_pc.png');
   const udonariumXml = io.github.shunshun94.trpg.udonarium.generateCharacterXmlFromYtSheet2SwordWorldPC(characterDataJson, location.href, image.hash);
   const udonariumUrl = await generateUdonariumZipFile(characterDataJson.characterName, udonariumXml, image);
   downloadFile(`udonarium_data_${characterId}.zip`, udonariumUrl);

--- a/_core/skin/sw2/sheet-monster.html
+++ b/_core/skin/sw2/sheet-monster.html
@@ -81,7 +81,7 @@ function getAbsoluteUrl(path) {
 async function downloadAsUdonarium() {
   const characterDataJson = await getJsonData();
   const characterId = characterDataJson.birthTime;
-  const image = await io.github.shunshun94.trpg.udonarium.getPicture('<TMPL_VAR coreDir>/skin/sw2/img/default_enemy.png');
+  const image = await io.github.shunshun94.trpg.ytsheet.getPicture('<TMPL_VAR coreDir>/skin/sw2/img/default_enemy.png');
   const udonariumXml = io.github.shunshun94.trpg.udonarium.generateCharacterXmlFromYtSheet2SwordWorldEnemy(characterDataJson, location.href, image.hash);
   const udonariumUrl = await generateUdonariumZipFile(characterDataJson.characterName, udonariumXml, image);
   downloadFile(`udonarium_data_${characterId}.zip`, udonariumUrl);


### PR DESCRIPTION
## 起こっている現象

FireFox から Udonarium の駒をダウンロードしようとすると https://github.com/yutorize/ytsheet2/blob/dc041639c2daf003345410a7c4024388c95df80c/_core/skin/_common/js/lib/ytsheetCommon.js#L97 で `e.currentTarget` が未定義とされて処理が停止する。
Google Chrome ではこの現象は発生しない。

event が格納された変数の挙動が両ブラウザで異なる？
（すみません、原因までちゃんと追えていないです）

## 好ましい挙動

注意書きには `IEは非対応です（推奨ブラウザ：Chrome／FireFox）。` とあるため、
FireFox / Google Chrome 双方で DL できる必要がある。

## 対応

* 画像 DL の関数が共通化されていなかったので共通化
* `e.currentTarget` を別変数に入れておき、それを使うことで未定義になるのを防止