### PR TITLE
SW エネミーデータの OGP について 知名度：知名度/知名度 になっているのを 知名度/弱点値にする

### DIFF
--- a/_core/lib/sw2/view-mons.pl
+++ b/_core/lib/sw2/view-mons.pl
@@ -216,7 +216,7 @@ $SHEET->param("imageSrc" => "${set::mons_dir}${main::file}/image.$pc{'image'}?$p
 ### OGP --------------------------------------------------
 $SHEET->param(ogUrl => url().($::in{'url'} ? "?url=$::in{'url'}" : "?id=$::in{'id'}"));
 #if($pc{'image'}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
-$SHEET->param(ogDescript => "レベル:$pc{'lv'}　分類:$pc{'taxa'}".($pc{'partsNum'}>1?"　部位数:$pc{'partsNum'}":'')."　知名度:$pc{'reputation'}／$pc{'reputation'}");
+$SHEET->param(ogDescript => "レベル:$pc{'lv'}　分類:$pc{'taxa'}".($pc{'partsNum'}>1?"　部位数:$pc{'partsNum'}":'')."　知名度:$pc{'reputation'}／$pc{'reputation+'}");
 
 ### バージョン等 --------------------------------------------------
 $SHEET->param("ver" => $::ver);


### PR DESCRIPTION
以下の添付画像のように SW のエネミーデータについて OGP 上の知名度が 知名度/知名度 と表示されます。   
これは 知名度/弱点値 を本来は意図しているのではないかと。弱点値を出すように変える PR です。
![image](https://user-images.githubusercontent.com/16047644/121784714-732f4780-cbf0-11eb-8e00-57b417f14788.png)

恐れ入りますが、ご確認をお願いします。