### PR TITLE
コンバート時の挙動修正提案

### DIFF
--- a/_core/lib/dx3/convert.pl
+++ b/_core/lib/dx3/convert.pl
@@ -23,8 +23,8 @@ sub data_convert {
   my $file;
   
   ## キャラクター保管所
-  if($set_url =~ m"^https?://charasheet\.vampire-blood\.net/"){
-    my $data = data_get($set_url.'.js') or error 'キャラクター保管所のデータが取得できませんでした';
+  if($set_url =~ m"(^https?://charasheet\.vampire-blood\.net/m?[a-f0-9]+)"){
+    my $data = data_get($1.'.js') or error 'キャラクター保管所のデータが取得できませんでした';
     my %in = %{ decode_json(encode('utf8', (join '', $data))) };
     
     return convertHokanjoToYtsheet(\%in);

--- a/_core/lib/sw2/convert.pl
+++ b/_core/lib/sw2/convert.pl
@@ -23,8 +23,8 @@ sub data_convert {
   my $file;
   
   ## キャラクター保管所
-  if($set_url =~ m"^https?://charasheet\.vampire-blood\.net/"){
-    my $data = data_get($set_url.'.js') or error 'キャラクター保管所のデータが取得できませんでした';
+  if($set_url =~ m"(^https?://charasheet\.vampire-blood\.net/m?[a-f0-9]+)"){
+    my $data = data_get($1.'.js') or error 'キャラクター保管所のデータが取得できませんでした';
     my %in = %{ decode_json(encode('utf8', (join '', $data))) };
     
     return convertHokanjoToYtsheet(\%in);

--- a/_core/lib/sw2/convert.pl
+++ b/_core/lib/sw2/convert.pl
@@ -382,9 +382,9 @@ sub convertHokanjoToYtsheet {
   }
   $pc{'honorItemsNum'} = $i;
   ## 履歴
-  $pc{'history0Exp'}   = $set::make_exp;
-  $pc{'history0Honor'} = $set::make_honor;
-  $pc{'history0Money'} = $set::make_money;
+  $pc{'history0Exp'}   = $in{'create_exp'}+$in{'create_ginou_exp'};
+  $pc{'history0Honor'} = 0;
+  $pc{'history0Money'} = 1200;
   my %bases = ( '1'=>'器用', '2'=>'敏捷', '3'=>'筋力', '4'=>'生命', '5'=>'知力', '6'=>'精神' );
   my $i = 0; my $growcount;
   foreach my $grow (@{$in{'V_SN_his'}}){

--- a/_core/lib/sw2/convert.pl
+++ b/_core/lib/sw2/convert.pl
@@ -382,6 +382,9 @@ sub convertHokanjoToYtsheet {
   }
   $pc{'honorItemsNum'} = $i;
   ## 履歴
+  $pc{'history0Exp'}   = $set::make_exp;
+  $pc{'history0Honor'} = $set::make_honor;
+  $pc{'history0Money'} = $set::make_money;
   my %bases = ( '1'=>'器用', '2'=>'敏捷', '3'=>'筋力', '4'=>'生命', '5'=>'知力', '6'=>'精神' );
   my $i = 0; my $growcount;
   foreach my $grow (@{$in{'V_SN_his'}}){


### PR DESCRIPTION
# 以下の問題への対処

* キャラクター保管所の URL に余計な文字列があったらコンバートが失敗する問題への対応
（例： https://charasheet.vampire-blood.net/4129510#top
　→ https://yutorize.2-d.jp/ytsheet/sw2.0/?url=https%3A%2F%2Fcharasheet.vampire-blood.net%2F4129510%23top ）
* SW2.X についてコンバートした際の作成時の初期値（経験点3000点やお金1200ガメル）が入らない問題への対応

# 相談したいこと

SW2.X についてコンバートした際の作成時の初期値についてサーバの設定を用いるようにしています。
しかし、キャラクター保管所からコンバートする場合は常に経験点3000点やお金1200ガメルになるはずなので、
ここは固定の値を用いるべきかもしれない、と考えています。
見解・方針をお伺いしたく。

