### PR TITLE
マナフレアを選んだ後に別の種族を選ぶとデーモンルーラーが無効のままになる

### DIFF
--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -213,11 +213,10 @@ function checkRace(){
   raceAbilityMp        = 0;
   raceAbilityMagicPower= 0;
   
-  for (const name of ['Fig', 'Gra', 'Fen', 'Sho', 'Sor', 'Con', 'Pri', 'Fai', 'Mag', 'Dru', 'Dem', 'Sco', 'Ran', 'Sag', 'Enh', 'Bar', 'Rid','Alc']) {
+  for (const name of ['Fig', 'Gra', 'Fen', 'Sho', 'Sor', 'Con', 'Pri', 'Fai', 'Mag', 'Dru', 'Dem', 'Sco', 'Ran', 'Sag', 'Enh', 'Bar', 'Rid', 'Alc', 'War', 'Geo']) {
     document.getElementById("class"+name).classList.remove('fail');
   }
   
-  if(AllClassOn) document.getElementById("classWar").classList.remove('fail');
   if(AllClassOn) document.getElementById("classMys").classList.remove('fail');
   if(AllClassOn) document.getElementById("classPhy").classList.remove('fail');
   if(AllClassOn) document.getElementById("classGri").classList.remove('fail');

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -213,7 +213,7 @@ function checkRace(){
   raceAbilityMp        = 0;
   raceAbilityMagicPower= 0;
   
-  for (const name of ['Fig', 'Gra', 'Fen', 'Sho', 'Sor', 'Con', 'Pri', 'Fai', 'Mag', 'Dru', 'Sco', 'Ran', 'Sag', 'Enh', 'Bar', 'Rid','Alc']) {
+  for (const name of ['Fig', 'Gra', 'Fen', 'Sho', 'Sor', 'Con', 'Pri', 'Fai', 'Mag', 'Dru', 'Dem', 'Sco', 'Ran', 'Sag', 'Enh', 'Bar', 'Rid','Alc']) {
     document.getElementById("class"+name).classList.remove('fail');
   }
   


### PR DESCRIPTION
> [2.5キャラシで種族：マナフレア選択後に別の種族へ変えた際にデーモンルーラー技能のみ取得不可の×マークが消えなくなるようです（他の魔法技能はちゃんと消える） ](https://discord.com/channels/463088353794064384/465834682613760000/915458455186333738)

という話を受けての対応となります。処理の前に現在無効な要素を全て有効にし直すリストにデーモンルーラーが抜けていたため、そこに追加いたしました。

修正したものが動作すること自体は手元のサーバで2.0/2.5 共に確認済みです。

---

ただ、今後技能が増えた場合の対応漏れを防ぐことを考えるとまず確実に更新されるであろう`classes`変数を元に全ての要素を有効にする処理を行うほうが良いのかもしれません。
ただ、その場合は大掛かりな修正になるのと他の処理との競合がよくわからないのでよろしければ見解をお伺いしたいです。
https://github.com/yutorize/ytsheet2/blob/c172442eeff8f5d2127ba4e2f48a3757637194f7/_core/lib/sw2/edit-chara.pl#L1702 