### PR TITLE
iOS でもココフォリアへのコマ作成を可能にする

### DIFF
--- a/_core/skin/_common/css/sheet.css
+++ b/_core/skin/_common/css/sheet.css
@@ -774,6 +774,31 @@ textarea::placeholder {
 }
 
 
+/* // CopyText-Box
+---------------------------------------------------------------------------------------------------- */
+#copyText-box {
+  position: fixed;
+  bottom: -100vh;
+  left:0;
+  width: 100%;
+  height: 100%;
+  z-index: 999;
+  opacity: 0;
+  background-color: rgba(0,0,0,0.7);
+  transition-property: opacity;
+  transition-duration: 0.2s;
+  transition-timing-function: ease-out;
+}
+#copyText-box-textarea {
+  position:absolute;
+  top: 40px;
+  bottom:40px;
+  left:20px;
+  right:20px;
+  resize:none;
+}
+
+
 /* // Backup
 ---------------------------------------------------------------------------------------------------- */
 aside#backuplist,

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -14,6 +14,23 @@ function closeImage() {
     document.getElementById("image-box").style.bottom = '-100vh';
   },200);
 }
+function popCopyText(text) {
+  document.getElementById("copyText-box").style.bottom = 0;
+  document.getElementById("copyText-box").style.opacity = 1;
+  const textarea = document.getElementById("copyText-box-textarea");
+  textarea.focus();
+  textarea.value = text;
+  textarea.setSelectionRange(0, textarea.value.length);
+}
+function closeCopyText() {
+  document.getElementById("copyText-box").style.opacity = 0;
+  setTimeout(function(){
+    document.getElementById("copyText-box").style.bottom = '-100vh';
+  },200);
+}
+function stopPropagation(e) {
+  e.stopPropagation();
+}
 function editOn() {
   document.querySelectorAll('.float-box:not(#login-form)').forEach(obj => { obj.classList.remove('show') });
   document.getElementById("login-form").classList.toggle('show');
@@ -105,12 +122,20 @@ async function downloadAsUdonarium() {
   downloadFile(`udonarium_data_${characterId}.zip`, udonariumUrl);
 }
 
+function isIOS() {
+  return /[ \(]iP/.test(navigator.userAgent) || navigator.userAgent.includes('Mac OS');
+}
+
 async function downloadAsCcfolia() {
   const characterDataJson = await getJsonData();
   const json = io.github.shunshun94.trpg.ccfolia[`generateCharacterJsonFromYtSheet2${generateType}`](characterDataJson, location.href);
   json.then((result)=>{
-    copyToClipboard(result);
-    alert('クリップボードにコピーしました。ココフォリアにペーストすることでデータを取り込めます');
+    if (isIOS()) {
+      popCopyText(result);
+    } else {
+      copyToClipboard(result);
+      alert('クリップボードにコピーしました。ココフォリアにペーストすることでデータを取り込めます');
+    }
   });
   
 }

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -122,15 +122,15 @@ async function downloadAsUdonarium() {
   downloadFile(`udonarium_data_${characterId}.zip`, udonariumUrl);
 }
 
-function isIOS() {
-  return /[ \(]iP/.test(navigator.userAgent) || navigator.userAgent.includes('Mac OS');
+function isTextAreaCopyMode() {
+  return location.search.includes('textareaCopyMode') || /[ \(]iP/.test(navigator.userAgent) || navigator.userAgent.includes('Mac OS');
 }
 
 async function downloadAsCcfolia() {
   const characterDataJson = await getJsonData();
   const json = io.github.shunshun94.trpg.ccfolia[`generateCharacterJsonFromYtSheet2${generateType}`](characterDataJson, location.href);
   json.then((result)=>{
-    if (isIOS()) {
+    if (isTextAreaCopyMode()) {
       popCopyText(result);
     } else {
       copyToClipboard(result);

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -826,6 +826,9 @@ window.onload = function() {
     <TMPL_IF image><div id="image-box" onclick="closeImage()">
       <img src="<TMPL_VAR imageSrc>" id="image-box-image">
     </div></TMPL_IF> 
+    <div id="copyText-box" onclick="closeCopyText()">
+      <textarea id="copyText-box-textarea" onclick="stopPropagation(arguments[0])"></textarea>
+    </div>
   </main>
   <TMPL_INCLUDE NAME="skin-add/sheet-sidebar.html">
 


### PR DESCRIPTION
# これは何

https://discord.com/channels/791236985116426271/791237812519043073/955311895127142491 への対応案です。
クリップボードに直接コピーするのではなく、テキストエリアを表示させてそこからユーザにコピーさせる感じです。

# 確認状況

https://hiyo-hitsu.sakura.ne.jp/ytsheets/staging/sw2.5/?id=yJGPyI で予想通り表示される事を Safari @ iPad で確認。
また、Windows・Android から試した場合に従来どおりコピーされる

以下からアクセスすると Windows でも Android でもテキストエリアを表示させてそこからユーザにコピーさせる挙動になります（URL 末尾に `&textareaCopyMode` を付与）
https://hiyo-hitsu.sakura.ne.jp/ytsheets/staging/sw2.5/?id=yJGPyI&textareaCopyMode

# 認識している課題

ただ以下は未確認です（端末がそもそも無いので確認し難くもあります）。
* Mac だとどうなる?（そもそも同様に動かなかったのかすら私は確認できていない）
* ~~iPhone でもうごく？~~ 動作する旨を確認しました

# SW2.5 向けにしか実装されていないようだが

現時点で SW2.5 向けにしか実装してません。実装方針が固まったら他システムにも同様に展開したものをコミットします。