### PR TITLE
iOS でもココフォリアへのコマ作成を可能にする

### DIFF
--- a/_core/skin/_common/css/sheet.css
+++ b/_core/skin/_common/css/sheet.css
@@ -773,6 +773,30 @@ textarea::placeholder {
   object-fit: scale-down;
 }
 
+/* // CopyText-Box
+---------------------------------------------------------------------------------------------------- */
+#copyText-box {
+  position: fixed;
+  bottom: 0;
+  left:0;
+  width: 100%;
+  height: 100%;
+  z-index: 998;
+  opacity: 1;
+  background-color: rgba(0,0,0,0.7);
+  transition-property: opacity;
+  transition-duration: 0.2s;
+  transition-timing-function: ease-out;
+}
+#copyText-box-textarea {
+  position:absolute;
+  top: 40px;
+  bottom:40px;
+  left:20px;
+  right:20px;
+  z-index: 999;
+  resize:none;
+}
 
 /* // Backup
 ---------------------------------------------------------------------------------------------------- */

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -85,20 +85,24 @@ function downloadFile(title, url) {
 }
 
 function copyToClipboard(text) {
+  const confirmBehavior = (location.search.includes('confirmBehavior')) ? (text)=>{alert(text);} : ()=>{};
   const textarea = document.createElement('textarea');
   document.getElementById('downloadlist').appendChild(textarea);
   textarea.value = text;
   textarea.focus();
   textarea.setSelectionRange(0, textarea.value.length);
-  const isCopied = document.execCommand('copy')
+  const isCopied = document.execCommand('copy');
   textarea.remove();
   if (isCopied) {
+    confirmBehavior('isCopied is "true"');
     return;
   } else if (location.protocol === 'https:') {
     if( navigator.clipboard ) {
+      confirmBehavior('isCopied is "false". navigator.clipboard will be used');
       navigator.clipboard.writeText(text);
       return;
     } else if ( window.clipboardData ) {
+      confirmBehavior('isCopied is "false". window.clipboardData.setData will be used');
       window.clipboardData.setData('Text', text);
       return;
     }

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -145,6 +145,7 @@ function getClipboardItem() {
       });
     }, (err)=>{
       console.error(err);
+      alert('キャラクターシートのデータ取得に失敗しました。通信状況等をご確認ください');
     })
   });
 }

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -14,6 +14,25 @@ function closeImage() {
     document.getElementById("image-box").style.bottom = '-100vh';
   },200);
 }
+function closeTextareaForCopy() {
+  document.getElementById('copyText-box').remove();
+  document.getElementById('copyText-box-textarea').remove();
+}
+function popTextareaForCopy(text) {
+  const div = document.createElement('div');
+  div.id = 'copyText-box';
+  div.onclick = closeTextareaForCopy;
+
+  const textarea = document.createElement('textarea');
+  textarea.id = 'copyText-box-textarea';
+  textarea.value = text;
+
+  document.getElementsByTagName('main')[0].appendChild(div);
+  document.getElementsByTagName('main')[0].appendChild(textarea);
+
+  textarea.focus();
+  textarea.setSelectionRange(0, textarea.value.length);
+}
 function editOn() {
   document.querySelectorAll('.float-box:not(#login-form)').forEach(obj => { obj.classList.remove('show') });
   document.getElementById("login-form").classList.toggle('show');
@@ -137,7 +156,7 @@ function clipboardItemToTextareaClipboard(clipboardItem) {
         copyToClipboard(jsonText);
         alert('クリップボードにコピーしました。ココフォリアにペーストすることでデータを取り込めます');
       } catch (e) {
-        alert('クリップボードへのコピーに失敗しました');
+        popTextareaForCopy(jsonText);
       }
     });
   });

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -85,15 +85,25 @@ function downloadFile(title, url) {
 }
 
 function copyToClipboard(text) {
-  // navigator.clipboard.writeText(text); は許可されていなければ動作せず、
-  // 非 SSL で繋いでいる場合は許可することすらできないので利用できない。
   const textarea = document.createElement('textarea');
   document.getElementById('downloadlist').appendChild(textarea);
   textarea.value = text;
   textarea.focus();
   textarea.setSelectionRange(0, textarea.value.length);
-  document.execCommand('copy');
+  const isCopied = document.execCommand('copy')
   textarea.remove();
+  if (isCopied) {
+    return;
+  } else if (location.protocol === 'https:') {
+    if( navigator.clipboard ) {
+      navigator.clipboard.writeText(text);
+      return;
+    } else if ( window.clipboardData ) {
+      window.clipboardData.setData('Text', text);
+      return;
+    }
+  }
+  throw 'クリップボードへの書き込みに失敗しました';
 }
 
 async function downloadAsUdonarium() {
@@ -109,8 +119,12 @@ async function downloadAsCcfolia() {
   const characterDataJson = await getJsonData();
   const json = io.github.shunshun94.trpg.ccfolia[`generateCharacterJsonFromYtSheet2${generateType}`](characterDataJson, location.href);
   json.then((result)=>{
-    copyToClipboard(result);
-    alert('クリップボードにコピーしました。ココフォリアにペーストすることでデータを取り込めます');
+    try {
+      copyToClipboard(result);
+      alert('クリップボードにコピーしました。ココフォリアにペーストすることでデータを取り込めます');
+    } catch(e) {
+      alert(e);
+    }
   });
   
 }


### PR DESCRIPTION
# これは何
[iPhone 等からココフォリアのクリップボード機能が動かない問題](https://discord.com/channels/791236985116426271/791237812519043073/955311895127142491)への対応案です。

# 挙動
|端末|HTTPS|HTTP|
|----|----|----|
|iPhone等|`navigator.clipboard.write`|テキストエリアを表示し手動でコピーさせる|
|Windows等|`document.execCommand`|`document.execCommand`|

実際は次の挙動をします。
```javascript
if(navigator.clipboardが利用可能ならば) {
  ClipboardItemを用いてnavigator.clipboard.writeを試みる
  if(ClipboardItemを用いたnavigator.clipboard.writeが成功したら) {
    終了
  } else {
    document.execCommand を用いた方法を試みる
    if(document.execCommand を用いた方法が成功したら) {
      終了
    } else {
      テキストエリアを表示して手動コピーさせる
    }
  }
} else {
  document.execCommand を用いた方法を試みる
  if(document.execCommand を用いた方法が成功したら) {
    終了
  } else {
    テキストエリアを表示して手動コピーさせる
  }
}
```

# 確認状況
このコードは実際に以下環境で実動作させているため、挙動については以下からご確認いただけます。
https://hiyo-hitsu.sakura.ne.jp/ytsheets/ytsheet2_sw2.5/sw2.5/?id=kU3NoI

HTTPS 環境については Windows PC と iPad から動作確認済みです。

# なんでこんな方法で書いたのか
iPadやiPhoneにおいてはクリップボードはユーザが実行したなんらかのアクション（例えば onclick）に応じて呼び出される必要があります（[New WebKit Features in Safari 13.1 | WebKit](https://webkit.org/blog/10247/new-webkit-features-in-safari-13-1/)）。しかし、ココフォリアの情報を処理するために非同期処理を挟んだことで "ユーザが実行したなんらかのアクションに応じて呼び出され" たとは判断されていなかったようです。

しかし、[`ClipboardItem`](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem)を用いて`navigator.clipboard.write`を試みることでユーザが実行した何らかのアクションに応じて`navigator.clipboard.write`を呼び出しつつ、クリップボードに挿入したいテキストの内容は非同期で取得できました。

ただ、この方法は従来の `execCommand` には使えませんからこの方法は HTTPS で接続されているゆとシートにしか利用できません。そのため HTTP の場合に対応するためにテキストエリアを出力する #29 で提案した手法を併用しています。


