### PR TITLE
出力にまつわる問題点の解消

### DIFF
--- a/_core/skin/_common/js/lib/ytsheetCommon.js
+++ b/_core/skin/_common/js/lib/ytsheetCommon.js
@@ -128,11 +128,11 @@ io.github.shunshun94.trpg.ytsheet.separateParametersFromChatPalette = (chatPalet
 	return result;
 };
 
-io.github.shunshun94.trpg.ytsheet.getChatPalette = (sheetUrl) => {
+io.github.shunshun94.trpg.ytsheet.getChatPalette = () => {
+	const paramId = /id=[1-9a-zA-Z]+/.exec(location.href)[0];
 	return new Promise((resolve, reject)=>{
-		if(sheetUrl === '' || ! sheetUrl.startsWith(location.origin)) {resolve('');return;}
 		let xhr = new XMLHttpRequest();
-		xhr.open('GET', `${sheetUrl}&tool=bcdice&mode=palette`, true);
+		xhr.open('GET', `./?${paramId}&tool=bcdice&mode=palette`, true);
 		xhr.responseType = "text";
 		xhr.onload = (e) => {
 			resolve(io.github.shunshun94.trpg.ytsheet.separateParametersFromChatPalette(e.currentTarget.response));

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -64,9 +64,10 @@ function chatPaletteSelect(tool) {
 }
 // 保存系 ----------------------------------------
 function getJsonData() {
+  const paramId = /id=[1-9a-zA-Z]+/.exec(location.href)[0];
   return new Promise((resolve, reject)=>{
     let xhr = new XMLHttpRequest();
-    xhr.open('GET', `${location.href}&mode=json`, true);
+    xhr.open('GET', `./${paramId}&mode=json`, true);
     xhr.responseType = "json";
     xhr.onload = (e) => {
       resolve(e.currentTarget.response);

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -67,7 +67,7 @@ function getJsonData() {
   const paramId = /id=[1-9a-zA-Z]+/.exec(location.href)[0];
   return new Promise((resolve, reject)=>{
     let xhr = new XMLHttpRequest();
-    xhr.open('GET', `./${paramId}&mode=json`, true);
+    xhr.open('GET', `./?${paramId}&mode=json`, true);
     xhr.responseType = "json";
     xhr.onload = (e) => {
       resolve(e.currentTarget.response);


### PR DESCRIPTION
# mode=any の際に上手く動かない問題
## 発生している事象
> [「パスワードが間違っているか、編集権限がありません。」と表示された画面から「出力」の各種操作をこころみると、ただしく実行されない](https://discord.com/channels/791236985116426271/791237812519043073/997326445871386675)

　キャラクターシートを編集しようとした場合、 `https://yutorize.2-d.jp/ytsheet/some_system/?mode=edit&id=xxxxxx` にアクセスする。しかし、編集権限がない場合、一見 `https://yutorize.2-d.jp/ytsheet/some_system/?id=xxxxxx` にアクセスした時と同様にキャラクターシートが表示されながらも "パスワードが間違っているか、編集権限がありません。" とメッセージが表示される。
　この状態で json データを取得しようとした場合、今の挙動だと `https://yutorize.2-d.jp/ytsheet/some_system/?mode=edit&id=xxxxxx&mode=json` へのアクセスとなり、`mode` は `edit` として扱われる。そのため、json データは取得できない。

## 対応
　その時点でアクセスしているページの `mode` の値に関わらず `./?id=xxxxxx&mode=json` にアクセスするように変更した。
　また、チャットパレットの取得についても同様の問題があったため、修正している。

# FireFox で動かない問題
## 発生している事象
> [FireFoxでのみココフォリア出力でエラー](https://discord.com/channels/791236985116426271/791237812519043073/997560203681734746)

　`ClipboardItem` および `navigator.clipboard.write` が FireFox では実装されていないことが原因。

## 対応
　`ClipboardItem` を参照して未定義である旨のエラーが throw された際、それを catch してインターフェースだけ似せた別のオブジェクトを返すように変更した（[ここ](https://github.com/Shunshun94/ytsheet_sw2.5/blob/1c5bc6c2042a807d008f5a68427e4b246377b8d9/_core/skin/_common/js/sheet.js#L154-L165)）。
　また、`navigator.clipboard.write` が定義されていない場合は HTTP の場合と同様、代替の実装を動かすようにした（[ここ](https://github.com/Shunshun94/ytsheet_sw2.5/blob/1c5bc6c2042a807d008f5a68427e4b246377b8d9/_core/skin/_common/js/sheet.js#L184)）

# 動作確認
　どちらの問題についても[自前のサーバのキャラクターシート](https://hiyo-hitsu.sakura.ne.jp/ytsheets/ytsheet2_sw2.5/sw2.5/?id=5OWWL5&mode=koneko)で動作を確認している。Google Chrome@Windows11、FireFox@Windows11、Safari@iPhone で確認済み。
