### PR TITLE
ルビ記法の代替を追加

### DIFF
--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -450,7 +450,7 @@ sub tagUnescape {
   $text =~ s/%%(.+?)%%/<span class="strike">$1<\/span>/gi;  # 打ち消し線
   $text =~ s/__(.+?)__/<span class="underline">$1<\/span>/gi;  # 下線
   $text =~ s/\{\{(.+?)\}\}/<span style="color:transparent">$1<\/span>/gi;  # 透明
-  $text =~ s/[|｜]([^|｜\n]+?)《(.+?)》/<ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby>/gi; # なろう式ルビ
+  $text =~ s/[|｜]([^|｜\n]+?)[《⟪](.+?)[⟫》]/<ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby>/gi; # なろう式ルビ
   $text =~ s/《《(.+?)》》/<span class="text-em">$1<\/span>/gi; # カクヨム式傍点
   
   $text =~ s/\[\[(.+?)&gt;((?:(?!<br>)[^"])+?)\]\]/&tagLinkUrl($2,$1)/egi; # リンク


### PR DESCRIPTION
二重山括弧（ DOUBLE ANGLE BRACKET ）の代わりに MATHEMATICAL DOUBLE ANGLE BRACKET をもちいる記法を追加。