### PR TITLE
[DX3] エフェクトの「制限」欄の入力候補にアージエフェクト用のものを追加

### DIFF
--- a/_core/lib/dx3/edit-chara.js
+++ b/_core/lib/dx3/edit-chara.js
@@ -16,7 +16,7 @@ window.onload = function() {
   calcMagic();
   calcItem();
   calcMemory();
-  calcEncroach();
+  refreshByImpulse();
   for(let i = 1; i <= 7; i++){ changeLoisColor(i); }
   imagePosition();
   changeColor();
@@ -274,6 +274,30 @@ function calcExp(){
   document.getElementById("exp-used-item"  ).innerHTML = exps['item']   || 0;
   document.getElementById("exp-used-memory").innerHTML = exps['memory'] || 0;
   document.getElementById("exp-rest").innerHTML = rest;
+}
+
+// 「衝動」由来の更新
+function refreshByImpulse(){
+  calcEncroach();
+
+  const optionClass = 'restrict-option-for-impulse';
+
+  const oldElement = document.querySelector(`#list-restrict .${optionClass}`);
+  if (oldElement != null) {
+    oldElement.parentNode.removeChild(oldElement);
+  }
+
+  const impulseName = document.querySelector('select[name="lifepathImpulse"]').value;
+
+  if (impulseName == null || impulseName === '') {
+    return;
+  }
+
+  const newElement = document.createElement('option');
+  newElement.classList.add(optionClass);
+  newElement.setAttribute('value', `${impulseName}、120%`);
+
+  document.querySelector('#list-restrict .percent120').after(newElement);
 }
 
 // 侵蝕値 ----------------------------------------

--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -519,7 +519,7 @@ print <<"HTML";
           <tbody>
           <tr>
             <th rowspan="2">衝動</th>
-            <td><select name="lifepathImpulse" oninput="calcEncroach()">@{[option "lifepathImpulse",@impulses]}</select></td>
+            <td><select name="lifepathImpulse" oninput="refreshByImpulse()">@{[option "lifepathImpulse",@impulses]}</select></td>
             <th class="small">侵蝕値</th>
             <td class="center" id="impulse-encroach"></td>
             <td class="left">@{[input "lifepathImpulseNote",'','','placeholder="備考"']}</td>
@@ -1406,7 +1406,7 @@ print <<"HTML";
     <option value="ピュア">
     <option value="80%">
     <option value="100%">
-    <option value="120%">
+    <option value="120%" class="percent120">
     <option value="Dロイス">
     <option value="リミット">
     <option value="RB">


### PR DESCRIPTION
# 出典

ルール定義は『レネゲイズアージ』p14。データの例は同書p24など。

# 仕様

 * 「衝動」が選択されていれば、 `{その衝動名}、120%` が入力候補に表示される。
 * 「衝動」が選択されていなければ、従来どおり。

# 実装

「衝動」欄に応じて datalist を動的に操作する。

# 動作イメージ

![image](https://user-images.githubusercontent.com/44130782/193478654-a838d979-62f1-4b6e-85fc-3f333d0ea6f3.png)
