### PR TITLE
キャラクターシートの閲覧画面のドキュメント内でゆとチャ用出力の URL を明示する

### DIFF
--- a/_core/skin/_common/sheet-head.html
+++ b/_core/skin/_common/sheet-head.html
@@ -12,6 +12,12 @@
     <meta name="twitter:site" content="@yutorize">
     <TMPL_IF hide><meta name="robots" content="none"></TMPL_IF>
   </TMPL_UNLESS>
+  <TMPL_IF convertUrl>
+  <link rel="ytchat-body-exporting-point" type="application/json" href="./?url=<TMPL_VAR convertUrl>&mode=json">
+  <TMPL_ELSE>
+  <link rel="ytchat-body-exporting-point" type="application/json" href="./?id=<TMPL_VAR id>&mode=json">
+  <link rel="ytchat-palette-exporting-point" type="text/plain" href="./?id=<TMPL_VAR id>&mode=palette">
+  </TMPL_IF>
   <link rel="stylesheet" data-dl href="<TMPL_VAR coreDir>/skin/_common/css/base.css?<TMPL_VAR ver>">
   <link rel="stylesheet" data-dl href="<TMPL_VAR coreDir>/skin/_common/css/sheet.css?<TMPL_VAR ver>">
   <link rel="stylesheet" data-dl href="<TMPL_VAR coreDir>/skin/<TMPL_VAR gameDir>/css/<TMPL_VAR sheetType>.css?<TMPL_VAR ver>">


### PR DESCRIPTION
ゆとチャがアクセスすべき URL を文書（HTML）内で明示する。
（ `&mode=json` やら `&mode=palette` やらの、ゆとシの実装詳細に関する知識をゆとチャから間接化する）
