### PR TITLE
Fix: コメントアウト記法（ `//...` ）を使用したときに改行がのこらないように

### DIFF
--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -386,7 +386,7 @@ sub tag_unescape_lines {
   my $text = $_[0];
   $text =~ s/&lt;br&gt;/\n/gi;
   
-  $text =~ s|^//(.*?)$||gm; # コメントアウト
+  $text =~ s|^//(.*?)\n?$||gm; # コメントアウト
   
   $text =~ s/\\\\\n/<br>/gi;
   


### PR DESCRIPTION
コメントアウト記法をもちいたとき、その行の数だけ改行が表示上でのこるようになっていた。
（のを直す）