### PR TITLE
[DX3] Fix: 能力値の成長がない場合、表示画面の「経験点計算」の「能力値」が空欄になるのを修正

### DIFF
--- a/_core/lib/dx3/calc-chara.pl
+++ b/_core/lib/dx3/calc-chara.pl
@@ -19,6 +19,7 @@ sub data_calc {
   
   ### 能力値 --------------------------------------------------
   my %status = (0=>'body', 1=>'sense', 2=>'mind', 3=>'social');
+  $pc{'expUsedStatus'} = 0;
   foreach my $num (keys %status){
     my $name = $status{$num};
     my $Name = ucfirst $name;


### PR DESCRIPTION
なお、この値の解決は保存時におこなわれているので、既存データには保存しなおさないと反映されない。