### PR TITLE
[DX3] Fix: 編集画面の経験点内訳の表示における数式の誤りを修正

### DIFF
--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -1018,11 +1018,11 @@ print <<"HTML";
         <p>
         経験点[<b id="exp-total"></b>] - 
         ( 能力値[<b id="exp-used-status"></b>]
-        - 技能[<b id="exp-used-skill"></b>]
-        - エフェクト[<b id="exp-used-effect"></b>]
-        <span class="cc-only">- 術式[<b id="exp-used-magic"></b>]</span>
-        - アイテム[<b id="exp-used-item"></b>]
-        - メモリー[<b id="exp-used-memory"></b>]
+        + 技能[<b id="exp-used-skill"></b>]
+        + エフェクト[<b id="exp-used-effect"></b>]
+        <span class="cc-only">+ 術式[<b id="exp-used-magic"></b>]</span>
+        + アイテム[<b id="exp-used-item"></b>]
+        + メモリー[<b id="exp-used-memory"></b>]
         ) = 残り[<b id="exp-rest"></b>]点
         </p>
       </div>


### PR DESCRIPTION
　数式として読む場合、括弧内の各演算は加算でなければおかしい。

　（ `消費できる上限 - ( 消費の内訳 ) = 残り` というニュアンスの式なので、括弧部分の計算結果は消費の合計にならなければならない）

　（ `x - ( a - b )` を展開すると `x - a + b` になってしまう）