### PR TITLE
og:imageのmetaタグのurlが `ytsheet/sw2.5//./?` のように、パス中に `/./` が混ざる問題への対応

### DIFF
--- a/_core/lib/ar2e/view-chara.pl
+++ b/_core/lib/ar2e/view-chara.pl
@@ -4,6 +4,7 @@ use strict;
 use utf8;
 use open ":utf8";
 use HTML::Template;
+use URI;
 
 ### データ読み込み ###################################################################################
 require $set::data_class;
@@ -626,7 +627,7 @@ if($pc{'imageCopyrightURL'}){
 
 ### OGP --------------------------------------------------
 $SHEET->param(ogUrl => url().($::in{'url'} ? "?url=$::in{'url'}" : "?id=$::in{'id'}"));
-if($pc{'image'}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
+if($pc{'image'}) { $SHEET->param(ogImg => URI->new_abs($imgsrc, url())); }
 $SHEET->param(ogDescript => tag_delete "種族:$pc{'race'}　性別:$pc{'gender'}　年齢:$pc{'age'}　クラス:$pc{'classMain'}／$pc{'classSupport'}".($pc{'classTitle'}?"／$pc{'classTitle'}":''));
 
 ### バージョン等 --------------------------------------------------

--- a/_core/lib/blp/view-chara.pl
+++ b/_core/lib/blp/view-chara.pl
@@ -4,6 +4,7 @@ use strict;
 use utf8;
 use open ":utf8";
 use HTML::Template;
+use URI;
 
 ### データ読み込み ###################################################################################
 # なし
@@ -424,7 +425,7 @@ $SHEET->param(images    => $images);
 
 ### OGP --------------------------------------------------
 $SHEET->param(ogUrl => url().($::in{'url'} ? "?url=$::in{'url'}" : "?id=$::in{'id'}"));
-if($pc{'image'}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
+if($pc{'image'}) { $SHEET->param(ogImg => URI->new_abs($imgsrc, url())); }
 $SHEET->param(ogDescript => tag_delete "ファクター:$pc{'factor'}／$pc{'factorCore'}／$pc{'factorStyle'}　性別:$pc{'gender'}　年齢:$pc{'age'}　".($pc{'factor'} eq '吸血鬼' ? '欠落':'喪失').":$pc{'missing'}　所属:$pc{'belong'}");
 
 ### バージョン等 --------------------------------------------------

--- a/_core/lib/dx3/view-chara.pl
+++ b/_core/lib/dx3/view-chara.pl
@@ -4,6 +4,7 @@ use strict;
 use utf8;
 use open ":utf8";
 use HTML::Template;
+use URI;
 
 ### データ読み込み ###################################################################################
 require $set::data_syndrome;
@@ -666,7 +667,7 @@ if($pc{'imageCopyrightURL'}){
 
 ### OGP --------------------------------------------------
 $SHEET->param(ogUrl => url().($::in{'url'} ? "?url=$::in{'url'}" : "?id=$::in{'id'}"));
-if($pc{'image'}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
+if($pc{'image'}) { $SHEET->param(ogImg => URI->new_abs($imgsrc, url())); }
 $SHEET->param(ogDescript => tag_delete "性別:$pc{'gender'}　年齢:$pc{'age'}　ワークス:$pc{'works'}　シンドローム:$pc{'syndrome1'} $pc{'syndrome2'} $pc{'syndrome3'}");
 
 ### バージョン等 --------------------------------------------------

--- a/_core/lib/kiz/view-chara.pl
+++ b/_core/lib/kiz/view-chara.pl
@@ -4,6 +4,7 @@ use strict;
 use utf8;
 use open ":utf8";
 use HTML::Template;
+use URI;
 
 ### データ読み込み ###################################################################################
 # なし
@@ -419,7 +420,7 @@ $SHEET->param(images    => $images);
 
 ### OGP --------------------------------------------------
 $SHEET->param(ogUrl => url().($::in{'url'} ? "?url=$::in{'url'}" : "?id=$::in{'id'}"));
-if($pc{'image'}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
+if($pc{'image'}) { $SHEET->param(ogImg => URI->new_abs($imgsrc, url())); }
 $SHEET->param(ogDescript => tag_delete "種別:$pc{'class'}　ネガイ:$pc{'negaiOutside'}／$pc{'negaiInside'}　性別:$pc{'gender'}　年齢:$pc{'age'}　所属:$pc{'belong'}");
 
 ### バージョン等 --------------------------------------------------

--- a/_core/lib/sw2/view-arts.pl
+++ b/_core/lib/sw2/view-arts.pl
@@ -4,6 +4,7 @@ use strict;
 use utf8;
 use open ":utf8";
 use HTML::Template;
+use URI;
 
 ### データ読み込み ###################################################################################
 # なし
@@ -360,7 +361,7 @@ if($pc{'image'}){
 
 ### OGP --------------------------------------------------
 $SHEET->param(ogUrl => url().($::in{'url'} ? "?url=$::in{'url'}" : "?id=$::in{'id'}"));
-if($pc{'image'}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
+if($pc{'image'}) { $SHEET->param(ogImg => URI->new_abs($imgsrc, url())); }
 {
   my $sub; my $category;
   if($pc{'category'} eq 'magic'){

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -4,6 +4,7 @@ use strict;
 use utf8;
 use open ":utf8";
 use HTML::Template;
+use URI;
 
 ### データ読み込み ###################################################################################
 require $set::data_class;
@@ -1013,7 +1014,7 @@ if($pc{'imageCopyrightURL'}){
 
 ### OGP --------------------------------------------------
 $SHEET->param(ogUrl => url().($::in{'url'} ? "?url=$::in{'url'}" : "?id=$::in{'id'}"));
-if($pc{'image'}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
+if($pc{'image'}) { $SHEET->param(ogImg => URI->new_abs($imgsrc, url())); }
 $SHEET->param(ogDescript => tag_delete "種族:$pc{'race'}　性別:$pc{'gender'}　年齢:$pc{'age'}　技能:${class_text}");
 
 ### バージョン等 --------------------------------------------------

--- a/_core/lib/sw2/view-item.pl
+++ b/_core/lib/sw2/view-item.pl
@@ -4,6 +4,7 @@ use strict;
 use utf8;
 use open ":utf8";
 use HTML::Template;
+use URI;
 
 ### データ読み込み ###################################################################################
 require $set::data_races;
@@ -172,7 +173,7 @@ $SHEET->param(imageSrc => "${set::item_dir}${main::file}/image.$pc{'image'}?$pc{
 
 ### OGP --------------------------------------------------
 $SHEET->param(ogUrl => url().($::in{'url'} ? "?url=$::in{'url'}" : "?id=$::in{'id'}"));
-#if($pc{'image'}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
+#if($pc{'image'}) { $SHEET->param(ogImg => URI->new_abs($imgsrc, url())); }
 $SHEET->param(ogDescript => tag_delete "カテゴリ:$pc{'category'}　形状:$pc{'shape'}　製作時期:$pc{'age'}　概要:$pc{'summary'}");
 
 ### バージョン等 --------------------------------------------------

--- a/_core/lib/sw2/view-mons.pl
+++ b/_core/lib/sw2/view-mons.pl
@@ -4,6 +4,7 @@ use strict;
 use utf8;
 use open ":utf8";
 use HTML::Template;
+use URI;
 
 ### データ読み込み ###################################################################################
 require $set::data_races;
@@ -203,7 +204,7 @@ $SHEET->param(imageSrc => "${set::mons_dir}${main::file}/image.$pc{'image'}?$pc{
 
 ### OGP --------------------------------------------------
 $SHEET->param(ogUrl => url().($::in{'url'} ? "?url=$::in{'url'}" : "?id=$::in{'id'}"));
-#if($pc{'image'}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
+#if($pc{'image'}) { $SHEET->param(ogImg => URI->new_abs($imgsrc, url())); }
 $SHEET->param(ogDescript => "レベル:$pc{'lv'}　分類:$pc{'taxa'}".($pc{'partsNum'}>1?"　部位数:$pc{'partsNum'}":'')."　知名度:$pc{'reputation'}／$pc{'reputation+'}");
 
 ### バージョン等 --------------------------------------------------

--- a/_core/lib/vc/view-chara.pl
+++ b/_core/lib/vc/view-chara.pl
@@ -4,6 +4,7 @@ use strict;
 use utf8;
 use open ":utf8";
 use HTML::Template;
+use URI;
 
 ### データ読み込み ###################################################################################
 require $set::data_class;
@@ -368,7 +369,7 @@ if($pc{'imageCopyrightURL'}){
 
 ### OGP --------------------------------------------------
 $SHEET->param(ogUrl => url().($::in{'url'} ? "?url=$::in{'url'}" : "?id=$::in{'id'}"));
-if($pc{'image'}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
+if($pc{'image'}) { $SHEET->param(ogImg => URI->new_abs($imgsrc, url())); }
 $SHEET->param(ogDescript => tag_delete "種族:$pc{'race'}　クラス:$pc{'class'}　スタイル:$pc{'style1'}／$pc{'style2'}　レベル:$pc{'level'}　外見:$pc{'gender'}／$pc{'age'}／$pc{'height'}");
 
 ### バージョン等 --------------------------------------------------


### PR DESCRIPTION
アクセス自体は通るので問題の程度としては小さいですが、あまり良くないので修正を行ってみました。

単純なパスの結合で問題が発生していたので、 URI:new_abs関数でパスを生成するようにしました。