### PR TITLE
[DX3] コンボの条件入力補助メニューが自動的に消えない不具合を修正

### DIFF
--- a/_core/lib/dx3/edit-chara.js
+++ b/_core/lib/dx3/edit-chara.js
@@ -1039,7 +1039,17 @@ function makeComboConditionUtility(comboNode) {
 
         const menuRemover = event => {
           if (event != null) {
-            if (event.path.some(node => node === utilityIcon)) {
+            function getNodePath(node) {
+              const path = [];
+              let current = node;
+              while (current != null) {
+                path.unshift(current);
+                current = current.parentNode;
+              }
+              return path;
+            }
+
+            if (getNodePath(event.target).some(node => node === utilityIcon)) {
               return;
             }
           }


### PR DESCRIPTION
なんか `Event` オブジェクトの `path` プロパティが存在しなくなってるっぽくて、そのせいでエラーになって処理が中断されてた。