### PR TITLE
[DX3] コンボを簡易的な形式で表示する機能を追加

### DIFF
--- a/_core/skin/dx3/css/chara.css
+++ b/_core/skin/dx3/css/chara.css
@@ -902,6 +902,9 @@ table.data-table tbody tr td:nth-child(9) span.thinest.small {
 
 
 /* Combos */
+#combo .open-button::before {
+  content: "▼";
+}
 #combo .combo-table {
   display: grid;
   grid-template-columns: 1.7fr 1.3fr 2fr;
@@ -1091,6 +1094,28 @@ table.data-table tbody tr td:nth-child(9) span.thinest.small {
   #combo .shorten {
     display: none !important;
   }
+}
+
+#combo[data-display-mode="simple"] .combo-table h3 {
+  border-bottom: none;
+}
+#combo[data-display-mode="simple"] .combo-table .combo-combo {
+  border-bottom: none;
+}
+#combo[data-display-mode="simple"] .combo-table .combo-combo > dt {
+  display: none;
+}
+#combo[data-display-mode="simple"] .combo-table .combo-combo > dd {
+  border-top: none;
+}
+#combo[data-display-mode="simple"] .combo-table .combo-in {
+  display: none;
+}
+#combo[data-display-mode="simple"] .combo-table .combo-out {
+  display: none;
+}
+#combo[data-display-mode="simple"] .combo-table .combo-note {
+  display: none;
 }
 
 /* Items */

--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -420,6 +420,7 @@
 
         <section class="box" id="combo">
           <h2>コンボ</h2>
+          <span class="open-button" onclick="swapComboDisplayMode();">簡易表示</span>
           <TMPL_LOOP Combos><div class="combo-table">
             <h3><span><TMPL_VAR NAME></span></h3>
             <dl class="combo-combo"><dt>組み合わせ</dt><dd><TMPL_VAR COMBO></dd></dl>
@@ -447,6 +448,14 @@
             <p class="combo-note"><TMPL_VAR NOTE></p>
           </div></TMPL_LOOP>
         </section>
+        <script>
+          let comboDisplayFull = true;
+          function swapComboDisplayMode() {
+            comboDisplayFull = !comboDisplayFull;
+            document.getElementById('combo').dataset.displayMode = comboDisplayFull ? 'full' : 'simple';
+            document.querySelector('#combo .open-button').textContent = comboDisplayFull ? "簡易表示" : "詳細表示";
+          }
+        </script>
         
         <div class="box-union" id="items">
           <TMPL_IF Weapons><section class="box">


### PR DESCRIPTION
# 機能

　コンボを簡易的な表示に切り替えられるようにする。

# 仕様

　コンボ欄の右上に「簡易表示」「詳細表示」の切り替えをおこなうＵＩを設け、それをクリックするごとに両者を切り替える。
　（レイアウトはエフェクトの折り畳み操作ＵＩを踏襲）

　簡易表示のあいだは、コンボ名と組み合わせの内容のみを表示する。

　デフォルトは「詳細表示」相当。（従来どおりの表示）

# 目的

　コンボの数が多い、または個々の内容が長い場合でも、キャラクターの全体的な把握を容易にする。
　（コンボ欄が伸びるとページ全体の高さのうちかなりの割合を占めることになって、全容を把握しづらい）

# 動作イメージ

![ytsheet-dx3-combo-simplize](https://user-images.githubusercontent.com/44130782/232377382-cccc896a-82a0-49ab-9571-396d6932a481.gif)
