### PR TITLE
Fix: あいだに改行があってもルビ記法として解釈されてしまう不具合を修正

### DIFF
--- a/_core/lib/ar2e/subroutine-ar2e.pl
+++ b/_core/lib/ar2e/subroutine-ar2e.pl
@@ -26,7 +26,7 @@ sub tag_unescape {
   $text =~ s/%%(.+?)%%/<span class="strike">$1<\/span>/gi;  # 打ち消し線
   $text =~ s/__(.+?)__/<span class="underline">$1<\/span>/gi;  # 下線
   $text =~ s/\{\{(.+?)\}\}/<span style="color:transparent">$1<\/span>/gi;  # 透明
-  $text =~ s/[|｜]([^|｜]+?)《(.+?)》/<ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby>/gi; # なろう式ルビ
+  $text =~ s/[|｜]([^|｜\n]+?)《(.+?)》/<ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby>/gi; # なろう式ルビ
   $text =~ s/《《(.+?)》》/<span class="text-em">$1<\/span>/gi; # カクヨム式傍点
   
   $text =~ s/\[\[(.+?)&gt;((?:(?!<br>)[^"])+?)\]\]/&tag_link_url($2,$1)/egi; # リンク

--- a/_core/lib/blp/subroutine-sub.pl
+++ b/_core/lib/blp/subroutine-sub.pl
@@ -26,7 +26,7 @@ sub tag_unescape {
   $text =~ s/%%(.+?)%%/<span class="strike">$1<\/span>/gi;  # 打ち消し線
   $text =~ s/__(.+?)__/<span class="underline">$1<\/span>/gi;  # 下線
   $text =~ s/\{\{(.+?)\}\}/<span style="color:transparent">$1<\/span>/gi;  # 透明
-  $text =~ s/[|｜]([^|｜]+?)《(.+?)》/<span><ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby><\/span>/gi; # なろう式ルビ
+  $text =~ s/[|｜]([^|｜\n]+?)《(.+?)》/<span><ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby><\/span>/gi; # なろう式ルビ
   $text =~ s/《《(.+?)》》/<span class="text-em">$1<\/span>/gi; # カクヨム式傍点
   
   $text =~ s/\[\[(.+?)&gt;((?:(?!<br>)[^"])+?)\]\]/&tag_link_url($2,$1)/egi; # リンク

--- a/_core/lib/dx3/subroutine-dx3.pl
+++ b/_core/lib/dx3/subroutine-dx3.pl
@@ -26,7 +26,7 @@ sub tag_unescape {
   $text =~ s/%%(.+?)%%/<span class="strike">$1<\/span>/gi;  # 打ち消し線
   $text =~ s/__(.+?)__/<span class="underline">$1<\/span>/gi;  # 下線
   $text =~ s/\{\{(.+?)\}\}/<span style="color:transparent">$1<\/span>/gi;  # 透明
-  $text =~ s/[|｜]([^|｜]+?)《(.+?)》/<span><ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby><\/span>/gi; # なろう式ルビ
+  $text =~ s/[|｜]([^|｜\n]+?)《(.+?)》/<span><ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby><\/span>/gi; # なろう式ルビ
   $text =~ s/《《(.+?)》》/<span class="text-em">$1<\/span>/gi; # カクヨム式傍点
   
   $text =~ s/\[\[(.+?)&gt;((?:(?!<br>)[^"])+?)\]\]/&tag_link_url($2,$1)/egi; # リンク

--- a/_core/lib/kiz/subroutine-sub.pl
+++ b/_core/lib/kiz/subroutine-sub.pl
@@ -26,7 +26,7 @@ sub tag_unescape {
   $text =~ s/%%(.+?)%%/<span class="strike">$1<\/span>/gi;  # 打ち消し線
   $text =~ s/__(.+?)__/<span class="underline">$1<\/span>/gi;  # 下線
   $text =~ s/\{\{(.+?)\}\}/<span style="color:transparent">$1<\/span>/gi;  # 透明
-  $text =~ s/[|｜]([^|｜]+?)《(.+?)》/<span><ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby><\/span>/gi; # なろう式ルビ
+  $text =~ s/[|｜]([^|｜\n]+?)《(.+?)》/<span><ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby><\/span>/gi; # なろう式ルビ
   $text =~ s/《《(.+?)》》/<span class="text-em">$1<\/span>/gi; # カクヨム式傍点
   
   $text =~ s/\[\[(.+?)&gt;((?:(?!<br>)[^"])+?)\]\]/&tag_link_url($2,$1)/egi; # リンク

--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -48,7 +48,7 @@ sub tag_unescape {
   $text =~ s/%%(.+?)%%/<span class="strike">$1<\/span>/gi;  # 打ち消し線
   $text =~ s/__(.+?)__/<span class="underline">$1<\/span>/gi;  # 下線
   $text =~ s/\{\{(.+?)\}\}/<span style="color:transparent">$1<\/span>/gi;  # 透明
-  $text =~ s/[|｜]([^|｜]+?)《(.+?)》/<ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby>/gi; # なろう式ルビ
+  $text =~ s/[|｜]([^|｜\n]+?)《(.+?)》/<ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby>/gi; # なろう式ルビ
   $text =~ s/《《(.+?)》》/<span class="text-em">$1<\/span>/gi; # カクヨム式傍点
   
   $text =~ s/\[\[(.+?)&gt;((?:(?!<br>)[^"])+?)\]\]/&tag_link_url($2,$1)/egi; # リンク

--- a/_core/lib/vc/subroutine-sub.pl
+++ b/_core/lib/vc/subroutine-sub.pl
@@ -26,7 +26,7 @@ sub tag_unescape {
   $text =~ s/%%(.+?)%%/<span class="strike">$1<\/span>/gi;  # 打ち消し線
   $text =~ s/__(.+?)__/<span class="underline">$1<\/span>/gi;  # 下線
   $text =~ s/\{\{(.+?)\}\}/<span style="color:transparent">$1<\/span>/gi;  # 透明
-  $text =~ s/[|｜]([^|｜]+?)《(.+?)》/<ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby>/gi; # なろう式ルビ
+  $text =~ s/[|｜]([^|｜\n]+?)《(.+?)》/<ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby>/gi; # なろう式ルビ
   $text =~ s/《《(.+?)》》/<span class="text-em">$1<\/span>/gi; # カクヨム式傍点
   
   $text =~ s/\[\[(.+?)&gt;((?:(?!<br>)[^"])+?)\]\]/&tag_link_url($2,$1)/egi; # リンク


### PR DESCRIPTION
# 主旨

　バーティカルバーから開始山括弧までのあいだに改行があってもルビ記法として解釈されてしまう（そして表示がこわれる）不具合を修正。

# 再現方法

　次のような文字列をシート内に記入する。

```
文中にバーティカルバー｜を記述

後の行に適当な《エフェクト名》を記述
```

![image](https://user-images.githubusercontent.com/44130782/232668844-0013ff1d-8fed-42ff-8e2f-bb0301b0d580.png)

## 再現例

https://yutorize.2-d.jp/ytsheet/dx3rd/?id=c70xsX

![image](https://user-images.githubusercontent.com/44130782/232669034-00d793f2-ec69-4f21-8af3-515bbb39a922.png)
