### PR TITLE
Fix: JSONファイルからインポートしたとき、最初の編集画面でのみ画像が表示されてしまう不具合を修正

### DIFF
--- a/_core/lib/edit.pl
+++ b/_core/lib/edit.pl
@@ -132,6 +132,7 @@ sub pcDataGet {
   elsif($mode eq 'convert'){
     %pc = %::conv_data;
     delete $pc{'image'};
+    delete $pc{'imageURL'};
     delete $pc{'protect'};
     $message = '「<a href="'.$::in{'url'}.'" target="_blank"><!NAME></a>」をコンバートして新規作成します。<br>（まだ保存はされていません）';
   }


### PR DESCRIPTION
# 不具合の内容

　画像が設定されているシートをエクスポートした JSON ファイルをインポートすると、初回の（＝インポート時の）編集画面でのみ画像が表示されてしまう。
　（このとき、そのまま保存しても画像が保存されるわけではない）

# 機序

　JSON 内の `imageURL` にもとづいて表示されているっぽい。

# 解決方法

　インポート時に、 `imageURL` を削除する。