### PR TITLE
[DX3] 「ブリード」に有効な値がないとき、表示を空にする

### DIFF
--- a/_core/lib/dx3/view-chara.pl
+++ b/_core/lib/dx3/view-chara.pl
@@ -256,8 +256,9 @@ $SHEET->param(wordsY => ($pc{'wordsY'} eq '下' ? 'bottom:0;' : 'top:0;'));
 if($pc{'stage'} =~ /クロウリングケイオス/){ $SHEET->param(ccOn => 1); }
 
 ### ブリード --------------------------------------------------
-$SHEET->param(breed => 
-  ($pc{'breed'} ? $pc{'breed'} : $pc{'syndrome3'} ? 'トライ' : $pc{'syndrome2'} ? 'クロス' : $pc{'syndrome1'} ? 'ピュア' : '') . '<span>ブリード</span>'
+my $breedPrefix = ($pc{'breed'} ? $pc{'breed'} : $pc{'syndrome3'} ? 'トライ' : $pc{'syndrome2'} ? 'クロス' : $pc{'syndrome1'} ? 'ピュア' : '');
+$SHEET->param(breed =>
+    $breedPrefix ? $breedPrefix . '<span>ブリード</span>' : ''
 );
 
 ### 能力値 --------------------------------------------------

--- a/_core/lib/dx3/view-chara.pl
+++ b/_core/lib/dx3/view-chara.pl
@@ -257,9 +257,7 @@ if($pc{'stage'} =~ /クロウリングケイオス/){ $SHEET->param(ccOn => 1); 
 
 ### ブリード --------------------------------------------------
 my $breedPrefix = ($pc{'breed'} ? $pc{'breed'} : $pc{'syndrome3'} ? 'トライ' : $pc{'syndrome2'} ? 'クロス' : $pc{'syndrome1'} ? 'ピュア' : '');
-$SHEET->param(breed =>
-    $breedPrefix ? $breedPrefix . '<span>ブリード</span>' : ''
-);
+$SHEET->param(breed => $breedPrefix ? "$breedPrefix<span>ブリード</span>" : '');
 
 ### 能力値 --------------------------------------------------
 my %status = (0=>'body', 1=>'sense', 2=>'mind', 3=>'social');


### PR DESCRIPTION
　シンドロームがひとつも選択されていないとき、表示画面で「ブリード」の文字のみが表示されていた。（次の画像のように）

![image](https://github.com/yutorize/ytsheet2/assets/44130782/d246b680-9a4d-4900-ae12-498858126bab)

　これはとくに意味を有さない表示であり、また非オーヴァードのキャラクターを表現したい場合などには明確に不自然なので、欄を空として表示するように。