### PR TITLE
[DX3] 末尾のエフェクトの下側に余計なボーダーがあるように見えるのを修正

### DIFF
--- a/_core/skin/dx3/css/chara.css
+++ b/_core/skin/dx3/css/chara.css
@@ -826,6 +826,11 @@ table.data-table tbody tr td:nth-child(9) span.thinest.small {
   font-style: normal;
   font-weight: bold;
 }
+@media screen and (min-width:736px){
+  #effect:not([data-full-open="true"]) table > tbody:last-child:not(:hover) > tr:last-child {
+    border-top: none;
+  }
+}
 @media screen and (max-width:735px){
   #effect table thead tr,
   #effect table tbody tr {

--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -396,7 +396,7 @@
           effectFullOpen = !effectFullOpen;
           document.querySelectorAll('#effect table td.left').forEach(obj => obj.style.display = effectFullOpen ? 'table-cell' : '');
           document.querySelector('#effect .open-button').dataset.open = effectFullOpen ? 'true' : '';
-          document.getElementById('effect').dataset.fullOpen = effectNoteOpenFlag ? 'true' : '';
+          document.getElementById('effect').dataset.fullOpen = effectNoteOpen ? 'true' : '';
         }
         </script>
         

--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -396,6 +396,7 @@
           effectFullOpen = !effectFullOpen;
           document.querySelectorAll('#effect table td.left').forEach(obj => obj.style.display = effectFullOpen ? 'table-cell' : '');
           document.querySelector('#effect .open-button').dataset.open = effectFullOpen ? 'true' : '';
+          document.getElementById('effect').dataset.fullOpen = effectNoteOpenFlag ? 'true' : '';
         }
         </script>
         


### PR DESCRIPTION
# 当該箇所

![image](https://github.com/yutorize/ytsheet2/assets/44130782/048178fc-0bba-4ea0-adec-ae7a5be4110b)

↓300%拡大

![image](https://github.com/yutorize/ytsheet2/assets/44130782/069958af-cd34-4b2a-b349-5f28f8e4f95a)

# 原因

効果行の tr の border-top が見えているせい