### PR TITLE
[DX3] 技能名とレベルがともに空なら単位「Lv」を表示しない

### DIFF
--- a/_core/lib/dx3/view-chara.pl
+++ b/_core/lib/dx3/view-chara.pl
@@ -281,10 +281,10 @@ foreach (1 .. max($pc{'skillRideNum'},$pc{'skillArtNum'},$pc{'skillKnowNum'},$pc
     && !$pc{'skillTotalRide'.$_} && !$pc{'skillTotalArt'.$_} && !$pc{'skillTotalKnow'.$_} && !$pc{'skillTotalInfo'.$_}
   );
   push(@skills, {
-    "RIDE" => $pc{'skillRide'.$_.'Name'}, "RIDELV" => ($pc{'skillAddRide'.$_}?"<span class=\"small\">+$pc{'skillAddRide'.$_}=</span>":'').$pc{'skillTotalRide'.$_},
-    "ART"  => $pc{'skillArt' .$_.'Name'}, "ARTLV"  => ($pc{'skillAddArt'.$_} ?"<span class=\"small\">+$pc{'skillAddArt'.$_}=</span>" :'').$pc{'skillTotalArt'.$_},
-    "KNOW" => $pc{'skillKnow'.$_.'Name'}, "KNOWLV" => ($pc{'skillAddKnow'.$_}?"<span class=\"small\">+$pc{'skillAddKnow'.$_}=</span>":'').$pc{'skillTotalKnow'.$_},
-    "INFO" => $pc{'skillInfo'.$_.'Name'}, "INFOLV" => ($pc{'skillAddInfo'.$_}?"<span class=\"small\">+$pc{'skillAddInfo'.$_}=</span>":'').$pc{'skillTotalInfo'.$_},
+    "RIDE" => $pc{'skillRide'.$_.'Name'}, "RIDELV" => ($pc{'skillAddRide'.$_}?"<span class=\"small\">+$pc{'skillAddRide'.$_}=</span>":'').$pc{'skillTotalRide'.$_}, "RIDE-NONE" => !($pc{'skillRide'.$_.'Name'} || $pc{'skillTotalRide'.$_}),
+    "ART"  => $pc{'skillArt' .$_.'Name'}, "ARTLV"  => ($pc{'skillAddArt'.$_} ?"<span class=\"small\">+$pc{'skillAddArt'.$_}=</span>" :'').$pc{'skillTotalArt'.$_}, "ART-NONE" => !($pc{'skillArt'.$_.'Name'} || $pc{'skillTotalArt'.$_}),
+    "KNOW" => $pc{'skillKnow'.$_.'Name'}, "KNOWLV" => ($pc{'skillAddKnow'.$_}?"<span class=\"small\">+$pc{'skillAddKnow'.$_}=</span>":'').$pc{'skillTotalKnow'.$_}, "KNOW-NONE" => !($pc{'skillKnow'.$_.'Name'} || $pc{'skillTotalKnow'.$_}),
+    "INFO" => $pc{'skillInfo'.$_.'Name'}, "INFOLV" => ($pc{'skillAddInfo'.$_}?"<span class=\"small\">+$pc{'skillAddInfo'.$_}=</span>":'').$pc{'skillTotalInfo'.$_}, "INFO-NONE" => !($pc{'skillInfo'.$_.'Name'} || $pc{'skillTotalInfo'.$_}),
   });
 }
 $SHEET->param(Skills => \@skills);

--- a/_core/skin/dx3/css/chara.css
+++ b/_core/skin/dx3/css/chara.css
@@ -522,7 +522,7 @@ table.data-table tbody tr td:nth-child(9) span.thinest.small {
   font-size: 70%;
   transform: scaleX(0.8);
 }
-#status table tbody td.right::after {
+#status table tbody td.right:not(.none)::after {
   content: 'Lv';
   margin-left: .1em;
   font-size: 70%;

--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -292,10 +292,10 @@
             <td class="left">調達</td><td class="right"><TMPL_VAR skillTotalProcure></td>
           </tr>
           <TMPL_LOOP Skills><tr>
-            <td class="left"><TMPL_VAR RIDE></td><td class="right"><TMPL_VAR RIDELV></td>
-            <td class="left"><TMPL_VAR ART ></td><td class="right"><TMPL_VAR ARTLV ></td>
-            <td class="left"><TMPL_VAR KNOW></td><td class="right"><TMPL_VAR KNOWLV></td>
-            <td class="left"><TMPL_VAR INFO></td><td class="right"><TMPL_VAR INFOLV></td>
+            <td class="left"><TMPL_VAR RIDE></td><td class="right <TMPL_IF RIDE-NONE>none</TMPL_IF>"><TMPL_VAR RIDELV></td>
+            <td class="left"><TMPL_VAR ART ></td><td class="right <TMPL_IF ART-NONE>none</TMPL_IF>"><TMPL_VAR ARTLV ></td>
+            <td class="left"><TMPL_VAR KNOW></td><td class="right <TMPL_IF KNOW-NONE>none</TMPL_IF>"><TMPL_VAR KNOWLV></td>
+            <td class="left"><TMPL_VAR INFO></td><td class="right <TMPL_IF INFO-NONE>none</TMPL_IF>"><TMPL_VAR INFOLV></td>
           </tr></TMPL_LOOP>
         </table>
       </section>


### PR DESCRIPTION
# 意図

名前も有効な値もない欄に単位だけが存在してもとくに意味がないので

# イメージ

## before

![image](https://github.com/yutorize/ytsheet2/assets/44130782/ffacc19e-8239-4bf8-9447-3f517e374d2c)

## after

![image](https://github.com/yutorize/ytsheet2/assets/44130782/14910199-53a8-4aad-ba5e-b8ef85d8da9b)
