### PR TITLE
[SW2.x] セッション履歴のフッタのフォントを bold にする

### DIFF
--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1152,6 +1152,7 @@ div#area-items-R {
 #history table tfoot tr td {
   padding-top: .25em;
   padding-bottom: .2em;
+  font-weight: bolder;
 }
 #history table tfoot tr td:not(:empty) {
   border-right-width: 1px;


### PR DESCRIPTION
直前の行とのコントラストが弱く、視覚的に区別しづらいので

![image](https://github.com/yutorize/ytsheet2/assets/44130782/457a5425-b322-4d4d-aa7c-3e185ec0431b)

とりあえず SW2.x だけやりましたが、 AR2E と VC もやったほうがいいかも。