### PR TITLE
[SW2.x] セッション履歴のフッタの背景色を直前の行と逆になるようにする

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -883,6 +883,7 @@ foreach (0 .. $pc{'historyNum'}){
   } );
 }
 $SHEET->param(History => \@history);
+$SHEET->param(HistoryNum => $#history);
 $SHEET->param(historyExpTotal   => commify $pc{'historyExpTotal'}   );
 $SHEET->param(historyHonorTotal => commify $pc{'historyHonorTotal'} );
 $SHEET->param(historyMoneyTotal => commify $pc{'historyMoneyTotal'} );

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1149,6 +1149,13 @@ div#area-items-R {
   transform: scale(0.8, 0.8);
   opacity: 0.8;
 }
+#history[data-history-num$="0"] table tfoot,
+#history[data-history-num$="2"] table tfoot,
+#history[data-history-num$="4"] table tfoot,
+#history[data-history-num$="6"] table tfoot,
+#history[data-history-num$="8"] table tfoot {
+  background-color: var(--box-even-rows-bg-color);
+}
 #history table tfoot tr td {
   padding-top: .25em;
   padding-bottom: .2em;

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -554,7 +554,7 @@
         <p><TMPL_VAR freeHistory></p>
       </section>
       </TMPL_IF>
-      <section class="box" id="history">
+      <section class="box" id="history" data-history-num="<TMPL_VAR HistoryNum>">
         <h2>セッション履歴</h2>
         <table class="data-table line-tbody">
           <thead>
@@ -595,6 +595,7 @@
               <td><TMPL_VAR historyMoneyTotal></td>
               <td><TMPL_VAR historyHonorTotal></td>
               <td><TMPL_VAR historyGrowTotal></td>
+              <td colspan="2">&nbsp;</td>
             </tr>
           </tfoot>
         </table>


### PR DESCRIPTION
　行の数が（キャラクター作成時のものをのぞいて）偶数のとき、末尾行とフッタがともに白背景（※ライトテーマ基準）で連続していた。
　（奇数行なら末尾行が色つき、フッタが白になる）

　これを常にフッタが末尾行と逆の色になるようにする。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/6acbae67-bb43-48ec-93be-e4cb87932d2e)

とりあえず SW2.x だけやりましたが、 AR2E と VC もやったほうがいいかも。