### PR TITLE
セッション履歴の空の行は表示しない

### DIFF
--- a/_core/lib/ar2e/view-chara.pl
+++ b/_core/lib/ar2e/view-chara.pl
@@ -536,6 +536,9 @@ foreach (0 .. $pc{'historyNum'}){
   }
   $pc{'history'.$_.'Money'} =~ s/([0-9]+)/$1<wbr>/g;
   $pc{'history'.$_.'Money'} =~ s/([0-9]+)/commify($1);/ge;
+  if (!($pc{'history'.$_.'Gm'} || $pc{'history'.$_.'Date'} || $pc{'history'.$_.'Exp'} || $pc{'history'.$_.'Payment'} || $pc{'history'.$_.'Honor'} || $pc{'history'.$_.'Money'} || $pc{'history'.$_.'Grow'} || $members || $pc{'history'.$_.'Note'})) {
+    next;
+  }
   push(@history, {
     "NUM"    => ($pc{'history'.$_.'Gm'} ? $h_num : ''),
     "DATE"   => $pc{'history'.$_.'Date'},

--- a/_core/lib/blp/view-chara.pl
+++ b/_core/lib/blp/view-chara.pl
@@ -367,6 +367,9 @@ foreach (0 .. $pc{'historyNum'}){
   foreach my $mem (split(/　/,$pc{'history'.$_.'Member'})){
     $members .= '<span>'.$mem.'</span>';
   }
+  if (!($pc{'history'.$_.'Gm'} || $pc{'history'.$_.'Date'} || $pc{'history'.$_.'Title'} || $pc{'history'.$_.'Grow'} || $members || $pc{'history'.$_.'Note'})) {
+    next;
+  }
   push(@history, {
     "NUM"    => ($pc{'history'.$_.'Gm'} ? $h_num : ''),
     "DATE"   => $pc{'history'.$_.'Date'},

--- a/_core/lib/dx3/view-chara.pl
+++ b/_core/lib/dx3/view-chara.pl
@@ -599,8 +599,13 @@ foreach (0 .. $pc{'historyNum'}){
     $members .= '<span>'.$mem.'</span>';
   }
   if($_ && !$pc{'history'.$_.'ExpApply'}) {
-    $pc{'history'.$_.'Exp'} = '<s>'.$pc{'history'.$_.'Exp'}.'</s>';
+    $pc{'history'.$_.'Exp'} = $pc{'history'.$_.'Exp'} ? '<s>'.$pc{'history'.$_.'Exp'}.'</s>' : '';
   }
+
+  if (!($pc{'history'.$_.'Date'} || $pc{'history'.$_.'Title'} || $pc{'history'.$_.'Exp'} || $pc{'history'.$_.'Gm'} || $members || $pc{'history'.$_.'Note'})) {
+    next;
+  }
+
   push(@history, {
     "NUM"    => ($pc{'history'.$_.'Gm'} ? $h_num : ''),
     "DATE"   => $pc{'history'.$_.'Date'},

--- a/_core/lib/kiz/view-chara.pl
+++ b/_core/lib/kiz/view-chara.pl
@@ -364,6 +364,9 @@ foreach (0 .. $pc{'historyNum'}){
   foreach my $mem (split(/　/,$pc{'history'.$_.'Member'})){
     $members .= '<span>'.$mem.'</span>';
   }
+  if (!($pc{'history'.$_.'Gm'} || $pc{'history'.$_.'Date'} || $pc{'history'.$_.'Title'} || $pc{'history'.$_.'Grow'} || $members || $pc{'history'.$_.'Note'})) {
+    next;
+  }
   push(@history, {
     "NUM"    => ($pc{'history'.$_.'Gm'} ? $h_num : ''),
     "DATE"   => $pc{'history'.$_.'Date'},

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -869,6 +869,11 @@ foreach (0 .. $pc{'historyNum'}){
   $pc{'history'.$_.'Exp'}   =~ s/([0-9]+)/commify($1);/ge;
   $pc{'history'.$_.'Money'} =~ s/([0-9]+)/$1<wbr>/g;
   $pc{'history'.$_.'Money'} =~ s/([0-9]+)/commify($1);/ge;
+
+  if (!($pc{'history'.$_.'Date'} || $pc{'history'.$_.'Title'} || $pc{'history'.$_.'Exp'} || $pc{'history'.$_.'Honor'} || $pc{'history'.$_.'Money'} || $pc{'history'.$_.'Grow'} || $pc{'history'.$_.'Gm'} || $members || $pc{'history'.$_.'Note'})) {
+    next;
+  }
+
   push(@history, {
     "NUM"    => ($pc{'history'.$_.'Gm'} ? $h_num : ''),
     "DATE"   => $pc{'history'.$_.'Date'},

--- a/_core/lib/vc/view-chara.pl
+++ b/_core/lib/vc/view-chara.pl
@@ -281,6 +281,9 @@ foreach (0 .. $pc{'historyNum'}){
   }
   $pc{'history'.$_.'Money'} =~ s/([0-9]+)/$1<wbr>/g;
   $pc{'history'.$_.'Money'} =~ s/([0-9]+)/commify($1);/ge;
+  if (!($pc{'history'.$_.'Gm'} || $pc{'history'.$_.'Date'} || $pc{'history'.$_.'Title'} || $pc{'history'.$_.'Result'} || $members || $pc{'history'.$_.'Note'})) {
+    next;
+  }
   push(@history, {
     "NUM"    => ($pc{'history'.$_.'Gm'} ? $h_num : ''),
     "DATE"   => $pc{'history'.$_.'Date'},


### PR DESCRIPTION
　表示されてもとくに意味がないので。

　“空”であることの判定は、「すべての入力欄が空であること」としている。