### PR TITLE
修正: [DX3] キャラクター保管所からのコンバート時に感情欄のチェックも対象にする

### DIFF
--- a/_core/lib/dx3/convert.pl
+++ b/_core/lib/dx3/convert.pl
@@ -147,6 +147,8 @@ sub convertHokanjoToYtsheet {
     $pc{"lois${i}Name"} = $in{'roice_name'}[$i-1];
     $pc{"lois${i}EmoPosi"} = $in{'roice_pos'}[$i-1];
     $pc{"lois${i}EmoNega"} = $in{'roice_neg'}[$i-1];
+    $pc{"lois${i}EmoPosiCheck"} = exists $in{'roice_pos_input'} && $in{'roice_pos_input'}{$i-1} eq '1' ? 1 : 0;
+    $pc{"lois${i}EmoNegaCheck"} = exists $in{'roice_neg_input'} && $in{'roice_neg_input'}{$i-1} eq '1' ? 1 : 0;
     $pc{"lois${i}Note"} = $in{'roice_memo'}[$i-1];
   }
   


### PR DESCRIPTION
コンバート時に表題のチェック欄が対象外になっていることに気づいたため修正を提案させていただきます。
ご検討いただけると幸いです。