### PR TITLE
[DX3] ロイスの「関係」に入力候補を設定

### DIFF
--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -557,7 +557,7 @@ foreach my $num (1 .. 7) {
 if(!$pc{"lois${num}State"}){ $pc{"lois${num}State"} = 'ロイス' }
 print <<"HTML";
             <tr id="lois${num}">
-              <td><span class="handle"></span>@{[input "lois${num}Relation"]}
+              <td><span class="handle"></span>@{[input "lois${num}Relation", '', '', 'list="list-lois-relation"']}
               <td>@{[input "lois${num}Name",'','encroachBonusType']}
               <td class="emo">@{[input "lois${num}EmoPosiCheck",'checkbox',"emoP($num)"]}@{[input "lois${num}EmoPosi",'','','list="list-emotionP"']}
               <td>／
@@ -1152,6 +1152,9 @@ print <<"HTML";
   </datalist>
   <datalist id="list-blood">
     <option value="A型"><option value="B型"><option value="AB型"><option value="O型"><option value="不明"><option value="不詳">
+  </datalist>
+  <datalist id="list-lois-relation">
+    <option value="Dロイス">
   </datalist>
   <datalist id="list-emotionP">
     <option value="傾倒">


### PR DESCRIPTION
ロイスの「関係」欄に入力候補を設定いただければと思っております。
キャラクター保管所からのコンバート時にも、こちらに「Dロイス」として自動入力されることから(下記)、欄の用途や表記はあっている認識でおります。
https://github.com/yutorize/ytsheet2/blob/f5233a818609bba93a9f090df9f565e3f7071bc9/_core/lib/dx3/convert.pl#L146

その上で、よく入力されるであろう「Dロイス」は入力候補にあると便利と考えたため提案させていただきます。
ご検討よろしくお願い致します。

動作確認：
<img width="152" alt="image" src="https://github.com/yutorize/ytsheet2/assets/10219395/2449daa4-303f-4b3c-a19b-38e5afa204e9">

// #61 をブランチ誤りに気づき再作成したPRになります