### PR TITLE
[SW2] Fix: 種族データが失われていても「キャラクター能力値作成」のログをとりあえず表示できるように

### DIFF
--- a/_core/lib/sw2/list-making.pl
+++ b/_core/lib/sw2/list-making.pl
@@ -110,7 +110,7 @@ foreach my $data (@lines) {
                  + $data::races{$race}{dice}{'E+'}
                  + $data::races{$race}{dice}{'F+'};
     
-    my $average = ($stt_A + $stt_B + $stt_C + $stt_D + $stt_E + $stt_F) / $dicetotal;
+    my $average = $dicetotal ? ($stt_A + $stt_B + $stt_C + $stt_D + $stt_E + $stt_F) / $dicetotal : 0;
        $average = ($stt_A + $stt_B + $stt_C + $stt_D + $stt_E + $stt_F + $tec + $phy + $spi) / 18 if $adventurer;
        
     my $url = "${tec}_${phy}_${spi}_"


### PR DESCRIPTION
　種族データが見当たらないと `$dicetotal` が `0` になってゼロ除算になって死ぬ。

　142行目の

```
      AVERAGE => $dicetotal ? sprintf("%.5g", $average) : '―',
```

　を見るに、 `$dicetotal` が `0` となる可能性は想定されているっぽく、実際とくに問題なく動くっぽいのでこれでよさげ。