### PR TITLE
[SW2] 魔物データの戦利品の見出しの幅を可変にする

### DIFF
--- a/_core/skin/sw2/css/monster.css
+++ b/_core/skin/sw2/css/monster.css
@@ -279,7 +279,7 @@ table.status tbody:nth-of-type(even) tr td.lv {
 }
 .loots dl {
   display: grid;
-  grid-template-columns: 6em 1fr;
+  grid-template-columns: max-content 1fr;
   grid-template-rows: auto;
   border-width: 1px;
   border-style: solid;
@@ -292,6 +292,7 @@ table.status tbody:nth-of-type(even) tr td.lv {
   border-width: 0px 1px 1px 0px;
   border-style: solid;
   text-align: center;
+  min-width: 6em;
 }
 .loots dl > dd {
   grid-column: 2;


### PR DESCRIPTION
自由入力なわりに、ちょっと長いテキストを書いたら見出し内で折り返しが発生していまいちだったので