### PR TITLE
[SW2] 魔物・アイテム・流派／神格データの作者名の幅を可変にする

### DIFF
--- a/_core/skin/sw2/css/arts.css
+++ b/_core/skin/sw2/css/arts.css
@@ -651,7 +651,8 @@ div.data dl.effects table {
 /* // Author
 ---------------------------------------------------------------------------------------------------- */
 #author {
-  width: 50%;
+  width: max-content;
+  min-width: 50%;
   margin: 2em 0 0 auto;
   padding: .5em;
   text-align: right;

--- a/_core/skin/sw2/css/item.css
+++ b/_core/skin/sw2/css/item.css
@@ -248,7 +248,8 @@ div.data {
 /* // Author
 ---------------------------------------------------------------------------------------------------- */
 #author {
-  width: 50%;
+  width: max-content;
+  min-width: 50%;
   margin: 2em 0 0 auto;
   padding: .5em;
   text-align: right;

--- a/_core/skin/sw2/css/monster.css
+++ b/_core/skin/sw2/css/monster.css
@@ -337,7 +337,8 @@ table.status {
 /* // Author
 ---------------------------------------------------------------------------------------------------- */
 #author {
-  width: 50%;
+  width: max-content;
+  min-width: 50%;
   margin: 2em 0 0 auto;
   padding: .5em;
   text-align: right;


### PR DESCRIPTION
魔物・アイテム・流派／神格データの作者名表示欄について、親の50％を超える場合にはそれに合わせて可変するように。
（たとえば個人名とサークル名を併記するなど、わりと超えるケースがある）
