### PR TITLE
[SW2] 特異な妖精魔法のダメージ算出コマンドをチャットパレットでサポート

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -157,7 +157,7 @@ sub palettePreset {
       $text .= "//行使修正=".($::pc{magicCastAdd}||0)."\n";
       $text .= "//魔法C=10\n";
       $text .= "//魔法D修正=".($::pc{magicDamageAdd}||0)."\n";
-      $text .= "//物理魔法D修正=".($::pc{magicDamageAdd}||0)."\n" if $::pc{lvDru};
+      $text .= "//物理魔法D修正=".($::pc{magicDamageAdd}||0)."\n" if $::pc{lvDru} || ($::pc{lvFai} && $::pc{fairyContractEarth});
       $text .= "//回復量修正=0\n" if $::pc{lvCon} || $::pc{lvPri} || $::pc{lvGri} || $::pc{lvBar} || $::pc{lvMag} >= 2;
       last;
     }
@@ -179,6 +179,9 @@ sub palettePreset {
         next if($id eq 'Fai' && $pows{$id}{$pow} > fairyRank($::pc{lvFai},$::pc{fairyContractEarth},$::pc{fairyContractWater},$::pc{fairyContractFire },$::pc{fairyContractWind },$::pc{fairyContractLight},$::pc{fairyContractDark }));
         if($id eq 'Bar'){ $pow += $::pc{finaleEnhance} || 0; }
         $text .= "k${pow}[{魔法C}]+{$name}".($name =~ /魔/ ?'+{魔力修正}':'').addNum($::pc{'magicDamageAdd'.$id})."+{魔法D修正} ダメージ".($bot{BCD}?"／$name":"")."\n";
+        if ($id eq 'Fai' && $::pc{fairyContractEarth} && ($pow == 10 || $pow == 50)) {
+          $text .= "k${pow}[12]+{$name}" . ($name =~ /魔/ ?'+{魔力修正}':'') . addNum($::pc{'magicDamageAdd'.$id}) . "+{物理魔法D修正} ダメージ（物理）" . ($bot{BCD}?"／$name":"")."\n";
+        }
         if ($bot{YTC}) { $text .= "k${pow}[13]+{$name}" . ($name =~ /魔/ ?'+{魔力修正}':'') . "//" . addNum($::pc{'magicDamageAdd'.$id}) . "+{魔法D修正} 半減\n"; }
         if ($bot{BCD}) { $text .= "k${pow}[13]+{$name}" . ($name =~ /魔/ ?'+{魔力修正}':'') . "h+("  . ($::pc{'magicDamageAdd'.$id} || 0) . "+{魔法D修正}) 半減／${name}\n"; }
       }


### PR DESCRIPTION
# 内容

一部の妖精魔法の「クリティカル値12かつ物理ダメージ」という挙動を、自動生成チャットパレットにおいてサポートする。

## 対象データ

 - 【アースハンマー】（『Ⅱ』191頁または『ＭＡ』132頁）
 - 【ジャイアントキック】（『Ⅲ』174頁または『ＭＡ』133頁）

（一部といえば一部だが、多用に値する性能のデータなので、自動生成でサポートされていてほしい）

# 挙動

## “物理魔法D修正”

森羅魔法用の変数 `物理魔法D修正` を本件においても利用する。

## 条件づけ

“「妖精魔法」かつ「土属性を契約している」かつ「威力10または威力50」”の場合、Ｃ値12・物理ダメージ用のコマンド**も**出力する。

### 備考

威力10は【ウィンドカッター】や【ファイアボルト】、威力50は【ファイアジャベリン】と区別がつかないので、通常の魔法ダメージ用のコマンドも依然として出力する。