### PR TITLE
[SW2] 近接攻撃・遠隔攻撃の威力解決コマンドに刃武器・打撃武器・魔法の武器の区分を明示する

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -398,7 +398,7 @@ sub palettePreset {
             $text .= $bot{YTC} ? '首切' : $bot{BCD} ? 'r5' : '';
           }
           $text .= " ダメージ";
-          $text .= extractWeaponMarks($::pc{'weapon'.$_.'Name'}) unless $bot{BCD};
+          $text .= extractWeaponMarks($::pc{'weapon'.$_.'Name'}.$::pc{'weapon'.$_.'Note'}) unless $bot{BCD};
           $text .= "／$::pc{'weapon'.$_.'Name'}$::pc{'weapon'.$_.'Usage'}" if $bot{BCD};
           $text .= "\n";
         }

--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -398,6 +398,7 @@ sub palettePreset {
             $text .= $bot{YTC} ? '首切' : $bot{BCD} ? 'r5' : '';
           }
           $text .= " ダメージ";
+          $text .= extractWeaponMarks($::pc{'weapon'.$_.'Name'}) unless $bot{BCD};
           $text .= "／$::pc{'weapon'.$_.'Name'}$::pc{'weapon'.$_.'Usage'}" if $bot{BCD};
           $text .= "\n";
         }
@@ -547,6 +548,14 @@ sub palettePreset {
     
     return $text;
   }
+}
+sub extractWeaponMarks {
+  my $text = shift;
+  my $marks = '';
+  while ($text =~ s/(\[[刃打魔]\])//) {
+    $marks .= $1;
+  }
+  return $marks;
 }
 ### プリセット（シンプル） ###########################################################################
 sub palettePresetSimple {


### PR DESCRIPTION
# 内容
武器名に `[刃]` `[打]` `[魔]` のいずれかないし複数が含まれている場合、それをダメージ算出コマンドにも含める。

## 例
![image](https://github.com/yutorize/ytsheet2/assets/44130782/d6cacec2-6205-4efe-88c1-759b6d46ecdc)


# 理由
従来も命中力判定のコマンドには含まれていたが、これらの記号の意味するところが影響するのはむしろダメージ算出のほうなので。

# 備考
BCDice 用のチャットパレットは、威力解決コマンドにアイテム名がそのまま含まれていた（それによって武器の性質も含まれていた）ので、ゆとチャ用のコマンドにのみ反映されるようにした。