### PR TITLE
[SW2] Fix: 魔物データの編集画面において、「現在の騎獣レベルの～」のくだりが騎獣でない場合にも表示される不具合を修正

### DIFF
--- a/_core/lib/sw2/edit-mons.pl
+++ b/_core/lib/sw2/edit-mons.pl
@@ -212,7 +212,7 @@ print <<"HTML";
         <dl>
           <dt><span class="mount-only">騎獣</span>レベル
           <dd>@{[ input 'lv','number','checkLevel','min="0"' ]}
-          <dd class="mount-only small" style="display:inline-block">※入力すると、閲覧画面では現在の騎獣レベルのステータスのみ表示されます
+          <dd class="mount-only small">※入力すると、閲覧画面では現在の騎獣レベルのステータスのみ表示されます
         </dl>
         <dl>
           <dt>知能


### PR DESCRIPTION
# 原因
`.mount-only` class による非表示化の実装（ `display: none;` ）が、 `style` 属性によって上書きされていた。