### PR TITLE
[SW2] Fix: 騎獣データの作成において、特定手順で undefined 参照が発生する不具合を修正

### DIFF
--- a/_core/lib/sw2/edit-mons.js
+++ b/_core/lib/sw2/edit-mons.js
@@ -157,20 +157,20 @@ function addStatusInsert(target, num, copy){
     <td ${ lv ? '' : `class="handle"`}></td>
     <td ${ lv ? 'class="name"' : ``} data-style="${num}">${ lv ? form[`status${num}Style`].value : `<input name="status${num}${lv}Style" type="text" value="${ini.style}" oninput="checkStyle(${num}${lv})">` }</td>
     <td>
-      <input name="status${num}${lv}Accuracy" type="text" oninput="calcAcc(${num}${lv})" value="${ini.accuracy}"><span class="monster-only calc-only"><br>
-      (<input name="status${num}${lv}AccuracyFix" type="text" oninput="calcAccF(${num}${lv})" value="${ini.accuracyFix}">)</span>
+      <input name="status${num}${lv}Accuracy" type="text" oninput="calcAcc('${num}${lv}')" value="${ini.accuracy}"><span class="monster-only calc-only"><br>
+      (<input name="status${num}${lv}AccuracyFix" type="text" oninput="calcAccF('${num}${lv}')" value="${ini.accuracyFix}">)</span>
     </td>
     <td><input name="status${num}${lv}Damage" type="text" value="${ini.damage}"></td>
     <td>
-      <input name="status${num}${lv}Evasion" type="text" oninput="calcEva(${num}${lv})" value="${ini.evasion}"><span class="monster-only calc-only"><br>
-      (<input name="status${num}${lv}EvasionFix" type="text" oninput="calcEvaF(${num}${lv})" value="${ini.evasionFix}">)</span>
+      <input name="status${num}${lv}Evasion" type="text" oninput="calcEva('${num}${lv}')" value="${ini.evasion}"><span class="monster-only calc-only"><br>
+      (<input name="status${num}${lv}EvasionFix" type="text" oninput="calcEvaF('${num}${lv}')" value="${ini.evasionFix}">)</span>
     </td>
     <td><input name="status${num}${lv}Defense" type="text" value="${ini.defense}"></td>
     <td><input name="status${num}${lv}Hp" type="text" value="${ini.hp}"></td>
     <td><input name="status${num}${lv}Mp" type="text" value="${ini.mp}"></td>
     <td class="mount-only"><input name="status${num}${lv}Vit" type="text" value="${ini.vit}"></td>
     <td class="mount-only"><input name="status${num}${lv}Mnd" type="text" value="${ini.mnd}"></td>
-    <td>${ lv ? '' : `<span class="button" onclick="addStatus(${num}${lv});">複<br>製</span>` }</td>
+    <td>${ lv ? '' : `<span class="button" onclick="addStatus('${num}${lv}');">複<br>製</span>` }</td>
   `;
   target.appendChild(tr, target);
 }


### PR DESCRIPTION
# 再現手順

以下の手順を連続して（＝途中で保存やリロードなどをせずに）おこなう。

1. 魔物データの新規作成を開始する
2. 騎獣モードに切り替える
3. 適正レベルの下限値に適当な値（例： 1 ）を入力する
4. 適正レベルの上限値に、下限値よりも大きな適当な値（例： 2 ）を入力する
5. 部位ごとのデータの、適正レベル下限値ではないレベル（前述の例でいえば 2 レベル）の、命中力の欄に適当な値（例： 1 ）を入力する
6. undefined 参照が発生する

# 直截的な原因

`oninput="calcAcc(1-2)"` のような属性が設定され、実行時には `1-2` の部分が式として解決されてしまうため、存在しない要素が参照される。

# 対処方法

`oninput="calcAcc('1-2')"` のようにパラメータをクォートでくくって文字列とする。