### PR TITLE
[SW2] Fix: 魔物・騎獣のデータをゆとチャに対して自動入力するとき、生命・精神抵抗力の値が適切に表示されない場合がある不具合を修正

### DIFF
--- a/_core/lib/sw2/json-sub.pl
+++ b/_core/lib/sw2/json-sub.pl
@@ -57,8 +57,8 @@ sub addJsonData {
         { 'MP' => $pc{"status${i}Mp"}.'/'.$pc{"status${i}Mp"} },
         { '防護' => $pc{"status${i}Defense"} },
       ];
-      $vitresist = $pc{"status${i}Vit"};
-      $mndresist = $pc{"status${i}Mnd"};
+      $vitresist = $pc{mount} ? $pc{"status${i}Vit"} : $pc{vitResist} . '（' . $pc{vitResistFix} . '）';
+      $mndresist = $pc{mount} ? $pc{"status${i}Mnd"} : $pc{mndResist} . '（' . $pc{mndResistFix} . '）';
     }
     my $taxa = "分類:$pc{taxa}";
     my $data1 = "知能:$pc{intellect}　知覚:$pc{perception}".($pc{mount}?'':"　反応:$pc{disposition}");

--- a/_core/lib/sw2/json-sub.pl
+++ b/_core/lib/sw2/json-sub.pl
@@ -38,8 +38,8 @@ sub addJsonData {
         push(@hp , {$partname.':HP' => $pc{"status${i}Hp"}.'/'.$pc{"status${i}Hp"}});
         push(@mp , {$partname.':MP' => $pc{"status${i}Mp"}.'/'.$pc{"status${i}Mp"}});
         push(@def, $partname.$pc{"status${i}Defense"});
-        $vitresist = $pc{"status${i}Vit"};
-        $mndresist = $pc{"status${i}Mnd"};
+        $vitresist = $pc{mount} ? $pc{"status${i}Vit"} : $pc{vitResist} . '（' . $pc{vitResistFix} . '）';
+        $mndresist = $pc{mount} ? $pc{"status${i}Mnd"} : $pc{mndResist} . '（' . $pc{mndResistFix} . '）';
       }
       $pc{unitStatus} = [ @hp,'|', @mp,'|', {'メモ' => '防護:'.join('／',@def)}];
       $pc{unitExceptStatus} = { 'HP'=>1,'MP'=>1,'防護'=>1 }

--- a/_core/lib/sw2/json-sub.pl
+++ b/_core/lib/sw2/json-sub.pl
@@ -38,8 +38,10 @@ sub addJsonData {
         push(@hp , {$partname.':HP' => $pc{"status${i}Hp"}.'/'.$pc{"status${i}Hp"}});
         push(@mp , {$partname.':MP' => $pc{"status${i}Mp"}.'/'.$pc{"status${i}Mp"}});
         push(@def, $partname.$pc{"status${i}Defense"});
-        $vitresist = $pc{mount} ? $pc{"status${i}Vit"} : $pc{vitResist} . '（' . $pc{vitResistFix} . '）';
-        $mndresist = $pc{mount} ? $pc{"status${i}Mnd"} : $pc{mndResist} . '（' . $pc{mndResistFix} . '）';
+        if (!$pc{mount} || $pc{"status${i}Vit"} =~ /\d/) {
+          $vitresist = $pc{mount} ? $pc{"status${i}Vit"} : $pc{vitResist} . '（' . $pc{vitResistFix} . '）';
+          $mndresist = $pc{mount} ? $pc{"status${i}Mnd"} : $pc{mndResist} . '（' . $pc{mndResistFix} . '）';
+        }
       }
       $pc{unitStatus} = [ @hp,'|', @mp,'|', {'メモ' => '防護:'.join('／',@def)}];
       $pc{unitExceptStatus} = { 'HP'=>1,'MP'=>1,'防護'=>1 }


### PR DESCRIPTION
# 現象

一定の条件下の魔物／騎獣データをゆとチャに自動入力すると、生命・精神抵抗力の値が適切に表示されない。

具体的には、空文字列で表示されたり（部位数を問わず魔物の場合はこれ）、末尾の部位の値が表示されたり（複数部位の騎獣の場合はこれ）していた。

## 問題のあったケース

* 複数部位の魔物
* 複数部位の騎獣
* 単一部位の魔物

※単一部位の騎獣は問題なかった

# 備考

修正のついでに、魔物の場合は括弧書きで固定達成値も表示するようにしておいた。
（そのほうがルールブック上の表現にちかいので）