### PR TITLE
[SW2.5] 【探索指令】を習得していなければライダー観察判定パッケージを表示しない

### DIFF
--- a/_core/lib/sw2.0/edit-chara.pl
+++ b/_core/lib/sw2.0/edit-chara.pl
@@ -675,12 +675,12 @@ foreach my $class (@data::class_names){
   my $i;
   foreach my $p_id (sort{$data{$a}{stt} cmp $data{$b}{stt}} keys %data){
     (my $p_name = $data{$p_id}{name}) =~ s/(\(.+?\))/<small>$1<\/small>/;
-    print '<tr>';
+    print '<tr id="package-'.$c_en.'-'.lc($p_id).'-row">';
     print '<th rowspan="'.$rowspan.'">'.$class if !$i;
     print '<th>'. $p_name;
     print '<td id="package-'.$c_en.'-'.lc($p_id).'-auto" class="small">';
-    print '<td>+'. (input "pack${c_id}${p_id}Add", 'number','calcPackage' ) .'=';
-    print '<td id="package-'.$c_en.'-'.lc($p_id).'">'. $data{"pack${c_id}${p_id}"};
+    print '<td><span class="value">+'. (input "pack${c_id}${p_id}Add", 'number','calcPackage' ) .'=</span>';
+    print '<td id="package-'.$c_en.'-'.lc($p_id).'"><span class="value">'. $data{"pack${c_id}${p_id}"} . '</span>';
     print '';
     $i++;
   }

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1081,10 +1081,19 @@ function calcPackage() {
             break;
           }
         }
-        
+
+        let disabled = false;
+        if(cId === 'Rid' && pId === 'Obs'){
+          disabled = true;
+          for(let i = 1; i <= lv.Rid; i++){
+            if(form[`craftRiding${i}`].value.match(/^探索指令$/)){ disabled = false; break; }
+          }
+        }
+
         let value = cLv + bonus[alphabetToStt[pData[pId].stt]] + Number(form[`pack${cId}${pId}Add`].value) + autoBonus;
+        document.getElementById(`package-${eName}-${pId.toLowerCase()}-row`).classList.toggle('disabled', disabled);
         document.getElementById(`package-${eName}-${pId.toLowerCase()}-auto`).textContent = autoBonus ? '+'+autoBonus : '';
-        document.getElementById(`package-${eName}-${pId.toLowerCase()}`).textContent = value;
+        document.getElementById(`package-${eName}-${pId.toLowerCase()}`).querySelector('.value').textContent = value;
 
         if(pData[pId].monsterLore){ lore.push(cLv > 0 ? value : 0); }
         if(pData[pId].initiative ){ init.push(cLv > 0 ? value : 0); }

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -612,7 +612,7 @@ foreach my $class (@data::class_names){
 HTML
   my $c_max = $class =~ /バード|ウォーリーダー/ ? 20 : $class eq 'アーティザン' ? 19 : 17;
   foreach my $lv (1..$c_max){
-    print '<li id="craft-'.$name.$lv.'"><div class="select-input"><select name="craft'.$Name.$lv.'" oninput="'.($class =~ /ウォーリーダー/ ? 'calcPackage();':'').'selectInputCheck(\'craft'.$Name.$lv.'\',this);">';
+    print '<li id="craft-'.$name.$lv.'"><div class="select-input"><select name="craft'.$Name.$lv.'" oninput="'.($class =~ /ウォーリーダー|ライダー/ ? 'calcPackage();':'').'selectInputCheck(\'craft'.$Name.$lv.'\',this);">';
     print '<option></option>';
     my %only; my $hit; my $value = $pc{"craft${Name}${lv}"};
     foreach my $data (@{$data::class{$class}{craft}{data}}){
@@ -660,12 +660,12 @@ foreach my $class (@data::class_names){
   my $i;
   foreach my $p_id (sort{$data{$a}{stt} cmp $data{$b}{stt}} keys %data){
     (my $p_name = $data{$p_id}{name}) =~ s/(\(.+?\))/<small>$1<\/small>/;
-    print '<tr>';
+    print '<tr id="package-'.$c_en.'-'.lc($p_id).'-row">';
     print '<th rowspan="'.$rowspan.'">'.$class if !$i;
     print '<th>'. $p_name;
     print '<td id="package-'.$c_en.'-'.lc($p_id).'-auto" class="small">';
-    print '<td>+'. (input "pack${c_id}${p_id}Add", 'number','calcPackage' ) .'=';
-    print '<td id="package-'.$c_en.'-'.lc($p_id).'">'. $data{"pack${c_id}${p_id}"};
+    print '<td><span class="value">+'. (input "pack${c_id}${p_id}Add", 'number','calcPackage' ) .'=</span>';
+    print '<td id="package-'.$c_en.'-'.lc($p_id).'"><span class="value">'. $data{"pack${c_id}${p_id}"} . '</span>';
     $i++;
   }
   print "</tbody>\n";

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -623,6 +623,15 @@ dl#level {
     vertical-align: middle;
   }
 }
+#package table.hide-rider-obs tbody[data-class-name="ライダー"] tr:nth-child(2) {
+  & td:last-child::before {
+    content: "―";
+  }
+
+  & td > span {
+    display: none;
+  }
+}
 
 /* Area-Other-Actions */
 #area-other-actions {

--- a/_core/skin/sw2/css/edit.css
+++ b/_core/skin/sw2/css/edit.css
@@ -375,6 +375,16 @@
 #area-package #package table {
   margin-top: 1px;
   margin-bottom: -1px;
+
+  & tr.disabled {
+    & td:has(.value)::before {
+      content: "―";
+    }
+
+    & td > .value {
+      display: none;
+    }
+  }
 }
 #package table tr:first-child th:first-child {
   width: 10em;

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -277,13 +277,13 @@
         <div id="area-package">
           <section class="box" id="package">
             <h2>判定パッケージ</h2>
-            <table class="data-table side-margin line-tbody">
-              <TMPL_LOOP Packages><tbody>
+            <table class="data-table side-margin line-tbody <TMPL_UNLESS riderObsOn>hide-rider-obs</TMPL_UNLESS>">
+              <TMPL_LOOP Packages><tbody data-class-name="<TMPL_VAR class>">
                 <TMPL_LOOP Packs><tr>
                   <TMPL_IF NAME="__first__"><th rowspan="<TMPL_VAR colspan>"><TMPL_VAR class><span class="small">技能レベル</span><TMPL_VAR lv></TMPL_IF>
                   <th><TMPL_VAR name>
-                  <td><TMPL_IF add>+<TMPL_VAR add>=</TMPL_IF>
-                  <td><TMPL_VAR total>
+                  <td><span><TMPL_IF add>+<TMPL_VAR add>=</TMPL_IF></span>
+                  <td><span><TMPL_VAR total></span>
                 </TMPL_LOOP>
               </tbody></TMPL_LOOP>
             </table>


### PR DESCRIPTION
ライダー観察判定パッケージは騎芸【探索指令】（⇒『Ⅲ』195頁）を習得していなければ実行できないが、ゆとシート上では当該騎芸の有無にかかわらず表示されていた。

実行できない挙動が表示されているのは、ゲームプレイにおいてかなり重大な誤解をまねきかねない（※とくにSW2のゆとシにおいては、全体的に“できないことは表示されない”ようになっているが、その傾向と一致していない）ので、当該パッケージを【探索指令】を習得していない場合には非表示にするように変更。