### PR TITLE
[SW2] Fix: 同名の部位が複数ある魔物をゆとチャ上に追加する際に当該部位間のステータスがひとまとめになってしまう不具合を修正

### DIFF
--- a/_core/lib/sw2/json-sub.pl
+++ b/_core/lib/sw2/json-sub.pl
@@ -23,8 +23,23 @@ sub addJsonData {
         $multiple{ $pc{"part${i}"} }++;
       }
       my %count;
+      my $lastPartName;
+      my $partNameContinuousCount;
       foreach my $i (1 .. $pc{statusNum}){
         my $partname = $pc{"part${i}"};
+        if ($partname eq $lastPartName) {
+          if ($partNameContinuousCount == 0) {
+            my @v = values(%{$hp[$#hp]});
+            $hp[$#hp] = { $partname . 'A' . ':HP' => $v[0] };
+            @v = values(%{$mp[$#mp]});
+            $mp[$#mp] = { $partname . 'A' . ':MP' => $v[0] };
+          }
+          $partNameContinuousCount++;
+          $partname .= substr(join('', 'A'..'Z'), $partNameContinuousCount, 1);
+        } else {
+          $lastPartName = $partname;
+          $partNameContinuousCount = 0;
+        }
         if($pc{mount}){
           if($pc{lv}){
             my $ii = ($pc{lv} - $pc{lvMin} +1);


### PR DESCRIPTION
# 現象

ソード・ワールド2.xには、同名の部位を複数もつ魔物データがしばしば存在する。
（例：デュラハン（⇒『ＭＬ』133頁）、ドラゴネット（⇒『ＭＬ』175頁）など）

![image](https://github.com/yutorize/ytsheet2/assets/44130782/31f55dc2-a2ca-4185-89df-3476b602204f)

そのような構造の魔物データをゆとシート上にて作成し、それをゆとチャにインポートすると、同名の部位のステータスが区別されずひとつにまとまってしまう。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/4ef2b341-4954-40e7-9a0a-69be9a875ad8)

# 変更内容

この現象を解消するために、ゆとシートの JSON 出力の `unitStatus` において、同名の部位があった場合は、異なる名称となるようにステータスに連番を振る。（厳密には、「同名の連続する部位」）

![image](https://github.com/yutorize/ytsheet2/assets/44130782/200a5e2f-d7e4-4d2a-9161-d2ee7a28d0fc)

## 連番

連番は、アルファベットの A, B, C, ..., となる。
（そのため、同一名称の部位が 26 個を超えて存在すると問題があるが、一般的な最大対象数が 20 であるこのゲームにおいて、単一の魔物の部位数が 26 を上回るケースは現実的ではないと考える）