### PR TITLE
Fix: 明示的なリンク記法の内側に何があっても二重リンクしないように

### DIFF
--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -487,6 +487,7 @@ sub tagUnescapePalette {
 sub tagLinkUrl {
   my $url = shift;
   my $txt = shift;
+  $txt =~ s/#/&#35;/g if $txt =~ /(?:making|能力値作成(?:履歴)?)#/;
   #foreach my $safe (@set::safeurl){
   #  next if !$safe;
   #  if($url =~ /^$safe/) { return '<a href="'.$url.'" target="_blank">'.$txt.'</a>'; }

--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -488,6 +488,7 @@ sub tagLinkUrl {
   my $url = shift;
   my $txt = shift;
   $txt =~ s/#/&#35;/g if $txt =~ /(?:making|能力値作成(?:履歴)?)#/;
+  $txt =~ s/:\/\//&#58;\/\//g if $txt =~ /https?:\/\//;
   #foreach my $safe (@set::safeurl){
   #  next if !$safe;
   #  if($url =~ /^$safe/) { return '<a href="'.$url.'" target="_blank">'.$txt.'</a>'; }


### PR DESCRIPTION
# 現象
明示的なリンク記法 `[[テキスト>URL]]` の `テキスト` 部分に特定のパターンの文字列があった場合、そこが内部リンク（メイキングリンクを含む）ないしは自動リンクとして解釈されて、 __a__ タグが二重になる。

__a__ タグが二重になると HTML 構造として壊れる & 表面上はリンク化されているがリンク先は内側のリンク（のように解釈されたもの）になっている

## 例１：メイキングリンク
別の環境のメイキングにリンクを貼るとして、そのうえで `テキスト` 部分に元の環境のメイキングリンクとして表示される文字列をそのままコピペしてくるような場合

`[[能力値作成履歴#2-1>https://example.com/ytsheet2/sw2.5/?&mode=making&num=2-1]]`
↓
`<a href="https://example.com/ytsheet2/sw2.5/?&mode=making&num=2-1" target="_blank"><a href="?&mode=making&num=2-1">能力値作成履歴#2-1</a></a>`

## 例２：自動リンク

`[[http://aaa.example.com/>http://bbb.example.com/]]`

※こっちは現実的にはそうそう発生しないとは思うが……

# 対処

明示的なリンク記法をもちいている以上はそれが優先されるべきだと考え、内側をリンク（内部リンクや自動リンク）として解釈されないようにする。

具体的には、特定の文字を数値文字参照に置き換えてリンク化のパターンにマッチしないようにする。