### PR TITLE
[SW2] 魔物データの部位セクションと特殊能力セクションの間の余白を大きくする

### DIFF
--- a/_core/skin/sw2/css/monster.css
+++ b/_core/skin/sw2/css/monster.css
@@ -249,7 +249,7 @@ table.status {
 ---------------------------------------------------------------------------------------------------- */
 .skills {
   border: 0;
-  margin: 1rem 0 0;
+  margin: 1.8rem 0 0;
   padding-bottom: .5em;
   background: var(--box-base-bg-color);
   border-radius: 0;


### PR DESCRIPTION
特殊能力セクション内の余白より小さかったので

![image](https://github.com/yutorize/ytsheet2/assets/44130782/db8f898c-6e60-496b-b2ca-26ffbab6f2eb)
