### PR TITLE
[SW2] アイテムデータの武器・防具としてのデータを表示するテーブルの「備考」欄が空ならその列そのものを非表示にする

### DIFF
--- a/_core/skin/sw2/css/item.css
+++ b/_core/skin/sw2/css/item.css
@@ -212,9 +212,9 @@ div.data {
       & td:not(.left) {
         white-space: nowrap;
       }
-    }
-    & table.weapon-table:has(tr:last-child > td:last-child:empty) tr > *:last-child {
-      display: none;
+      &:not(:has(tbody td.note:not(:empty))) tr > *.note {
+        display: none;
+      }
     }
     & > :is(dt,dd):nth-of-type(n+2) {
       border-top-width: 1px;

--- a/_core/skin/sw2/css/item.css
+++ b/_core/skin/sw2/css/item.css
@@ -213,6 +213,9 @@ div.data {
         white-space: nowrap;
       }
     }
+    & table.weapon-table:has(tr:last-child > td:last-child:empty) tr > *:last-child {
+      display: none;
+    }
     & > :is(dt,dd):nth-of-type(n+2) {
       border-top-width: 1px;
       border-top-style: solid;

--- a/_core/skin/sw2/sheet-item.html
+++ b/_core/skin/sw2/sheet-item.html
@@ -104,7 +104,14 @@
         <TMPL_VAR effects>
         <TMPL_IF WeaponData>
           <table class="weapon-table">
-            <tr><th>用法<th>必筋<th>命中<th>威力<th>C値<th>追加D<th class="left">備考
+            <tr>
+              <th>用法
+              <th>必筋
+              <th>命中
+              <th>威力
+              <th>C値
+              <th>追加D
+              <th class="note left">備考
             <TMPL_LOOP WeaponData><tr>
               <td><TMPL_VAR USAGE>
               <td><TMPL_VAR REQD>
@@ -112,19 +119,24 @@
               <td><TMPL_VAR RATE>
               <td><TMPL_VAR CRIT>
               <td><TMPL_VAR DMG>
-              <td class="left"><TMPL_VAR NOTE></td>
+              <td class="note left"><TMPL_VAR NOTE></td>
             </TMPL_LOOP>
           </table>
         </TMPL_IF>
         <TMPL_IF ArmourData>
           <table class="weapon-table">
-          <tr><th>用法<th>必筋<th>回避<th>防護<th class="left">備考
+            <tr>
+              <th>用法
+              <th>必筋
+              <th>回避
+              <th>防護
+              <th class="note left">備考
             <TMPL_LOOP ArmourData><tr>
               <td><TMPL_VAR USAGE>
               <td><TMPL_VAR REQD>
               <td><TMPL_VAR EVA>
               <td><TMPL_VAR DEF>
-              <td class="left"><TMPL_VAR NOTE></td>
+              <td class="note left"><TMPL_VAR NOTE></td>
             </TMPL_LOOP>
           </table>
         </TMPL_IF>

--- a/_core/skin/sw2/sheet-item.html
+++ b/_core/skin/sw2/sheet-item.html
@@ -112,7 +112,7 @@
               <td><TMPL_VAR RATE>
               <td><TMPL_VAR CRIT>
               <td><TMPL_VAR DMG>
-              <td class="left"><TMPL_VAR NOTE>
+              <td class="left"><TMPL_VAR NOTE></td>
             </TMPL_LOOP>
           </table>
         </TMPL_IF>
@@ -124,7 +124,7 @@
               <td><TMPL_VAR REQD>
               <td><TMPL_VAR EVA>
               <td><TMPL_VAR DEF>
-              <td class="left"><TMPL_VAR NOTE>
+              <td class="left"><TMPL_VAR NOTE></td>
             </TMPL_LOOP>
           </table>
         </TMPL_IF>


### PR DESCRIPTION
空の備考欄が表示されるのは据わりがわるいし無意味なので

---

**td** を明示的に閉じるようにしたのは、そうしないと `<td>` の後にある空白文字が要素内に含まれて `:empty` にならないからです。