### PR TITLE
[SW2] 名前のある魔物は編集画面でも「名前（種族名）」形式のタイトルにする

### DIFF
--- a/_core/lib/sw2/edit-mons.pl
+++ b/_core/lib/sw2/edit-mons.pl
@@ -50,6 +50,20 @@ $pc{description} =~ s/&lt;br&gt;/\n/g;
 $pc{chatPalette} =~ s/&lt;br&gt;/\n/g;
 
 
+my $title;
+if ($mode eq 'edit') {
+    $title = '編集：';
+    if ($pc{characterName}) {
+        $title .= $pc{characterName};
+        $title .= "（$pc{monsterName}）" if $pc{monsterName};
+    }
+    else {
+        $title .= $pc{monsterName};
+    }
+}
+else {
+    $title = '新規作成';
+}
 ### フォーム表示 #####################################################################################
 print <<"HTML";
 Content-type: text/html\n
@@ -58,7 +72,7 @@ Content-type: text/html\n
 
 <head>
   <meta charset="UTF-8">
-  <title>@{[$mode eq 'edit'?"編集：$pc{monsterName}":'新規作成']} - $set::title</title>
+  <title>$title - $set::title</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" media="all" href="${main::core_dir}/skin/_common/css/base.css?${main::ver}">
   <link rel="stylesheet" media="all" href="${main::core_dir}/skin/_common/css/sheet.css?${main::ver}">


### PR DESCRIPTION
今までは「編集：グレートキクロプス」のように表示されていたところを、「編集：バードゥング（グレートキクロプス）」のように表示する。

---

元種族のデータと名前がある魔物版のデータを同時に開いて編集しているときにどっちがどっちだか分からなくなるので。

また、SW2の慣例上も名前がある魔物は「個別名（種族名）」表記が一般的であり、実際ゆとシにおいても閲覧画面のタイトルではそうなっているので。