### PR TITLE
[DX3] JSON出力時、Ｅロイスはロイス数に計上しない

### DIFF
--- a/_core/lib/dx3/json-sub.pl
+++ b/_core/lib/dx3/json-sub.pl
@@ -13,7 +13,7 @@ sub addJsonData {
   ## ロイス数
   my @dloises; $pc{loisHave} = 0; $pc{loisMax} = 0; $pc{titusHave} = 0; $pc{sublimated} = 0;
   foreach my $num (1..7){
-    if($pc{"lois${num}Relation"} =~ /[DＤ]ロイス|^[DＤ]$/){
+    if($pc{"lois${num}Relation"} =~ /[DＤEＥ]ロイス|^[DＤEＥ]$/){
       $pc{"lois${num}Name"} =~ s#/#／#g;
       push(@dloises, $pc{"lois${num}Name"});
     }


### PR DESCRIPTION
D ロイスと同様に、 E ロイスも除外する。
