### PR TITLE
[DX3] キャラクターシート倉庫からのコンバートに際してＥロイスを考慮する

### DIFF
--- a/_core/lib/dx3/convert.pl
+++ b/_core/lib/dx3/convert.pl
@@ -412,6 +412,7 @@ sub convertSoukoToYtsheet {
   my $i = 1;
   foreach (@{$in{'lois'}}){
     @$_{'type'} =~ s/^[DＤ]$/Dロイス/;
+    @$_{'type'} =~ s/^[EＥ]$/Eロイス/;
     $pc{"lois${i}Relation"} = @$_{'type'};
     $pc{"lois${i}Name"}     = @$_{'name'};
     $pc{"lois${i}EmoPosi"}  = @$_{'Pfeel'}; $pc{"lois${i}EmoPosiCheck"} = @$_{'Pemotion'};


### PR DESCRIPTION
キャラクターシート倉庫からのコンバート時、 D ロイスと同様の考慮を E ロイスについても適用する。