### PR TITLE
[DX3] トライブリードでないとき、「オプショナル」の見出しを表示しない

### DIFF
--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -131,7 +131,7 @@
             <dt>シンドローム
             <dd><TMPL_VAR syndrome1>
             <dd><TMPL_VAR syndrome2>
-            <dt>オプショナル
+            <dt><TMPL_IF syndrome3>オプショナル</TMPL_IF>
             <dd><TMPL_VAR syndrome3>
           </dl>
         </div>


### PR DESCRIPTION
ピュアブリードやクロスブリードには、「オプショナルシンドローム」という概念が存在しないため。

---

公式のキャラクターシートには常に「オプショナルシンドローム」の見出しがあるが、これは媒体が印刷物であることを前提としたものだと考える。ウェブアプリとしては不要なものは表示しないほうが自然なはず。