### PR TITLE
[DX3] 能力値の「ワークスによる修正」のラジオボタンの周囲（ラベル要素）のボーダーを消す

### DIFF
--- a/_core/skin/dx3/css/edit.css
+++ b/_core/skin/dx3/css/edit.css
@@ -81,6 +81,9 @@ body:not(.mode-crc) .crc-only {
 }
 #syndrome-status thead th:nth-child(1)   { width: 3.5em; }
 #syndrome-status thead th:nth-last-child(-n+4) { width:   5em; }
+#syndrome-status label.radio-button {
+  border: none;
+}
 #syndrome-status input[type=radio] {
   cursor: pointer;
   transform: scale(1.5) translateY(.1em);


### PR DESCRIPTION
テキストが付帯しているわけではないことからラベルの範囲を示すことに意味がなく、ラジオボタンの円をラベルのボーダーの角丸四角形が囲んでいるのが視覚的に落ち着かない（不必要にごちゃついて見える）ので。