### PR TITLE
[SW2] 騎獣の部位の追加において、生命・精神抵抗力のデフォルト値を `―` にする

### DIFF
--- a/_core/lib/sw2/edit-mons.js
+++ b/_core/lib/sw2/edit-mons.js
@@ -147,8 +147,8 @@ function addStatusInsert(target, num, copy){
     "defense"    : copy        ? form[`status${copy}${lv}Defense`     ].value : '',
     "hp"         : copy        ? form[`status${copy}${lv}Hp`          ].value : '',
     "mp"         : copy        ? form[`status${copy}${lv}Mp`          ].value : '',
-    "vit"        : copy        ? form[`status${copy}${lv}Vit`         ].value : '',
-    "mnd"        : copy        ? form[`status${copy}${lv}Mnd`         ].value : '',
+    "vit"        : copy        ? form[`status${copy}${lv}Vit`         ].value : '―',
+    "mnd"        : copy        ? form[`status${copy}${lv}Mnd`         ].value : '―',
   };
   let tr = document.createElement('tr');
   tr.setAttribute('id',idNumSet('status-row',lv));


### PR DESCRIPTION
公式の文書（例：『Ⅲ』268頁や『ＥＴ』156頁）に倣うと、騎獣の２つ目以降の部位の抵抗力は「―」表記なので、デフォルト値をそれに合わせる。