### PR TITLE
[SW2] バトルダンサーの宣言特技枠において常時特技・主動作特技の optgroup を表示しない

### DIFF
--- a/_core/skin/sw2/css/edit.css
+++ b/_core/skin/sw2/css/edit.css
@@ -325,6 +325,9 @@
     }
   }
 }
+#combat-feats-lv1bat select optgroup:empty {
+  display: none;
+}
 
 #crafts {
   flex-basis: 66%;


### PR DESCRIPTION
バトルダンサーの宣言特技枠追加の選択欄において、今までは _optgroup_ のグループ名だけ表示されていた。（画像参照）

![image](https://github.com/yutorize/ytsheet2/assets/44130782/a19a5a69-b62e-489a-9f8f-5413015f2c42)

空の _optgroup_ が表示されても意味がないので、これを非表示にする。
（これが通常の特技枠であるのなら空のグループが表示されてもよいかもしれないが、バトルダンサーが得るこれは、ルール記述上「宣言特技枠」「宣言特技枠追加」（『ＢＭ』６頁）であり、宣言特技以外の選択肢がありえないことが自明である）