### PR TITLE
[SW2] 魔物の魔法能力を、その固定達成値が記述されていなくともチャットパレットに出力するように

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -366,7 +366,7 @@ sub palettePreset {
       [\/／]
       (?:魔力)
       ([0-9]+)
-      [(（][0-9]+[）)]
+      (?:[(（][0-9]+[）)])?
       /$text .= "2d+{$+{name}} $+{name}\n\n";/megix;
     
     $skills =~ s/^
@@ -657,7 +657,7 @@ sub paletteProperties {
     $skills =~ tr/０-９（）/0-9\(\)/;
     $skills =~ s/\|/｜/g;
     $skills =~ s/<br>/\n/g;
-    $skills =~ s/^(?:$skill_mark)+(.+?)(?:[0-9]+(?:レベル|LV)|\(.+\))*[\/／](?:魔力)([0-9]+)[(（][0-9]+[）)]/push @propaties, "\/\/$1=$2";/megi;
+    $skills =~ s/^(?:$skill_mark)+(.+?)(?:[0-9]+(?:レベル|LV)|\(.+\))*[\/／](?:魔力)([0-9]+)(?:[(（][0-9]+[）)])?/push @propaties, "\/\/$1=$2";/megi;
 
     $skills =~ s/^
       (?<head>


### PR DESCRIPTION
騎獣の場合、魔法をあらわす能力があっても固定達成値をもたない。（例：レッサードラゴン⇒『ＥＴ』160頁）
そのような書式であってもチャットパレットに当該能力を出力するように。

---

騎獣以外で魔法的能力をもつデータは、公式文書の範囲ではすべて固定達成値をもつはずだが、“固定達成値をもちいるつもりがない、自作の魔物”などにも副産物的に恩恵があると思われる。