### PR TITLE
[DX3] 属性つきロイスがひとつもない場合は、属性の列を表示しない

### DIFF
--- a/_core/skin/dx3/css/chara.css
+++ b/_core/skin/dx3/css/chara.css
@@ -572,6 +572,9 @@ body {
 #lois table tbody .sperior span[data-state="ロイス"]  { background: linear-gradient(to right,hsla(0,100%,50%,0.3) 1.1em, hsla(120,100%,50%,0.05) 1.1em); }
 #lois table tbody .sperior span[data-state="タイタス"]{ background: linear-gradient(to right,hsla(0,100%,50%,0.3) 1.1em, hsla(200,100%,50%,0.3 ) 1.1em); }
 #lois table tbody .sperior span[data-state="昇華"]    { background: linear-gradient(to right,hsla(0,100%,50%,0.3) 1.1em, hsla( 50,100%,50%,0.3 ) 1.1em); }
+#lois table:not(:has(td.color:not(:empty))) .color {
+  display: none;
+}
 
 #memory table tbody td:nth-child(1) { width: 6.2em; border-right-width: 1px; } /* 関係 */
 #memory table tbody td:nth-child(2) { width:  14em; border-right-width: 1px; } /* 名前 */

--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -295,7 +295,7 @@
               <th>関係
               <th>名前
               <th colspan="3">感情<span class="small">(Posi／Nega)</span>
-              <th>属性
+              <th class="color">属性
               <th>
               <th class="right">状態
             
@@ -307,7 +307,7 @@
               <td class="emo <TMPL_IF P-CHECK>checked</TMPL_IF>"><TMPL_VAR POSI>
               <td>／
               <td class="emo <TMPL_IF N-CHECK>checked</TMPL_IF>"><TMPL_VAR NEGA>
-              <td style="<TMPL_VAR COLOR-BG>"><TMPL_VAR COLOR>
+              <td class="color" style="<TMPL_VAR COLOR-BG>"><TMPL_VAR COLOR></td>
               <td class="left"<TMPL_IF D> colspan="2"</TMPL_IF>><TMPL_VAR NOTE>
               <TMPL_UNLESS D><td class="right <TMPL_IF S>sperior</TMPL_IF>"><span data-state="<TMPL_VAR STATE>"></span></TMPL_UNLESS>
             </TMPL_LOOP>


### PR DESCRIPTION
![image](https://github.com/yutorize/ytsheet2/assets/44130782/01d20479-823a-42f1-9bb2-cb7649804f58)

---

* ロイスの属性は後発サプリメント（『リンケージマインド』）による追加ルールであり、採用していないセッション環境が現実的にありうる。
* ロイスの属性は、ルール上はタイタスの効果に対してのみ作用するため、（原則としてタイタスの効果を得られない）NPCにとっては属性の概念が不要である。

上記の理由から、属性の指定されているロイスがひとつもない場合は、属性の列そのものを非表示にするように。

---

_td_ を明示的に閉じているのは、 `:empty` を検出するためです。