### PR TITLE
[DX3] 関係も名前も備考も空のロイスの行には「状態」を表示しない

### DIFF
--- a/_core/lib/dx3/view-chara.pl
+++ b/_core/lib/dx3/view-chara.pl
@@ -302,6 +302,7 @@ foreach (1 .. 7){
   elsif($pc{'lois'.$_.'Color'} =~ /^(WH|白)/i    ){ $color = 'hsla(  0,  0%,100%,0.2)'; }
   elsif($pc{'lois'.$_.'Color'} =~ /^(YE|黄)/i    ){ $color = 'hsla( 60,100%, 50%,0.2)'; }
   $color = $color ? "background-color:${color};" : '';
+  $pc{'lois'.$_.'State'} = '' unless $pc{'lois'.$_.'Relation'} || $pc{'lois'.$_.'Name'} || $pc{'lois'.$_.'Note'};
   push(@loises, {
     "RELATION" => $pc{'lois'.$_.'Relation'},
     "NAME"     => $pc{'lois'.$_.'Name'},

--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -309,7 +309,7 @@
               <td class="emo <TMPL_IF N-CHECK>checked</TMPL_IF>"><TMPL_VAR NEGA>
               <td style="<TMPL_VAR COLOR-BG>"><TMPL_VAR COLOR>
               <td class="left"<TMPL_IF D> colspan="2"</TMPL_IF>><TMPL_VAR NOTE>
-              <TMPL_UNLESS D><td class="right <TMPL_IF S>sperior</TMPL_IF>"><span data-state="<TMPL_VAR STATE>"></span></TMPL_UNLESS>
+              <TMPL_UNLESS D><td class="right <TMPL_IF S>sperior</TMPL_IF>"><TMPL_IF STATE><span data-state="<TMPL_VAR STATE>"></span></TMPL_IF></TMPL_UNLESS>
             </TMPL_LOOP>
           </tbody>
         </table>


### PR DESCRIPTION
# 目的

未取得の枠において「ロイス」と表示されているのは不自然なので、これを解消する。
（取得していないものはロイスではなく、そしてロイスとしての状態を持たないため）

（「未取得」のように表示するのもアリかもしれないが……、かならずしも取得しなければならないものではないので、「未」という表現が有する感覚的なニュアンスは実際の在り方に沿わないような気がする）

# 仕様

ロイスの関係・名前・備考のすべてが空であれば、「状態」を表示しない。

* ルール上は、ロイスの取得に際して「対象」（ここでいう「名前」）が必要（『ルールブック１』P217）である。
* ルールを逸脱するとしても、現実的な運用として、上記の３つがすべて空のうえで「状態」が意味をもつ状況がありうるとは考えづらい。

# イメージ

※右端参照

**before**
![image](https://github.com/yutorize/ytsheet2/assets/44130782/5a751c83-f380-4890-a26c-916a375390f4)

**after**
![image](https://github.com/yutorize/ytsheet2/assets/44130782/2bd19c2f-77c8-42b3-834f-63fece9be009)
