### PR TITLE
[DX3] 有意なロイスの状態の指定がひとつもなければ、状態の見出しテキストを非表示にする

### DIFF
--- a/_core/skin/dx3/css/chara.css
+++ b/_core/skin/dx3/css/chara.css
@@ -575,6 +575,9 @@ body {
 #lois table:not(:has(td.color:not(:empty))) .color {
   display: none;
 }
+#lois table:not(:has(td.state:not(:empty))) thead th.state > .text {
+  display: none;
+}
 
 #memory table tbody td:nth-child(1) { width: 6.2em; border-right-width: 1px; } /* 関係 */
 #memory table tbody td:nth-child(2) { width:  14em; border-right-width: 1px; } /* 名前 */

--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -299,7 +299,7 @@
               <th colspan="3">感情<span class="small">(Posi／Nega)</span>
               <th class="color">属性
               <th>
-              <th class="right">状態
+              <th class="state right"><span class="text">状態</span>
             
           </thead>
           <tbody>
@@ -311,7 +311,7 @@
               <td class="emo <TMPL_IF N-CHECK>checked</TMPL_IF>"><TMPL_VAR NEGA>
               <td class="color" style="<TMPL_VAR COLOR-BG>"><TMPL_VAR COLOR></td>
               <td class="left"<TMPL_UNLESS STATE> colspan="2"</TMPL_UNLESS>><TMPL_VAR NOTE>
-              <TMPL_IF STATE><td class="right <TMPL_IF S>sperior</TMPL_IF>"><span data-state="<TMPL_VAR STATE>"></span></TMPL_IF>
+              <TMPL_IF STATE><td class="state right <TMPL_IF S>sperior</TMPL_IF>"><span data-state="<TMPL_VAR STATE>"></span></td></TMPL_IF>
             </TMPL_LOOP>
           </tbody>
         </table>


### PR DESCRIPTION
状態をもつロイスがひとつもなければ、「状態」の列見出しに意味はないので

![image](https://github.com/yutorize/ytsheet2/assets/44130782/eef9cf1a-c379-4555-8a89-e7c3aa21621c)
