### PR TITLE
Fix: [GS] セッション履歴の「目標達成」または「成長点」のみが記入されている行を削除しようとしても確認が挟まれない

### DIFF
--- a/_core/lib/gs/edit-chara.js
+++ b/_core/lib/gs/edit-chara.js
@@ -929,7 +929,9 @@ function delHistory(){
   if(num > 1){
     if ( form[`history${num}Date`].value
       || form[`history${num}Title`].value
+      || form[`history${num}Completed`].value
       || form[`history${num}Exp`].value
+      || form[`history${num}Adp`].value
       || form[`history${num}Money`].value
       || form[`history${num}Gm`].value
       || form[`history${num}Member`].value


### PR DESCRIPTION
`Completed`, `Adp` に対する処理がなかった

---

#124 と同種