### PR TITLE
[DX3] アイテムの種別の候補に「エンブレム／その他」「リレーション／その他」を追加

### DIFF
--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -1371,6 +1371,7 @@ print <<"HTML";
     <option value="使い捨て">
     <option value="エンブレム／コネ">
     <option value="エンブレム／一般">
+    <option value="エンブレム／その他">
     <option value="エンブレム／使い捨て">
     <option value="リレーション／コネ">
     <option value="リレーション／一般">

--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -1375,6 +1375,7 @@ print <<"HTML";
     <option value="エンブレム／使い捨て">
     <option value="リレーション／コネ">
     <option value="リレーション／一般">
+    <option value="リレーション／その他">
     <option value="リレーション／使い捨て">
   </datalist>
   <datalist id="list-dfclty">


### PR DESCRIPTION
9c7e48dddc2235444762d109aa7c4d303170d56d によって「エンブレム／一般」「リレーション／一般」が追加されたが、『アイテムアーカイブ』を採用していない環境においては、そのたぐいのアイテムは「～／その他」という種別をもつので、それをサポートする意図。

「エンブレム／～」は『ユニバーサルガーディアン』が初出、「リレーション／～」は『ヒューマンリレーション』が初出です。
『アイテムアーカイブ』によってエンブレムデータとリレーションアイテムはすべて再録されましたが、同書が後発のサプリメントであり、採用していないセッション環境が現実的にある（なんならたぶんそっちのほうが多い）ことをかんがみると、『ＩＡ』前の環境向けの入力候補も存在すべきだという考えです。（ https://github.com/yutorize/ytsheet2/pull/71 が置き換えではなく追加だったのも同じ考えによるものです）