### PR TITLE
[SW2] 単部位の魔物の場合は、閲覧画面上で「攻撃方法」の後の「（部位）」を表示しない

### DIFF
--- a/_core/lib/sw2/edit-mons.pl
+++ b/_core/lib/sw2/edit-mons.pl
@@ -282,7 +282,7 @@ print <<"HTML";
           <tr>
             <th class="lv mount-only">Lv
             <th class="handle">
-            <th class="name">攻撃方法（部位）
+            <th class="name">攻撃方法<span class="text-part">（部位）</span>
             <th class="acc">命中力
             <th class="atk">打撃点
             <th class="eva">回避力

--- a/_core/skin/sw2/css/monster.css
+++ b/_core/skin/sw2/css/monster.css
@@ -192,6 +192,9 @@ table.status {
     &.vit    { width: 8.5%; }
     &.mnd    { width: 8.5%; }
   }
+  &:not(#status-table):has(tbody tr:first-child:last-child) thead th.name > .text-part {
+    display: none;
+  }
   & tbody {
     border-top-width: 1px;
     border-top-style: solid;

--- a/_core/skin/sw2/sheet-monster.html
+++ b/_core/skin/sw2/sheet-monster.html
@@ -145,7 +145,7 @@
         <thead>
           <tr>
             <TMPL_IF mount><th class="lv">Lv</TMPL_IF>
-            <th class="name">攻撃方法（部位）
+            <th class="name">攻撃方法<span class="text-part">（部位）</span>
             <th class="acc">命中力
             <th class="atk">打撃点
             <th class="eva">回避力


### PR DESCRIPTION
魔物の部位一覧の見出し行において、常に「攻撃方法（部位）」と表示されていたが、単一部位の魔物の場合には「（部位）」を表示しないようにする。

理由：

* 公式文書においてもそのような書式になっている
* 単一部位の場合には実際に意味がないし、単一部位の魔物はふつう攻撃方法のみを表記されるため、「（部位）」という見出しが事実に反することになる

**閲覧画面**
![image](https://github.com/yutorize/ytsheet2/assets/44130782/7ec3cc9a-bcfa-47d9-96c4-cc97954f4783)

---

編集画面では、部位数にかかわらず「（部位）」を表示する。
（編集中は部位の数が未確定であり、判断がつかないため）