### PR TITLE
[DX3] 「欲望」はＦＨワークスのキャラクターの場合にのみ表示する

### DIFF
--- a/_core/lib/dx3/edit-chara.js
+++ b/_core/lib/dx3/edit-chara.js
@@ -12,6 +12,7 @@ window.onload = function() {
   nameSet();
   checkCreateType();
   checkStage();
+  checkWorks();
   checkSyndrome();
   calcStt();
   calcEffect();
@@ -85,6 +86,16 @@ function checkStage(){
   document.body.classList.toggle('mode-crc', form.stage.value.match('クロウリングケイオス'));
   calcMagic();
 }
+
+// ワークスによる他の箇所の変化 ----------------------------------------
+function checkWorks() {
+  const worksInput = document.querySelector('input[name="works"]');
+  const works = worksInput.value.trim();
+
+  const isFH = /[FＦ][HＨ]/i.test(works);
+  document.querySelector('#lifepath > table').classList.toggle('is-fh', isFH);
+}
+
 // シンドローム変更 ----------------------------------------
 function changeSyndrome(num,syn){
   syndromes[num-1] = syn;

--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -320,7 +320,7 @@ print <<"HTML";
           <dl class="box"><dt>血液型<dd>@{[input "blood",'','','list="list-blood"']}</dl>
         </div>
         <div class="box-union" id="works-cover">
-          <dl class="box"><dt>ワークス<dd>@{[input "works"]}</dl>
+          <dl class="box"><dt>ワークス<dd>@{[input "works",'','checkWorks']}</dl>
           <dl class="box"><dt>カヴァー<dd>@{[input "cover"]}</dl>
         </div>
 
@@ -506,9 +506,9 @@ print <<"HTML";
               <th>経験
               <td colspan="2">@{[input "lifepathExperience"]}
               <td colspan="2" class="left">@{[input "lifepathExperienceNote",'','','placeholder="備考"']}
-          <tbody>
+          <tbody class="encounter-or-desire">
             <tr>
-              <th>邂逅/欲望
+              <th><span class="encounter">邂逅</span><span class="desire">欲望</span>
               <td colspan="2">@{[input "lifepathEncounter"]}
               <td colspan="2" class="left">@{[input "lifepathEncounterNote",'','','placeholder="備考"']}
           <tbody>

--- a/_core/lib/dx3/view-chara.pl
+++ b/_core/lib/dx3/view-chara.pl
@@ -260,6 +260,10 @@ $SHEET->param(wordsY => ($pc{wordsY} eq '下' ? 'bottom:0;' : 'top:0;'));
 ### ステージ --------------------------------------------------
 if($pc{stage} =~ /クロウリングケイオス/){ $SHEET->param(ccOn => 1); }
 
+### ワークス --------------------------------------------------
+my $isFH = $pc{works} =~ /[FＦ][HＨ]/i ? 1 : 0;
+$SHEET->param(isFH => $isFH);
+
 ### ブリード --------------------------------------------------
 my $breedPrefix = ($pc{breed} ? $pc{breed} : $pc{syndrome3} ? 'トライ' : $pc{syndrome2} ? 'クロス' : $pc{syndrome1} ? 'ピュア' : '');
 $SHEET->param(breed => isNoiseText(tagDelete $breedPrefix) ? $breedPrefix : $breedPrefix ? "$breedPrefix<span class=\"shorten\">ブリード</span>" : '');

--- a/_core/skin/dx3/css/chara.css
+++ b/_core/skin/dx3/css/chara.css
@@ -310,6 +310,11 @@ body {
   /* min-height: calc(100% - 1.4rem * 1.5); */
   border-style: solid hidden hidden;
   empty-cells: hide;
+
+  &:not(.is-fh) tbody.encounter-or-desire th:first-child > .desire,
+  &.is-fh tbody.encounter-or-desire th:first-child > .encounter {
+    display: none;
+  }
 }
 #lifepath table th:first-child {
   width: 6.2em;

--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -178,7 +178,7 @@
         
         <section class="box" id="lifepath">
           <h2>ライフパス</h2>
-          <table class="data-table line-tbody">
+          <table class="data-table line-tbody <TMPL_IF isFH>is-fh</TMPL_IF>">
             <tbody>
               <tr>
                 <th class="left" colspan="2">出自
@@ -191,9 +191,9 @@
                 <td rowspan="2" class="left"><TMPL_VAR lifepathExperienceNote>
               <tr>
                 <td colspan="2"><TMPL_VAR lifepathExperience></td>
-            <tbody>
+            <tbody class="encounter-or-desire">
               <tr>
-                <th class="left" colspan="2">邂逅／欲望
+                <th class="left" colspan="2"><span class="encounter">邂逅</span><span class="desire">欲望</span>
                 <td rowspan="2" class="left"><TMPL_VAR lifepathEncounterNote>
               <tr>
                 <td colspan="2"><TMPL_VAR lifepathEncounter></td>


### PR DESCRIPTION
# 内容

ライフパス欄に「欲望」の文言を表示するのは、ＦＨワークスのキャラクターの場合のみにする。
また、「欲望」の文言を表示する場合には、「邂逅」の文言を表示しない。

## 仕様

ワークス内に「ＦＨ」という文字列があれば、ＦＨに属するキャラクターであるとみなす。

ファルスハーツに所属するＰＣは『パブリックエネミー』P31に定義されているワークスからワークスを選択せねばならず（※同書P30のルール文より）、それらのワークスはすべて名称に「ＦＨ」の文字列を含む。（以下の画像参照）

![image](https://github.com/yutorize/ytsheet2/assets/44130782/67262a60-cc5f-4f3c-9f4d-710e0c862dcd)
（[『パブリックエネミー』](https://www.kadokawa.co.jp/product/321803001644/)P31より）

また、ファルスハーツに所属するＰＣは、すべて「邂逅」ではなく「欲望」を取得しなければならない（※『パブリックエネミー』P31のルール文より）ため、「欲望」を表示する場合には「邂逅」は不要である。

# 理由

* 「欲望」という概念をもつのは、ファルスハーツに所属するＰＣのみであり、そうでないキャラクターに表示されるのは不自然である
* ファルスハーツに所属するＰＣは、サプリメント『パブリックエネミー』によるルール追加のもとでしか作成できない。ファルスハーツに属するＰＣという概念も、欲望という概念も、同書の内容を把握していないユーザーにとっては何のことだかわからない
