### PR TITLE
Fix: [SW2] 魔法/神格/流派画面のヘッダの h1 要素のリンク先を修正

### DIFF
--- a/_core/skin/sw2/sheet-arts.html
+++ b/_core/skin/sw2/sheet-arts.html
@@ -15,7 +15,7 @@
 </head>
 <body id="arts" <TMPL_IF wideMode>class="wide"</TMPL_IF>>
   <header>
-    <h1><a href="./"><TMPL_VAR title></a></h1>
+    <h1><a href="./?type=a"><TMPL_VAR title></a></h1>
     <nav>
       <ul>
         <TMPL_LOOP Menu><li class="<TMPL_VAR SIZE>"><a <TMPL_VAR TYPE>="<TMPL_VAR VALUE>"><TMPL_VAR TEXT></a>


### PR DESCRIPTION
他のデータ区分（キャラクター・魔物・アイテム）のページではヘッダの h1 要素部分からその区分のトップに飛ぶが、魔法/神格/流派にかぎりそうなっていなかったのを修正。