### PR TITLE
[SW2] 能力値作成の個別の結果ページ内のヘッダの h1 要素からは能力値作成のトップに飛ばす

### DIFF
--- a/_core/lib/sw2/list-making.pl
+++ b/_core/lib/sw2/list-making.pl
@@ -168,6 +168,9 @@ if(!$in_num) {
   $INDEX->param(pagePrevOn => $page - $page_items >= 0);
   $INDEX->param(pageNextOn => $page + $page_items < @lines);
 }
+else {
+  $INDEX->param(isMakingResult => 1);
+}
 $INDEX->param(formOn => 1) if !$::in{num} && !$::in{id};
 
 $INDEX->param(title => $set::title);

--- a/_core/skin/sw2/index.html
+++ b/_core/skin/sw2/index.html
@@ -23,7 +23,7 @@
 <body>
   <script src="<TMPL_VAR coreDir>/skin/_common/js/common.js?<TMPL_VAR ver>"></script>
   <header>
-    <h1><a href="./"><TMPL_VAR title></a></h1>
+    <h1><a href="./<TMPL_IF isMakingResult>?mode=making</TMPL_IF>"><TMPL_VAR title></a></h1>
     <nav><TMPL_INCLUDE NAME="../_common/index-menu.html"></nav>
     <TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>
   </header>


### PR DESCRIPTION
キャラクター・魔物・アイテムの個別データのぺージなどと同じ感覚で、能力値作成の結果ページのヘッダからは能力値作成のトップに飛ぶように変更。