### PR TITLE
[SW2] フェローの備考が空なら備考欄そのものを表示しない

### DIFF
--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1296,6 +1296,10 @@ dl#level {
 
 #fellowNote {
   margin-top: 1.5rem;
+
+  &:not(:has(dd:not(:empty))) {
+    display: none;
+  }
 }
 
 @media screen and (max-width:735px){

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -725,7 +725,7 @@
       </table>
       <dl id="fellowNote">
         <dt>備考
-        <dd><TMPL_VAR fellowNote>
+        <dd><TMPL_VAR fellowNote></dd>
       </dl>
       <TMPL_ELSE>
         <p>このキャラクターのフェローは公開されていません。</p>


### PR DESCRIPTION
表示してもとくに意味がないので