### PR TITLE
[SW2] フェローの言語をひとつごとに改行する

### DIFF
--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1224,6 +1224,10 @@ dl#level {
   margin-left: 1em;
 }
 
+#f-language span {
+  display: block;
+}
+
 #f-classes,
 #f-language {
   min-height: 80px;


### PR DESCRIPTION
それぞれに括弧書きがともなうこともあってか、言語が多いキャラクターだとあまりにもごちゃついて見え、内容を把握しづらいので。
（「このキャラクターはこの言語を理解できるのか？」ということを確認したいとき、現状ではブラウザの検索機能などを使わないとかなりつらい）

（例；手持ちのキャラクターをフェロー化したもの）
![image](https://github.com/yutorize/ytsheet2/assets/44130782/ca01644e-4538-4342-8c2c-57f80d5de824)
