### PR TITLE
[SW2] ＰＣデータ／フェローデータの切り替えボタンをよりわかりやすい表現に置き換える

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -1027,15 +1027,15 @@ if(!$pc{modeDownload}){
   }
   else {
     if($pc{logId}){
-      if   ($::in{f}         ){ push(@menu, { TEXT => '通常'    , TYPE => "href", VALUE => "./?id=$::in{id}&log=$pc{logId}" }); }
-      elsif($pc{fellowPublic}){ push(@menu, { TEXT => 'フェロー', TYPE => "href", VALUE => "./?id=$::in{id}&log=$pc{logId}&f=1" }); }
+      if   ($::in{f}         ){ push(@menu, { TEXT => 'ＰＣ',     TYPE => "href", VALUE => "./?id=$::in{id}&log=$pc{logId}",     CLASSES => 'character-format', }); }
+      elsif($pc{fellowPublic}){ push(@menu, { TEXT => 'フェロー', TYPE => "href", VALUE => "./?id=$::in{id}&log=$pc{logId}&f=1", CLASSES => 'character-format', }); }
       push(@menu, { TEXT => '過去ログ', TYPE => "onclick", VALUE => 'loglistOn()', });
       if($pc{reqdPassword}){ push(@menu, { TEXT => '復元', TYPE => "onclick", VALUE => "editOn()", }); }
       else                 { push(@menu, { TEXT => '復元', TYPE => "href"   , VALUE => "./?mode=edit&id=$::in{id}&log=$pc{logId}", }); }
     }
     else {
-      if   ($::in{f}         ){ push(@menu, { TEXT => '通常'    , TYPE => "href", VALUE => "./?id=$::in{id}" }); }
-      elsif($pc{fellowPublic}){ push(@menu, { TEXT => 'フェロー', TYPE => "href", VALUE => "./?id=$::in{id}&f=1" }); }
+      if   ($::in{f}         ){ push(@menu, { TEXT => 'ＰＣ',     TYPE => "href", VALUE => "./?id=$::in{id}",     CLASSES => 'character-format', }); }
+      elsif($pc{fellowPublic}){ push(@menu, { TEXT => 'フェロー', TYPE => "href", VALUE => "./?id=$::in{id}&f=1", CLASSES => 'character-format', }); }
       if(!$pc{forbiddenMode}){
         push(@menu, { TEXT => 'パレット', TYPE => "onclick", VALUE => "chatPaletteOn()",   });
         push(@menu, { TEXT => '出力'    , TYPE => "onclick", VALUE => "downloadListOn()",  });

--- a/_core/skin/sw2.0/sheet-chara.html
+++ b/_core/skin/sw2.0/sheet-chara.html
@@ -9,7 +9,7 @@
     <h1><a href="./"><TMPL_VAR title></a></h1>
     <nav>
       <ul>
-        <TMPL_LOOP Menu><li class="<TMPL_VAR SIZE>"><a <TMPL_VAR TYPE>="<TMPL_VAR VALUE>"><TMPL_VAR TEXT></a>
+        <TMPL_LOOP Menu><li class="<TMPL_VAR SIZE> <TMPL_VAR CLASSES>"><a <TMPL_VAR TYPE>="<TMPL_VAR VALUE>"><TMPL_VAR TEXT></a>
         </TMPL_LOOP>
         <li><a onclick="nightModeChange()" class="nightmode-icon" title="ナイトモード"></a>
       </ul>

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -79,6 +79,23 @@ body {
   font-family: var(--base-font-family-mono);
 }
 
+/* // Menu
+---------------------------------------------------------------------------------------------------- */
+header nav ul li.character-format {
+  > a {
+    display: flex;
+    flex-flow: column;
+    justify-content: center;
+    font-size: 85%;
+
+    &::after {
+      content: "データ";
+      font-size: 75%;
+      margin-top: 0.2em;
+    }
+  }
+}
+
 /* // Area-Status
 ---------------------------------------------------------------------------------------------------- */
 #area-status {

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -9,7 +9,7 @@
     <h1><a href="./"><TMPL_VAR title></a></h1>
     <nav>
       <ul>
-        <TMPL_LOOP Menu><li class="<TMPL_VAR SIZE>"><a <TMPL_VAR TYPE>="<TMPL_VAR VALUE>"><TMPL_VAR TEXT></a>
+        <TMPL_LOOP Menu><li class="<TMPL_VAR SIZE> <TMPL_VAR CLASSES>"><a <TMPL_VAR TYPE>="<TMPL_VAR VALUE>"><TMPL_VAR TEXT></a>
         </TMPL_LOOP>
         <li><a onclick="nightModeChange()" class="nightmode-icon" title="ナイトモード"></a>
       </ul>


### PR DESCRIPTION
# 従来のＵＩの問題

フェロー画面からＰＣ画面にもどるためのボタンが致命的にわかりづらかった。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/ea3da47d-c080-4e76-abb2-2efdd9bd0e89)

当該機能をもつボタンのラベルが「通常」となっており、なにを意味するのかまったくわからなかった。
（「通常」という表現は、そうでない具体的ななにかと組でもちいないかぎり、何に対する“通常”なのかが特定できない。フェローに対する元キャラクターデータを“通常”と称するような慣習もないはず）

# 改善版

当該ボタンのラベルを「ＰＣデータ」に変更した。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/fa595771-b31a-4099-b5b0-93febfaf6b04)

合わせて、ＰＣ画面からフェロー画面に遷移するためのボタンも、「フェロー」から「フェローデータ」に変更した。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/450c71fd-11c2-4081-8bd2-780acbc42499)

「フェローデータ」という表現は、編集画面におけるそれとも一致しており、妥当だと考えられる。
（他方、逆のボタンは、編集画面に合わせるならば「ＰＣデータ」より「キャラクターデータ」となるところだが、フェローもキャラクターであるため、その機能のボタンにもちいるには明瞭でないと考える）