### PR TITLE
[SW2] フェローのレベルのあしらいの六角形を SVG での実装に置き換える

### DIFF
--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1121,48 +1121,36 @@ dl#level {
 
 #fellow #f-level {
   margin: 0 auto;
-  width: 52px;
-  height: 86px;
+  width: 99px;
+  height: 99px;
   display: block;
   position: relative;
   border-bottom: 0px !important;
+  background-image: url(../img/hexagon_light.svg);
+  background-size: contain;
+  background-position: center center;
+  background-repeat: no-repeat;
+
+  .night & {
+    background-image: url(../img/hexagon_night.svg);
+  }
 }
 #fellow #f-level dd {
-  width: 100%;
-  height: 90px;
-  line-height: 80px;
   color: var(--text-color);
-  text-align: center;
+  justify-content: center;
+  align-items: center;
   font-size: 2.5rem;
-  display: block;
-  position: relative;
-  z-index: 1;
-  border-width: 2px 0px;
-  border-style: solid;
-  border-color: var(--box-outside-border-color);
-}
-#fellow #f-level::before,
-#fellow #f-level::after {
-  content: '';
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  display: flex;
   position: absolute;
-  z-index: 0;
-  border-width: 2px 0px;
-  border-style: solid;
-  border-color: var(--box-outside-border-color);
-}
-#fellow #f-level::before {
-  transform: rotate(60deg);
-}
-#fellow #f-level::after {
-  transform: rotate(-60deg);
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
 }
 #fellow #f-level dt {
   position: absolute;
-  bottom: 0;
+  bottom: 9%;
   width: 100%;
   line-height: 1;
   text-align: center;
@@ -1313,12 +1301,10 @@ dl#level {
   }
 
   #fellow #f-level {
-    width: 46px;
-    height: 76px;
+    width: 88px;
+    height: 88px;
 }
   #fellow #f-level dd {
-    height: 80px;
-    line-height: 70px;
     font-size: 2.5rem;
 }
   #f-image-none,

--- a/_core/skin/sw2/img/hexagon_light.svg
+++ b/_core/skin/sw2/img/hexagon_light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 226" width="260" height="226">
+	<polygon points="258,113 194,2.15 66,2.15 2,113 66,223.85 194,223.85" fill="none" stroke="#8FA291" stroke-width="5" />
+</svg>

--- a/_core/skin/sw2/img/hexagon_night.svg
+++ b/_core/skin/sw2/img/hexagon_night.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 226" width="260" height="226">
+	<polygon points="258,113 194,2.15 66,2.15 2,113 66,223.85 194,223.85" fill="none" stroke="#516152" stroke-width="5" />
+</svg>


### PR DESCRIPTION
従来は CSS で実装されていた六角形のあしらいを、 SVG での実装に置き換える。

# 理由

従来のあしらいはガタガタしていた。
まあこれだけなら調整であるていど誤魔化せなくもないかもしれないが、そもそもこういった歪みが発生するのは CSS で強引に実装していることに由来するものであり、画像にしてしまったほうが安定するはず。

SVG なら実質的にテキストデータなので軽量であり、またベクターデータであるので拡縮にも堪える。

**before**
![image](https://github.com/yutorize/ytsheet2/assets/44130782/5c69b256-ecfe-4dec-9e7d-8bb0710519bb)

**after**
![image](https://github.com/yutorize/ytsheet2/assets/44130782/a7d151f2-b152-47ba-bf7c-61281c98aa1a)

**after / 拡大500%**
![image](https://github.com/yutorize/ytsheet2/assets/44130782/921288a4-625b-4d98-b67f-9828166b1ad9)
