### PR TITLE
[SW2] フェロー行動表の「行動」「効果」において複数行を記入できるように

### DIFF
--- a/_core/lib/edit.pl
+++ b/_core/lib/edit.pl
@@ -206,6 +206,15 @@ sub input {
   ($oninput?' oninput="'.$oninput.'"':"").
   '>';
 }
+sub textarea {
+  my ($name, $oninput, $other) = @_;
+  if($oninput && $oninput !~ /\(.*?\)$/){ $oninput .= '()'; }
+  '<textarea'.
+      ' name="'.$name.'"'.
+      ($other?" $other":"").
+      ($oninput?' oninput="'.$oninput.'"':"").
+      '>' . $::pc{$name} . '</textarea>';
+}
 sub checkbox {
   my ($name, $text, $oninput, $other) = @_;
   if($oninput && $oninput !~ /\(.*?\)$/){ $oninput .= '()'; }

--- a/_core/lib/sw2/calc-chara.pl
+++ b/_core/lib/sw2/calc-chara.pl
@@ -620,6 +620,10 @@ sub data_calc {
   $pc{fellowNote}    =~ s/\r\n?|\n/<br>/g;
   $pc{chatPalette}   =~ s/\r\n?|\n/<br>/g;
   $pc{'chatPaletteInsert'.$_} =~ s/\r\n?|\n/<br>/g foreach(1..2);
+  foreach (keys %pc) {
+    next unless $_ =~ /^fellow[-0-9]+(?:Action|Note)$/;
+    $pc{$_} =~ s/\r\n?|\n/<br>/g;
+  }
   
   #### 保存処理でなければここまで --------------------------------------------------
   if(!$::mode_save){ return %pc; }

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -112,6 +112,10 @@ $pc{fellowProfile}   =~ s/&lt;br&gt;/\n/g;
 $pc{fellowNote}      =~ s/&lt;br&gt;/\n/g;
 $pc{chatPalette}     =~ s/&lt;br&gt;/\n/g;
 $pc{'chatPaletteInsert'.$_} =~ s/&lt;br&gt;/\n/g foreach(1..2);
+foreach (keys %pc) {
+  next unless $_ =~ /^fellow[-0-9]+(?:Action|Note)$/;
+  $pc{$_} =~ s/&lt;br&gt;/\n/g;
+}
 
 ### フォーム表示 #####################################################################################
 my $titlebarname = removeTags nameToPlain unescapeTags ($pc{characterName}||"“$pc{aka}”");
@@ -1391,55 +1395,55 @@ print <<"HTML";
         <tr class="border-top">
           <td rowspan="2">⚀<br>⚁
           <td class="number">7
-          <td>@{[ input 'fellow1Action' ]}
+          <td>@{[ textarea 'fellow1Action','','rows="3"' ]}
           <td>@{[ input 'fellow1Words' ]}
           <td>@{[ input 'fellow1Num' ]}
-          <td>@{[ input 'fellow1Note' ]}
+          <td>@{[ textarea 'fellow1Note','','rows="3"' ]}
         <tr>
           <td class="number">6
-          <td>@{[ input 'fellow1-2Action' ]}
+          <td>@{[ textarea 'fellow1-2Action','','rows="3"' ]}
           <td>@{[ input 'fellow1-2Words' ]}
           <td>@{[ input 'fellow1-2Num' ]}
-          <td>@{[ input 'fellow1-2Note' ]}
+          <td>@{[ textarea 'fellow1-2Note','','rows="3"' ]}
         <tr class="border-top">
           <td rowspan="2">⚂<br>⚃
           <td class="number">8
-          <td>@{[ input 'fellow3Action' ]}
+          <td>@{[ textarea 'fellow3Action','','rows="3"' ]}
           <td>@{[ input 'fellow3Words' ]}
           <td>@{[ input 'fellow3Num' ]}
-          <td>@{[ input 'fellow3Note' ]}
+          <td>@{[ textarea 'fellow3Note','','rows="3"' ]}
         <tr>
           <td class="number">5
-          <td>@{[ input 'fellow3-2Action' ]}
+          <td>@{[ textarea 'fellow3-2Action','','rows="3"' ]}
           <td>@{[ input 'fellow3-2Words' ]}
           <td>@{[ input 'fellow3-2Num' ]}
-          <td>@{[ input 'fellow3-2Note' ]}
+          <td>@{[ textarea 'fellow3-2Note','','rows="3"' ]}
         <tr class="border-top">
           <td rowspan="2">⚄
           <td class="number">9
-          <td>@{[ input 'fellow5Action' ]}
+          <td>@{[ textarea 'fellow5Action','','rows="3"' ]}
           <td>@{[ input 'fellow5Words' ]}
           <td>@{[ input 'fellow5Num' ]}
-          <td>@{[ input 'fellow5Note' ]}
+          <td>@{[ textarea 'fellow5Note','','rows="3"' ]}
         <tr>
           <td class="number">4
-          <td>@{[ input 'fellow5-2Action' ]}
+          <td>@{[ textarea 'fellow5-2Action','','rows="3"' ]}
           <td>@{[ input 'fellow5-2Words' ]}
           <td>@{[ input 'fellow5-2Num' ]}
-          <td>@{[ input 'fellow5-2Note' ]}
+          <td>@{[ textarea 'fellow5-2Note','','rows="3"' ]}
         <tr class="border-top">
           <td rowspan="2">⚅
           <td class="number">10
-          <td>@{[ input 'fellow6Action' ]}
+          <td>@{[ textarea 'fellow6Action','','rows="3"' ]}
           <td>@{[ input 'fellow6Words' ]}
           <td>@{[ input 'fellow6Num' ]}
-          <td>@{[ input 'fellow6Note' ]}
+          <td>@{[ textarea 'fellow6Note','','rows="3"' ]}
         <tr>
           <td class="number">3
-          <td>@{[ input 'fellow6-2Action' ]}
+          <td>@{[ textarea 'fellow6-2Action','','rows="3"' ]}
           <td>@{[ input 'fellow6-2Words' ]}
           <td>@{[ input 'fellow6-2Num' ]}
-          <td>@{[ input 'fellow6-2Note' ]}
+          <td>@{[ textarea 'fellow6-2Note','','rows="3"' ]}
         </tr>
       </table>
       </div>


### PR DESCRIPTION
# 変更内容

フェロー行動表内の「行動」「効果」で複数行を取り扱えるようにする。
（『DX3』の「コンボ」の解説欄と同様の挙動）

# 理由

『SW2』におけるキャラクターの行動は、しばしば複数の要素が併用され（典型的な例は、宣言型の戦闘特技や、【ターゲットサイト】等の補助動作で使用できる自己強化能力）、またその効果もしばしば複雑になる。
フェローにおいてもそれは（程度の差はあるかもしれないが）同様であり、フェロー行動表の「行動」「効果」を単一行で記述するには難のあるケースがありうる。

一例として、『Ⅰ』236・237頁の「記入例」では「内容」が３行、同240頁の「記入例」では「内容」が４行・「効果」が３行ある。

『Ⅰ』240頁の記入例相当の内容：
![image](https://github.com/yutorize/ytsheet2/assets/44130782/3e1ce32d-ecc6-4288-88ce-1c3674075204)

従来でも、最終的な表示は（自動的な折り返しによって）複数行にわたることができたが、『Ⅰ』232～240頁の記入例を見るに、改行位置をコントロールできるほうがより望ましいと思われる。
（ルールブックの記入例は、（若干の例外はあるものの）意味的な単位と行の対応が意識されていると思われる）