### PR TITLE
[SW2] フェロー行動表の達成値が途中で改行されないように

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -995,6 +995,11 @@ if($::in{id}){
 
 ### フェロー --------------------------------------------------
 $SHEET->param(FellowMode => $::in{f});
+foreach (keys %pc) {
+  next unless $_ =~ /^fellow[-0-9]+Num$/;
+  $pc{$_} =~ s#(\d+)#<span class="number">$1</span>#g;
+  $SHEET->param($_ => $pc{$_});
+}
 
 ### タイトル --------------------------------------------------
 $SHEET->param(title => $set::title);

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1275,6 +1275,10 @@ dl#level {
   border-right: 1px dotted;
   border-color: var(--box-outside-border-color);
   padding: .2rem .5rem;
+
+  &.num > .number {
+    word-break: keep-all;
+  }
 }
 
 #fellow-actions td[rowspan]{

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -675,52 +675,52 @@
           <td class="number">7
           <td><TMPL_VAR fellow1Action>
           <td><TMPL_VAR fellow1Words>
-          <td><TMPL_VAR fellow1Num>
+          <td class="num"><TMPL_VAR fellow1Num>
           <td><TMPL_VAR fellow1Note>
         <tr>
           <td class="number">6
           <td><TMPL_VAR fellow1-2Action>
           <td><TMPL_VAR fellow1-2Words>
-          <td><TMPL_VAR fellow1-2Num>
+          <td class="num"><TMPL_VAR fellow1-2Num>
           <td><TMPL_VAR fellow1-2Note>
         <tr>
           <td rowspan="2">⚂<br>⚃
           <td class="number">8
           <td><TMPL_VAR fellow3Action>
           <td><TMPL_VAR fellow3Words>
-          <td><TMPL_VAR fellow3Num>
+          <td class="num"><TMPL_VAR fellow3Num>
           <td><TMPL_VAR fellow3Note>
         <tr>
           <td class="number">5
           <td><TMPL_VAR fellow3-2Action>
           <td><TMPL_VAR fellow3-2Words>
-          <td><TMPL_VAR fellow3-2Num>
+          <td class="num"><TMPL_VAR fellow3-2Num>
           <td><TMPL_VAR fellow3-2Note>
         <tr>
           <td rowspan="2">⚄
           <td class="number">9
           <td><TMPL_VAR fellow5Action>
           <td><TMPL_VAR fellow5Words>
-          <td><TMPL_VAR fellow5Num>
+          <td class="num"><TMPL_VAR fellow5Num>
           <td><TMPL_VAR fellow5Note>
         <tr>
           <td class="number">4
           <td><TMPL_VAR fellow5-2Action>
           <td><TMPL_VAR fellow5-2Words>
-          <td><TMPL_VAR fellow5-2Num>
+          <td class="num"><TMPL_VAR fellow5-2Num>
           <td><TMPL_VAR fellow5-2Note>
         <tr>
           <td rowspan="2">⚅
           <td class="number">10
           <td><TMPL_VAR fellow6Action>
           <td><TMPL_VAR fellow6Words>
-          <td><TMPL_VAR fellow6Num>
+          <td class="num"><TMPL_VAR fellow6Num>
           <td><TMPL_VAR fellow6Note>
         <tr>
           <td class="number">3
           <td><TMPL_VAR fellow6-2Action>
           <td><TMPL_VAR fellow6-2Words>
-          <td><TMPL_VAR fellow6-2Num>
+          <td class="num"><TMPL_VAR fellow6-2Num>
           <td><TMPL_VAR fellow6-2Note>
       </table>
       <dl id="fellowNote">


### PR DESCRIPTION
複数の達成値を記述するなど、達成値欄のテキストが長い場合、数値（数字列）の途中で改行が発生してしまうことがあった。
（以下は『Ⅰ』240頁の記入例を入力したもの）

![image](https://github.com/yutorize/ytsheet2/assets/44130782/082238fc-431a-458f-a8a6-f89cda0a365f)

これを回避する。
（上記の例だと、次のようになる）

![image](https://github.com/yutorize/ytsheet2/assets/44130782/7843bd39-7fd0-4905-b3e4-c639e05f5967)
