### PR TITLE
Fix: キャラクター名も表示名も空のときに名前の表示例が不自然に表示されてしまうのを回避

### DIFF
--- a/_core/skin/_common/css/edit.css
+++ b/_core/skin/_common/css/edit.css
@@ -1251,6 +1251,13 @@ input[type="submit"]:hover {
         &.tekey { color:#000000; background: #ffffff; }
         &.ccfol { color:#ffffff; background: #2a2a2a; }
         &.udona { color:#444444; background: #fcf0e3; }
+
+        &:empty {
+          display: none;
+        }
+      }
+      #name-plate-view:not(:has(:is(.ytcha, .tekey, .ccfol, .udona):not(:empty))) {
+        display: none;
       }
 
       table {


### PR DESCRIPTION
# 現象

キャラクター名と表示名がともに空であるとき、表示例の部分がきわめて不自然な見え方をする。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/870d3a4e-b77a-40a9-8f86-e6f84f786e09)

# 対処方法

表示例の中身が空になるときは、表示例の部分をまるごと非表示にする。

## 動作イメージ

![ytsheet-fix_nameplate_view](https://github.com/yutorize/ytsheet2/assets/44130782/795bcf98-8cf2-463b-a921-0e600960c707)
