### PR TITLE
Fix: [SW2] 騎獣の場合は og:description に「知名度／弱点値」を含めない

### DIFF
--- a/_core/lib/sw2/view-mons.pl
+++ b/_core/lib/sw2/view-mons.pl
@@ -249,7 +249,7 @@ $SHEET->param(ogUrl => url().($::in{url} ? "?url=$::in{url}" : "?id=$::in{id}"))
 #if($pc{image}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
 my @ogDescriptionItems = ("レベル:$pc{lv}", "分類:$pc{taxa}");
 push(@ogDescriptionItems, "部位数:$pc{partsNum}") if $pc{partsNum}>1;
-push(@ogDescriptionItems, "知名度:$pc{reputation}／$pc{'reputation+'}");
+push(@ogDescriptionItems, "知名度:$pc{reputation}／$pc{'reputation+'}") unless $pc{mount};
 $SHEET->param(ogDescript => removeTags(join('　', @ogDescriptionItems)));
 
 ### バージョン等 --------------------------------------------------

--- a/_core/lib/sw2/view-mons.pl
+++ b/_core/lib/sw2/view-mons.pl
@@ -247,7 +247,10 @@ else {
 ### OGP --------------------------------------------------
 $SHEET->param(ogUrl => url().($::in{url} ? "?url=$::in{url}" : "?id=$::in{id}"));
 #if($pc{image}) { $SHEET->param(ogImg => url()."/".$imgsrc); }
-$SHEET->param(ogDescript => removeTags "レベル:$pc{lv}　分類:$pc{taxa}".($pc{partsNum}>1?"　部位数:$pc{partsNum}":'')."　知名度:$pc{reputation}／$pc{'reputation+'}");
+my @ogDescriptionItems = ("レベル:$pc{lv}", "分類:$pc{taxa}");
+push(@ogDescriptionItems, "部位数:$pc{partsNum}") if $pc{partsNum}>1;
+push(@ogDescriptionItems, "知名度:$pc{reputation}／$pc{'reputation+'}");
+$SHEET->param(ogDescript => removeTags(join('　', @ogDescriptionItems)));
 
 ### バージョン等 --------------------------------------------------
 $SHEET->param(ver => $::ver);


### PR DESCRIPTION
# 現象

騎獣シートの _og:description_ に `知名度:／` （※具体的な値のない空の知名度）という文字列が含まれてしまう。

例：
![image](https://github.com/yutorize/ytsheet2/assets/44130782/115da09b-668c-4392-8cc0-2ad1a5e3a08f)

# 原因

騎獣の編集画面では知名度／弱点値の欄が表示されない（※これはルールブックに照らして適切な仕様である）が、 _og:description_ の出力においてそれが考慮されていない。