### PR TITLE
[SW2] 魔物データの編集画面において、「部位数」「コア部位」の見出しを上下中央揃えに

### DIFF
--- a/_core/skin/sw2/css/monster.css
+++ b/_core/skin/sw2/css/monster.css
@@ -239,6 +239,14 @@ table.status {
   & dl {
     display: flex;
     margin-right: 1.5em;
+    @media screen and (min-width: 736px) {
+      & dt {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        line-height: 100%;
+      }
+    }
     & dt::after {
       content: ':';
       display: inline-block;


### PR DESCRIPTION
従来は上揃えで表示されていた。
![image](https://github.com/yutorize/ytsheet2/assets/44130782/ec277f30-93cf-4be4-8018-46ce8df3abcf)

それがいまひとつ不揃いに見えるので、上下中央揃えにした。
![image](https://github.com/yutorize/ytsheet2/assets/44130782/5e11d5da-81d5-4ec8-8428-2347106b14c6)
