### PR TITLE
Fix: キャラクター以外のシートの編集画面でエラーが発生していたのを修正

### DIFF
--- a/_core/lib/edit.js
+++ b/_core/lib/edit.js
@@ -307,7 +307,9 @@ function addUnitStatus(){
 function delUnitStatus(){
   delRow('unitStatusNum', '#unit-status-optional tr:last-of-type')
 }
-setSortable('unitStatus','#unit-status-optional','tr');
+if (document.getElementById('unit-status-optional') != null) {
+  setSortable('unitStatus', '#unit-status-optional', 'tr');
+}
 
 // 画像配置 ----------------------------------------
 // ビューを開く


### PR DESCRIPTION
# 現象

キャラクターをあつかわないシートの編集画面において、 JS で例外が発生していた。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/f17d36ef-72b0-4985-a133-31b67d69f8a3)

該当するシート：
* [SW2] アイテムシート
* [SW2] 魔法/神格/流派シート
* [MS] クランシート

# 原因

https://github.com/yutorize/ytsheet2/commit/dd9c84493e378f749c1afa5f805a706ece7a7c94#diff-0a51076b029b7a29306292ed0366383c8e7318ce6536e87d464ac5cb8dfc60fc において、 _edit.js_ （つまりキャラクター以外のシートでも実行されるスクリプト）内で、無条件に `setSortable('unitStatus', '#unit-status-optional', 'tr');` が実行されていた。

# 対処方法

`#unit-status-optional` が存在する場合にのみ実行するようにした。