### PR TITLE
[SW2] 魔法データの系統選択における操霊魔法・深智魔法の位置を変更

### DIFF
--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -16,7 +16,7 @@ foreach(@data::class_names){
     push(@magic_classes, '基本妖精魔法', '属性妖精魔法(土)', '属性妖精魔法(水・氷)', '属性妖精魔法(炎)', '属性妖精魔法(風)', '属性妖精魔法(光)', '属性妖精魔法(闇)', '特殊妖精魔法');
   }
   elsif($_ eq 'コンジャラー'){
-    push(@craft_classes, $data::class{$_}{magic}{jName}, '深智魔法');
+    push(@magic_classes, $data::class{$_}{magic}{jName}, '深智魔法');
   }
   elsif($_ eq 'バード'){
     push(@craft_classes, $data::class{$_}{craft}{jName}, '終律');


### PR DESCRIPTION
# 従来の並び

![image](https://github.com/yutorize/ytsheet2/assets/44130782/0d207e92-5411-4bed-9bdc-28d49be50473)

## 従来の並びの問題

* 操霊魔法がこの位置なのはどう考えてもおかしい。ルールブックⅠの時点で収録されているごく一般的な魔法系統であり、公式文書上では常に真語魔法の次に位置している。（コードから推測すると、これは不具合だと思われる）
* 深智魔法の位置も、一般的なユーザーの感覚には沿わないと思われる。深智魔法が掲載されている『ＷＴ』『ＭＡ』においては、いずれも、操霊魔法の次に位置している。（深智魔法を一般的な魔法系統とは異なるものとして取り扱うことには考慮の余地があるものの、『ＷＴ』『ＭＡ』に準ずるほうがユーザーにとってあつかいやすいと考える）

# 変更後

真語魔法と神聖魔法のあいだに、操霊魔法・深智魔法を移動した。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/d0a44383-396f-44a5-af00-73b44fd3fe7c)
