### PR TITLE
[SW2] 魔法データの系統選択において、妖精魔法関連を optgroup にまとめる

### DIFF
--- a/_core/lib/edit.pl
+++ b/_core/lib/edit.pl
@@ -270,6 +270,10 @@ sub option {
       $text .= '<optgroup label="'.$value.'">';
       $label = 1;
     }
+    elsif($value eq 'close_group') {
+      $text .= '</optgroup>';
+      $label = 0;
+    }
     else {
       if($value =~ s/\|\<(.*?)\>$//){ $view = $1 } else { $view = $value }
       $text .= '<option value="'.$value.'"'.($::pc{$name} eq $value ? ' selected':'').'>'.$view;

--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -13,7 +13,12 @@ my @magic_classes;
 my @craft_classes;
 foreach(@data::class_names){
   if($_ eq 'フェアリーテイマー'){
-    push(@magic_classes, '基本妖精魔法', '属性妖精魔法(土)', '属性妖精魔法(水・氷)', '属性妖精魔法(炎)', '属性妖精魔法(風)', '属性妖精魔法(光)', '属性妖精魔法(闇)', '特殊妖精魔法');
+    push(
+        @magic_classes,
+        'label=妖精魔法',
+        ('基本妖精魔法', '属性妖精魔法(土)', '属性妖精魔法(水・氷)', '属性妖精魔法(炎)', '属性妖精魔法(風)', '属性妖精魔法(光)', '属性妖精魔法(闇)', '特殊妖精魔法'),
+        'close_group'
+    );
   }
   elsif($_ eq 'コンジャラー'){
     push(@craft_classes, $data::class{$_}{magic}{jName}, '深智魔法');


### PR DESCRIPTION
**before**
![image](https://github.com/yutorize/ytsheet2/assets/44130782/636f6b66-14ac-4b62-8b1e-187aa0921804)

---

**after**
![image](https://github.com/yutorize/ytsheet2/assets/44130782/3c301fbc-a1e9-4688-ace5-6f1aff65732b)

---

妖精魔法関連の選択肢が他とくらべてかなり多く、見通しがわるかったため。