### PR TITLE
[SW2] アイテムデータの「用法」の入力候補を、武器と防具で区別する

### DIFF
--- a/_core/lib/sw2/edit-item.pl
+++ b/_core/lib/sw2/edit-item.pl
@@ -194,7 +194,7 @@ foreach my $num ('TMPL', 1 .. $pc{weaponNum}){
   print <<"HTML";
           @{[ $num eq 'TMPL' ? '<template id="weapon-template">' : '' ]}<tr id="weapon-row$num">
             <td class="handle">
-            <td>@{[ input "weapon${num}Usage",'text','','list="list-usage"' ]}
+            <td>@{[ input "weapon${num}Usage",'text','','list="list-weapon-usage"' ]}
             <td>@{[ input "weapon${num}Reqd" ]}
             <td>@{[ input "weapon${num}Acc" ]}
             <td>@{[ input "weapon${num}Rate" ]}
@@ -221,7 +221,7 @@ foreach my $num ('TMPL', 1 .. $pc{armourNum}){
   print <<"HTML";
           @{[ $num eq 'TMPL' ? '<template id="armour-template">' : '' ]}<tr id="armour-row$num">
             <td class="handle">
-            <td>@{[ input "armour${num}Usage",'text','','list="list-usage"' ]}
+            <td>@{[ input "armour${num}Usage",'text','','list="list-armour-usage"' ]}
             <td>@{[ input "armour${num}Reqd" ]}
             <td>@{[ input "armour${num}Eva" ]}
             <td>@{[ input "armour${num}Def" ]}
@@ -266,7 +266,7 @@ print <<"HTML";
   <datalist id="list-item-name">
     <option value="〈〉">
   </datalist>
-  <datalist id="list-usage">
+  <datalist id="list-weapon-usage">
     <option value="1H">
     <option value="1H#">
     <option value="1H投">
@@ -276,6 +276,10 @@ print <<"HTML";
     <option value="2H#">
     <option value="振2H">
     <option value="突2H">
+  </datalist>
+  <datalist id="list-armour-usage">
+    <option value="1H">
+    <option value="2H">
   </datalist>
   <datalist id="list-age">
     <option value="現在">


### PR DESCRIPTION
従来は武器と防具で共通の _datalist_ が参照されていた。
![image](https://github.com/yutorize/ytsheet2/assets/44130782/87b697f0-baca-41f9-b7db-35ceac2b353a)

しかしながら、武器向けの入力候補の大部分は防具（盾）にとって不要なので、別々の _datalist_ を定義して使い分けるようにした。
![image](https://github.com/yutorize/ytsheet2/assets/44130782/03954bd9-c854-416d-ad5f-bf43a456c6f9)

防具向けの _datalist_ の具体的内容は、『ＥＴ』104頁をもとに設定した。
