### PR TITLE
Fix: [SW2] 装飾品「その他」枠を追加するチェックが入っていない場合は、追加枠に値が入力されていても表示しない

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -827,6 +827,10 @@ else {
     next if (@$_[1] =~ /Other2/ &&  $pc{raceAbility} !~ /［見えざる手］/);
     next if (@$_[1] =~ /Other3/ && ($pc{raceAbility} !~ '［見えざる手］' || $pc{level} <  6));
     next if (@$_[1] =~ /Other4/ && ($pc{raceAbility} !~ '［見えざる手］' || $pc{level} < 16));
+    if (@$_[1] =~ /_$/) {
+      my $baseKey = substr(@$_[1], 0, length(@$_[1]) - 1);
+      next unless $pc{'accessory'.$baseKey.'Add'};
+    }
     push(@accessories, {
       TYPE => @$_[0],
       NAME => $pc{'accessory'.@$_[1].'Name'},


### PR DESCRIPTION
1. その他枠を追加するチェックを入れる
2. 追加されたその他枠になんらかを記入する
3. その枠を追加するためのチェックを外す
4. 保存する

という手順をふんだとき、閲覧画面で当該追加枠の内容が表示されていた。

チェックが外れている以上は表示しないのが妥当なはずなので、そのように改める。