### PR TITLE
[SW2] 閲覧画面において、能力値ボーナス欄手前の「÷６」の存在感を薄める

### DIFF
--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -303,6 +303,9 @@ body {
   font-size: 1.2rem;
   text-align: right;
 }
+main#character #status dl[id^="stt-bonus"]::after {
+  opacity: 0.3;
+}
 #status dl[id^="stt-bonus"] dt span {
   display: block;
   width: 3em;


### PR DESCRIPTION
![image](https://github.com/yutorize/ytsheet2/assets/44130782/670dd9a1-5440-4235-b915-acda0f09eaf5)

編集画面ならまだしも、閲覧画面において「÷６」が目立っている必要はないと思うので……。