### PR TITLE
[SW2] 借金／預金がともに 0 なら `―` と表示する

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -953,7 +953,7 @@ if($pc{money} =~ /^(?:自動|auto)$/i){
   $SHEET->param(money => commify($pc{moneyTotal}));
 }
 if($pc{deposit} =~ /^(?:自動|auto)$/i){
-  $SHEET->param(deposit => commify($pc{depositTotal}).' G ／ '.commify($pc{debtTotal}));
+  $SHEET->param(deposit => $pc{depositTotal} || $pc{debtTotal} ? commify($pc{depositTotal}).' G ／ '.commify($pc{debtTotal}) : '');
 }
 $pc{cashbook} =~ s/(:(?:\:|&lt;|&gt;))((?:[\+\-\*\/]?[0-9,]+)+)/$1.cashCheck($2)/eg;
   $SHEET->param(cashbook => $pc{cashbook});

--- a/_core/skin/sw2.0/sheet-chara.html
+++ b/_core/skin/sw2.0/sheet-chara.html
@@ -497,7 +497,7 @@
         <div id="area-items-L">
           <dl class="box" id="money">
             <dt>所持金<dd><TMPL_VAR money> G
-            <dt>預金／借金<dd><TMPL_VAR deposit> G
+            <dt>預金／借金<dd><TMPL_IF deposit><TMPL_VAR deposit> G</TMPL_IF></dd>
           </dl>
           <section class="box" id="items">
             <h2><TMPL_IF head_items><TMPL_VAR head_items><TMPL_ELSE>所持品</TMPL_IF></h2>

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -901,6 +901,10 @@ dl#level {
   }
   & dd {
     grid-row: 2;
+
+    &:last-child:empty::before {
+      content: "―";
+    }
   }
 }
 

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -473,7 +473,7 @@
         <div id="area-items-L">
           <dl class="box" id="money">
             <dt>所持金<dd><TMPL_VAR money> G
-            <dt>預金／借金<dd><TMPL_VAR deposit> G
+            <dt>預金／借金<dd><TMPL_IF deposit><TMPL_VAR deposit> G</TMPL_IF></dd>
           </dl>
           <section class="box" id="items">
             <h2><TMPL_IF head_items><TMPL_VAR head_items><TMPL_ELSE>所持品</TMPL_IF></h2>


### PR DESCRIPTION
# 変更内容

借金／預金がともに 0 なら `―` と表示するように

## 表示例

![image](https://github.com/yutorize/ytsheet2/assets/44130782/46b84a33-2091-4d25-b921-88c9a63b9301)

# 理由

借金・預金がともに 0 であるあいだはそれらの概念と無関係と考えられるので（すべてのキャラクターが借金・預金という項目を有するものではなく、むしろそれらが存在しないときこそが自然状態のはず）、その場合には（従来の `0 G ／ 0 G` という表記にくらべて）より“存在しない”ことを明確にあらわせる表現に変更した。
