### PR TITLE
[SW2] 穢れの値が空であるなら、閲覧画面で穢れ欄を非表示にする

### DIFF
--- a/_core/skin/sw2.0/sheet-chara.html
+++ b/_core/skin/sw2.0/sheet-chara.html
@@ -129,7 +129,7 @@
             <dt>信仰<dd><TMPL_VAR faith>
           </dl>
           <dl class="box" id="sin">
-            <dt>穢れ<dd><TMPL_VAR sin>
+            <dt>穢れ<dd><TMPL_VAR sin></dd>
           </dl>
         </div>
 

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -166,6 +166,17 @@ body {
     display: inline-block;
   }
 }
+#personal {
+  &:has(#sin > dd:empty) {
+    #race-ability {
+      flex-basis: 100%;
+    }
+
+    #sin {
+      display: none;
+    }
+  }
+}
 
 /* Status */
 #status {

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -132,7 +132,7 @@
             <dt>ランク<dd><TMPL_VAR rank>
           </dl>
           <dl class="box" id="sin">
-            <dt>穢れ<dd><TMPL_VAR sin>
+            <dt>穢れ<dd><TMPL_VAR sin></dd>
           </dl>
         </div>
 


### PR DESCRIPTION
# 変更内容

閲覧画面において、「穢れ」の値が空であるならば穢れ欄自体を非表示にする。

## 表示例

![image](https://github.com/yutorize/ytsheet2/assets/44130782/3ef3b192-8f6a-4d4f-920d-ac10270f65ec)
（「穢れ」欄を非表示にして、その分だけ「種族特徴」の欄を拡げる）

# 理由

大半（すくなくとも半数以上程度）のＰＣは「穢れ」をもっていないと考えられ、そして空の欄が表示されると間が抜けた感じになる（しかもかなり目立つ場所に穢れ欄がある（公式のキャラクターシートの、左下の経歴欄の片隅というのにくらべると、ゆとシの穢れ欄は存在感がつよい））。