### PR TITLE
[SW2.5] フェローの閲覧画面に二つ名を表示する

### DIFF
--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1189,6 +1189,22 @@ dl#level {
 }
 #f-character-name dd {
   font-size: 2rem;
+
+  .aka {
+    &::before {
+      content: "“";
+    }
+
+    &::after {
+      content: "”";
+    }
+  }
+
+  .aka,
+  .aka + .name {
+    word-break: keep-all;
+    white-space: nowrap;
+  }
 }
 
 #f-race,

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -623,7 +623,8 @@
         <dt>レベル<dd><TMPL_VAR level>
       </dl>
       <dl id="f-character-name">
-        <dt>名前<dd><TMPL_VAR characterName>
+        <dt>名前
+        <dd><TMPL_IF aka><span class="aka"><TMPL_VAR aka></span></TMPL_IF><span class="name"><TMPL_VAR characterName></span>
       </dl>
       <dl id="f-player-name">
         <dt>プレイヤー名<dd><TMPL_VAR playerName>


### PR DESCRIPTION
# 変更内容

フェローの閲覧画面において、二つ名を表示するように。

## 表示例

![image](https://github.com/yutorize/ytsheet2/assets/44130782/c82d8106-a05c-4756-ab03-bf397d128e6d)

![image](https://github.com/yutorize/ytsheet2/assets/44130782/cc3f2f5b-dbc6-4fcd-a488-ad0f518e7a7f)
