### PR TITLE
[SW2.5] フェローの自己紹介文に、 `unescapeTagsLines` による記法の解決を適用する

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -119,7 +119,7 @@ $SHEET->param(rawName => $pc{characterName} || ($pc{aka} ? "“$pc{aka}”" : ''
 if($pc{ver}){
   foreach (keys %pc) {
     next if($_ =~ /^image/);
-    if($_ =~ /^(?:items|freeNote|freeHistory|cashbook)$/){
+    if($_ =~ /^(?:items|freeNote|freeHistory|cashbook|fellowProfile)$/){
       $pc{$_} = unescapeTagsLines($pc{$_});
     }
     $pc{$_} = unescapeTags($pc{$_});


### PR DESCRIPTION
`RIGHT:` 記法を適用した例

![image](https://github.com/yutorize/ytsheet2/assets/44130782/9f554d1c-11f7-44f6-ac03-b327cbf5b48c)
