### PR TITLE
[SW2] Fix: 言語に関する notice の順序が不安定なのを修正

### DIFF
--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1673,7 +1673,7 @@ function checkLanguage(){
     count[read.value] ||= 0; count[read.value]++;
   }
   let notice = '';
-  for (let key in SET.class){
+  for (let key of SET.classNames){
     if(!SET.class[key].language){ continue; }
     const className = key;
     const classId = SET.class[key].id;


### PR DESCRIPTION
# 現象

言語に関する notice （選択習得の不足や過剰、自動習得の欠如などを画面上に示すもの）の順序が不安定だった。

## 例

たとえば https://yutorize.2-d.jp/ytsheet/sw2.5/?id=fDvHmB このようなキャラクターデータがあったとして、これに対する当該 notice は、

![image](https://github.com/yutorize/ytsheet2/assets/44130782/ecea5080-435b-4fee-8cbf-e819ad695002)
のようなときもあれば、

![image](https://github.com/yutorize/ytsheet2/assets/44130782/a797b19d-3426-4611-bd47-0518429d51eb)
のようなときもあった。

（ Chrome で確認したかぎりでは、通常のリロードを繰り返すかぎりはおおむね一定で、スーパーリロードをすると再びシャッフルされるっぽい。謎）

# 原因

_object_ のキー群に対する順次的な処理だったため。

* JS の _object_ のキーの列挙は、（すくなくとも処理系によっては）順序が安定している（ Chromium は安定してる気がする）
* Perl のハッシュのキーの列挙は、順序が安定していない

JS はともかく、この _object_ は Perl 上のハッシュを JSON にしたものが元なので、 Perl のハッシュを経由している時点で不安定なのは避けられない。

# 対処方法

順序の安定した配列として `SET.classNames` があったので、それを参照するようにした。