### PR TITLE
[SW2] キャラクターシートの一部の欄で、能力区分をあらわすアイコンをサポート

### DIFF
--- a/_core/lib/edit.pl
+++ b/_core/lib/edit.pl
@@ -607,6 +607,8 @@ HTML
 sub textRuleArea {
   my $system_rule = shift;
   my $multiline = shift;
+  my $multilineSystemRule = shift;
+  $multilineSystemRule = '<br><br>' . $multilineSystemRule if $multilineSystemRule;
   return <<"HTML";
     <aside id="text-rule" class="sticky-footer" style="display:none">
       <h2>テキスト装飾・整形ルール</h2>
@@ -647,6 +649,7 @@ sub textRuleArea {
         折り畳み終了：行頭に<code>[---]</code>：（ハイフンは3つ以上任意）<br>
         　　　　　　　省略すると、以後のテキストが全て折りたたまれます。<br>
         コメントアウト：行頭に<code>//</code>：記述した行を非表示にします。
+        ${multilineSystemRule}
       </div>
     </aside>
 HTML

--- a/_core/lib/sw2.0/edit-chara.pl
+++ b/_core/lib/sw2.0/edit-chara.pl
@@ -1398,7 +1398,16 @@ my $text_rule = <<"HTML";
         　刃武器　　　　：<code>[刃]</code>：<img class="i-icon" src="${set::icon_dir}wp_edge.png"><br>
         　打撃武器　　　：<code>[打]</code>：<img class="i-icon" src="${set::icon_dir}wp_blow.png"><br>
 HTML
-print textRuleArea( $text_rule,'「容姿・経歴・その他メモ」「履歴（自由記入）」「所持品」「収支履歴」' );
+my $multilineRule = <<"HTML";
+        アイコン<br>
+        　常時　　　：<code>[○]</code><code>[◯]</code><code>[〇]</code>：<i class="s-icon passive">○</i><br>
+        　主動作　　：<code>[＞]</code><code>[▶]</code><code>[〆]</code>：<i class="s-icon major0">〆</i><br>
+        　補助動作　：<code>[☆]</code><code>[≫]</code><code>[»]</code><code>[&gt;&gt;]</code>：<i class="s-icon minor0">☆</i><br>
+        　宣言型　　：<code>[□]</code><code>[☐]</code><code>[☑]</code><code>[🗨]</code>：<i class="s-icon active0">☑</i><br>
+        　条件型　　：<code>[▽]</code>：<i class="s-icon condition">▽</i><br>
+        　条件選択型：<code>[▼]</code>：<i class="s-icon selection">▼</i>
+HTML
+print textRuleArea( $text_rule,'「容姿・経歴・その他メモ」「履歴（自由記入）」「所持品」「収支履歴」',$multilineRule );
 
 print <<"HTML";
   </main>

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -1590,7 +1590,15 @@ my $text_rule = <<"HTML";
         　刃武器　　　　：<code>[刃]</code>：<img class="i-icon" src="${set::icon_dir}wp_edge.png"><br>
         　打撃武器　　　：<code>[打]</code>：<img class="i-icon" src="${set::icon_dir}wp_blow.png"><br>
 HTML
-print textRuleArea( $text_rule,'「容姿・経歴・その他メモ」「履歴（自由記入）」「所持品」「収支履歴」' );
+my $multilineRule = <<"HTML";
+        アイコン<br>
+        　常時　　：<code>[○]</code><code>[◯]</code><code>[〇]</code>：<i class="s-icon passive">○</i><br>
+        　戦闘準備：<code>[△]</code>：<i class="s-icon setup">△</i><br>
+        　主動作　：<code>[＞]</code><code>[▶]</code><code>[〆]</code>：<i class="s-icon major">▶</i><br>
+        　補助動作：<code>[☆]</code><code>[≫]</code><code>[»]</code><code>[&gt;&gt;]</code>：<i class="s-icon minor">≫</i><br>
+        　宣言型　：<code>[□]</code><code>[☐]</code><code>[☑]</code><code>[🗨]</code>：<i class="s-icon active">☑</i><br>
+HTML
+print textRuleArea( $text_rule,'「容姿・経歴・その他メモ」「履歴（自由記入）」「所持品」「収支履歴」',$multilineRule );
 
 print <<"HTML";
   </main>

--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -103,6 +103,7 @@ sub class_color {
 ### タグ変換 --------------------------------------------------
 sub textToIcon {
   my $text = shift;
+  my $requireSquareBrackets = shift;
 
   my @patterns = ();
 
@@ -123,6 +124,7 @@ sub textToIcon {
   
   foreach (@patterns) {
     (my $re, my $replacement) = @{$_};
+    $re = "\\[(?:$re)]" if $requireSquareBrackets;
     $text =~ s{$re}{$replacement}gi;
   }
   

--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -103,19 +103,27 @@ sub class_color {
 ### タグ変換 --------------------------------------------------
 sub textToIcon {
   my $text = shift;
+
+  my @patterns = ();
+
   if($::SW2_0){
-    $text =~ s{[○◯〇]}{<i class="s-icon passive">○</i>}gi;
-    $text =~ s{[＞▶〆]}{<i class="s-icon major0">〆</i>}gi;
-    $text =~ s{[☆≫»]|&gt;&gt;}{<i class="s-icon minor0">☆</i>}gi;
-    $text =~ s{[□☐☑🗨]}{<i class="s-icon active0">☑</i>}gi;
-    $text =~ s{[▽]}{<i class="s-icon condition">▽</i>}gi;
-    $text =~ s{[▼]}{<i class="s-icon selection">▼</i>}gi;
+    push(@patterns, ['[○◯〇]', '<i class="s-icon passive">○</i>']);
+    push(@patterns, ['[＞▶〆]', '<i class="s-icon major0">〆</i>']);
+    push(@patterns, ['[☆≫»]|&gt;&gt;', '<i class="s-icon minor0">☆</i>']);
+    push(@patterns, ['[□☐☑🗨]', '<i class="s-icon active0">☑</i>']);
+    push(@patterns, ['[▽]', '<i class="s-icon condition">▽</i>']);
+    push(@patterns, ['[▼]', '<i class="s-icon selection">▼</i>']);
   } else {
-    $text =~ s{[○◯〇]}{<i class="s-icon passive">○</i>}gi;
-    $text =~ s{[△]}{<i class="s-icon setup">△</i>}gi;
-    $text =~ s{[＞▶〆]}{<i class="s-icon major">▶</i>}gi;
-    $text =~ s{[☆≫»]|&gt;&gt;}{<i class="s-icon minor">≫</i>}gi;
-    $text =~ s{[□☐☑🗨]}{<i class="s-icon active">☑</i>}gi;
+    push(@patterns, ['[○◯〇]', '<i class="s-icon passive">○</i>']);
+    push(@patterns, ['[△]', '<i class="s-icon setup">△</i>']);
+    push(@patterns, ['[＞▶〆]', '<i class="s-icon major">▶</i>']);
+    push(@patterns, ['[☆≫»]|&gt;&gt;', '<i class="s-icon minor">≫</i>']);
+    push(@patterns, ['[□☐☑🗨]', '<i class="s-icon active">☑</i>']);
+  }
+  
+  foreach (@patterns) {
+    (my $re, my $replacement) = @{$_};
+    $text =~ s{$re}{$replacement}gi;
   }
   
   return $text;

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -123,7 +123,7 @@ if($pc{ver}){
       $pc{$_} = unescapeTagsLines($pc{$_});
     }
     $pc{$_} = unescapeTags($pc{$_});
-    $pc{$_} = textToIcon($pc{$_}, 1) if $_ =~ /^(?:items|freeNote|freeHistory|cashbook)$/;
+    $pc{$_} = textToIcon($pc{$_}, 1) if $_ =~ /^(?:items|freeNote|freeHistory|cashbook|fellow[-0-9]+Action)$/;
 
     $pc{$_} = noiseTextTag $pc{$_} if $pc{forbiddenMode};
   }

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -123,6 +123,7 @@ if($pc{ver}){
       $pc{$_} = unescapeTagsLines($pc{$_});
     }
     $pc{$_} = unescapeTags($pc{$_});
+    $pc{$_} = textToIcon($pc{$_}, 1) if $_ =~ /^(?:items|freeNote|freeHistory|cashbook)$/;
 
     $pc{$_} = noiseTextTag $pc{$_} if $pc{forbiddenMode};
   }


### PR DESCRIPTION
# 変更内容

キャラクターシート（ＰＣなどをとりあつかうシート）の一部の欄で、能力区分をあらわすアイコン（魔物シートで使えているもの）を使えるようにする。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/0d49d347-40f3-4ed3-ba84-c52ae888212d)

また、それを記法のヘルプにおいて示す。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/58ac6dd9-5b6e-4695-a85c-5c1c5c3903c5)

## 対象の欄

* フェロー行動表の「行動」
* 「容姿・経歴・その他メモ」
* 「履歴（自由記入）」
* 「所持品」
* 「収支履歴」

まず、フェロー行動表の「行動」については、その性質上、なんらかの主動作や補助動作を書くことがごく当たり前の欄であり、使えることに明確なメリットがあると考えられる。
（記号によって、任意の行動内容が主動作であるのか補助動作であるのかを簡潔にあらわせる）

「容姿・経歴・その他メモ」「履歴（自由記入）」については、ゲーム上の行動に関するメモが記述されることがままあるため、やはりメリットが期待できる。

「所持品」「収支履歴」欄については、とくにメリットはなさそうだが、既存の記法の適用範囲と一貫させるために、対象にふくめた。

# 仕様

入力する記号と出力される記号の対応づけは、魔物データにおける既存の記法を踏襲している。

ただし、記号の前後を `[` `]` でくくる必要があるとした。
その理由は、意図しないものがこの記法として解釈されることをできるかぎり防ぐため。（たとえば、「○」などは箇条書きや小見出しのニュアンスでもちいられることがままあるが、それが常時能力のアイコンに変更されるのは望ましくない。まあフェローの行動欄くらいは括弧なしでもいいような気がするが……）
くくる文字に `[` `]` を採用したのは、ゆとチャ.adv を意識している。