### PR TITLE
[SW2] 魔物データの閲覧画面において、「解説」が空ならセクションごと非表示にする

### DIFF
--- a/_core/skin/sw2/css/monster.css
+++ b/_core/skin/sw2/css/monster.css
@@ -326,6 +326,10 @@ table.status {
   background: var(--box-base-bg-color);
   border-radius: 0;
   box-shadow: none !important;
+
+  &:has(> p:first-of-type:last-of-type:empty) {
+    display: none;
+  }
 }
 .description :is(h2, h2:nth-child(n+2)) {
   margin: 0;


### PR DESCRIPTION
「ドレイクバロン」（『モンストラスロア』85頁）のような、“複数の形態をもつ魔物において一方の形態の解説を省略する”ようなケースを想定。