### PR TITLE
[SW2] 魔物の穢れに明示的に 0 が入力されていれば、閲覧画面においてそれを表示する

### DIFF
--- a/_core/lib/sw2/view-mons.pl
+++ b/_core/lib/sw2/view-mons.pl
@@ -150,6 +150,7 @@ $SHEET->param(Tags => \@tags);
 {
   $SHEET->param(appLv => $pc{lvMin}.($pc{lvMax} != $pc{lvMin} ? " ～ $pc{lvMax}":''));
 }
+$SHEET->param(displaySin => $pc{sin} || $pc{sin} eq '0' ? 1 : 0);
 ### ステータス --------------------------------------------------
 $SHEET->param(vitResist => $pc{vitResist} eq '' ? '' : $pc{vitResist}.(!$pc{statusTextInput}?' ('.$pc{vitResistFix}.')':''));
 $SHEET->param(mndResist => $pc{mndResist} eq '' ? '' : $pc{mndResist}.(!$pc{statusTextInput}?' ('.$pc{mndResistFix}.')':''));

--- a/_core/skin/sw2/sheet-monster.html
+++ b/_core/skin/sw2/sheet-monster.html
@@ -109,7 +109,7 @@
           <div>
             <dl><dt>知能<dd><TMPL_VAR intellect></dl>
             <dl><dt>知覚<dd><TMPL_VAR perception></dl>
-            <TMPL_IF sin><dl><dt>穢れ<dd><TMPL_VAR sin></dl></TMPL_IF>
+            <TMPL_IF displaySin><dl><dt>穢れ<dd><TMPL_VAR sin></dl></TMPL_IF>
             <dl><dt>言語<dd><TMPL_VAR language></dl>
           </div>
           <div>
@@ -121,7 +121,7 @@
             <dl><dt>知能<dd><TMPL_VAR intellect></dl>
             <dl><dt>知覚<dd><TMPL_VAR perception></dl>
             <dl><dt>反応<dd><TMPL_VAR disposition></dl>
-            <TMPL_IF sin><dl><dt>穢れ<dd><TMPL_VAR sin></dl></TMPL_IF>
+            <TMPL_IF displaySin><dl><dt>穢れ<dd><TMPL_VAR sin></dl></TMPL_IF>
           </div>
           <div>
             <dl><dt>言語<dd><TMPL_VAR language></dl>


### PR DESCRIPTION
# 変更内容

魔物データにおいて、穢れ欄に（空ではなく）明示的に「 0 」が入力されていれば、閲覧画面で穢れを表示する。
（従来は、穢れの値が 0 だったら表示されなかった）

## 表示例

![image](https://github.com/yutorize/ytsheet2/assets/44130782/3dbb5b2a-abac-4b1c-9432-b85d397304ab)

# 理由

「タロス」（⇒『バトルマスタリー』102頁）のような、“分類上は穢れの項目が存在するべきだが、穢れの値は 0 である”という魔物データを表現できるようにするため。