### PR TITLE
チャットパレットにおいてコメントアウト記法を追加

### DIFF
--- a/_core/lib/palette.pl
+++ b/_core/lib/palette.pl
@@ -54,6 +54,7 @@ sub outputChatPalette {
     $_ = unescapeTagsPalette($_) foreach values %pc;
   }
   $pc{chatPalette} =~ s/<br>/\n/gi;
+  $pc{chatPalette} =~ s/(?:^|\n);(?:[^\n]+)?//g;
   $pc{skills} =~ s/<br>/\n/gi;
 
   $pc{ver} =~ s/^([0-9]+)\.([0-9]+)\.([0-9]+)$/$1.$2$3/;


### PR DESCRIPTION
https://github.com/yutorize/ytsheet2/pull/156 より復旧

---

# 機能

チャットパレットにおけるコメントアウト記法

## 記法

行頭を `;` にする

## 挙動

当該行が存在しないかのようにチャットパレットを出力する

# 想定用途

“チャットパレットにあるとわずらわしい気がするが、削除していいと断言できるほどでもない”ものを一時的に除去するためにもちいる。

例：「キャラクターの成長にともなって、より上位の能力を手に入れたため、下位の能力用のコマンドはもう使わないような気がする……が、（消費コスト等の都合から）もしかすると使うことになるかもしれない……」というような場合

あるいは、セッションごとに ON/OFF するような使い方もできるかもしれない。
（ダンジョン攻略用の能力のコマンドは、ダンジョンの関与しないシナリオには不要……みたいなケース）

# 議論

## 記法

記法がこれでよいのかには議論の余地がある。

一般的に、単一行のコメントアウトは、行頭に `#` や `//` や `;` を置くという記法が採用されている。それぞれについての検討は以下：

### `#`

以下の点から誤判定の可能性が想定される（ないしは、すくなくともまぎらわしい）ため、不適当と思われる。

* ゆとチャにおいては、チャットパレットの折りたたみ記法 `###` と重複してしまう
* （先頭に置かれることはそうないであろうとはいえ、）ダイスボットのたぐいにおいて `#` がコマンドに含まれることはままある（たとえば BCDice においては、 `#` を含みうるコマンドが多数ある）

### `//`

ゆとシの複数行記述欄におけるコメントアウト記法と一致しており、一貫性はある、が……。

チャットパレット上では、ゆとチャを含む主要なセッションツール全般において、変数定義の記法に採用されており、採用できない。

### `;`

セミコロン `;` によるコメントアウトは、 _.vimrc_ や _php.ini_ に倣ったもの。

主要なダイスボットやセッションツールにおいて、すくなくとも行頭にセミコロンを置くようなコマンドは思い当たらない。

一般的な用法においても、行頭にセミコロンを置くケースはまずないと考えられる。

# 備考

どこかにこの記法についての説明を載せるべきだと思うが、チャットパレット周辺のＵＩのどこにねじ込んでもいまいち目立たない気がしたので、とりあえずＰＲ時点ではどこにも書いていない。