### PR TITLE
[SW2] 閲覧画面において、防具の「回避力」が空なら `―` と表示する

### DIFF
--- a/_core/skin/sw2.0/sheet-chara.html
+++ b/_core/skin/sw2.0/sheet-chara.html
@@ -456,7 +456,7 @@
                 <th class="type"><TMPL_VAR TYPE>
                 <td class="name"><span class="item-name"><TMPL_VAR NAME></span>
                 <td class="reqd"><TMPL_VAR REQD>
-                <td class="eva "><TMPL_VAR EVA>
+                <td class="eva "><TMPL_VAR EVA></td>
                 <td class="def "><TMPL_VAR DEF>
                 <td class="own "><TMPL_IF OWN>✔</TMPL_IF>
                 <td class="note"><TMPL_VAR NOTE>

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -849,6 +849,9 @@ dl#level {
   &.own  { width:   1em; } /* 専用 */
   &.note { width:  auto; } /* 備考 */
 }
+#armours td.eva:empty::before {
+  content: "―";
+}
 #armours td.note {
   padding-left: .3em;
   text-align: left;

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -432,7 +432,7 @@
                 <th class="type"><TMPL_VAR TYPE>
                 <td class="name"><span class="item-name"><TMPL_VAR NAME></span>
                 <td class="reqd"><TMPL_VAR REQD>
-                <td class="eva "><TMPL_VAR EVA>
+                <td class="eva "><TMPL_VAR EVA></td>
                 <td class="def "><TMPL_VAR DEF>
                 <td class="own "><TMPL_IF OWN>✔</TMPL_IF>
                 <td class="note"><TMPL_VAR NOTE>


### PR DESCRIPTION
https://github.com/yutorize/ytsheet2/pull/154 より復旧

---

『Ⅰ』317頁などの表現に合わせる

![image](https://github.com/yutorize/ytsheet2/assets/44130782/0ebc988a-5d5e-48e5-8314-e62de1bbac45)
