### PR TITLE
[DX3] セッション履歴において空の経験点を <s> 要素で括らないように

### DIFF
--- a/_core/lib/dx3/view-chara.pl
+++ b/_core/lib/dx3/view-chara.pl
@@ -612,7 +612,7 @@ foreach (0 .. $pc{historyNum}){
     $members .= '<span>'.$mem.'</span>';
   }
   if($_ && !$pc{'history'.$_.'ExpApply'}) {
-    $pc{'history'.$_.'Exp'} = '<s>'.$pc{'history'.$_.'Exp'}.'</s>';
+    $pc{'history'.$_.'Exp'} = $pc{'history'.$_.'Exp'} ? '<s>'.$pc{'history'.$_.'Exp'}.'</s>' : '';
   }
   push(@history, {
     NUM    => ($pc{'history'.$_.'Gm'} ? $h_num : ''),

--- a/_core/lib/dx3/view-chara.pl
+++ b/_core/lib/dx3/view-chara.pl
@@ -611,8 +611,8 @@ foreach (0 .. $pc{historyNum}){
   foreach my $mem (split(/　/,$pc{'history'.$_.'Member'})){
     $members .= '<span>'.$mem.'</span>';
   }
-  if($_ && !$pc{'history'.$_.'ExpApply'}) {
-    $pc{'history'.$_.'Exp'} = $pc{'history'.$_.'Exp'} ? '<s>'.$pc{'history'.$_.'Exp'}.'</s>' : '';
+  if($_ && !$pc{'history'.$_.'ExpApply'} && $pc{'history'.$_.'Exp'} ne '') {
+    $pc{'history'.$_.'Exp'} = '<s>'.$pc{'history'.$_.'Exp'}.'</s>';
   }
   push(@history, {
     NUM    => ($pc{'history'.$_.'Gm'} ? $h_num : ''),


### PR DESCRIPTION
https://github.com/yutorize/ytsheet2/pull/123 より復旧

---

DX3 のセッション履歴において、経験点の欄が空で、「適用」もチェックされていないとき、閲覧画面では空の _s_ 要素が発生していた。

（開始前～継続中のセッションなどの場合、経験点欄が（一時的に）空になっていることは現実的にありうる）

明確な実害はないが、  HTML としては不自然なので、経験点欄が空のときは `<s>` 要素でくくるのをやめる。
