### PR TITLE
[SW2] 複数部位の魔物データを Udonarium 向けに出力する際の、防護点を記述する項目の名称を変更

### DIFF
--- a/_core/lib/json.pl
+++ b/_core/lib/json.pl
@@ -78,7 +78,7 @@ if($pc{ver} ne '') {
   $pc{result} = "OK";
   if($set::lib_json_sub){
     require $set::lib_json_sub;
-    %pc = %{ addJsonData(\%pc , $type) };
+    %pc = %{ addJsonData(\%pc , $type , $::in{target} || '') };
   }
   delete $pc{IP};
 }

--- a/_core/lib/sw2/json-sub.pl
+++ b/_core/lib/sw2/json-sub.pl
@@ -9,6 +9,7 @@ require $set::data_class;
 sub addJsonData {
   my %pc = %{ $_[0] };
   my $type = $_[1];
+  my $target = $_[2];
   $pc{'gameVersion'} = $::SW2_0 ? '2.0' : '2.5';
   ### 魔物 --------------------------------------------------
   if ($pc{type} eq 'm'){
@@ -79,7 +80,7 @@ sub addJsonData {
   }
 
   ## ユニット（コマ）用ステータス --------------------------------------------------
-  $pc{unitStatus} = createUnitStatus(\%pc);
+  $pc{unitStatus} = createUnitStatus(\%pc, $target);
   
   return \%pc;
 }

--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -11,6 +11,7 @@ use Fcntl;
 ### ユニットステータス出力 --------------------------------------------------
 sub createUnitStatus {
   my %pc = %{$_[0]};
+  my $target = $_[1] || '';
   my @unitStatus;
   if ($pc{type} eq 'm'){
     my @n2a = ('','A' .. 'Z');
@@ -44,7 +45,11 @@ sub createUnitStatus {
       @unitStatus = ();
       push(@unitStatus, @hp);
       push(@unitStatus, @mp) if $#mp >= 0;
-      push(@unitStatus, {'メモ' => '防護:'.join('／',@def)});
+      if ($target eq 'udonarium') {
+        push(@unitStatus, {'防護' => join('／',@def)});
+      } else {
+        push(@unitStatus, {'メモ' => '防護:'.join('／',@def)});
+      }
     }
     else { # 1部位
       my $i = 1;

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -74,11 +74,11 @@ window.addEventListener('DOMContentLoaded', ()=>{
 });
 
 // 保存系 ----------------------------------------
-function getJsonData() {
+function getJsonData(targetEnvironment = '') {
   const paramId = /id=[0-9a-zA-Z\-]+/.exec(location.href)[0];
   return new Promise((resolve, reject)=>{
     let xhr = new XMLHttpRequest();
-    xhr.open('GET', `./?${paramId}&mode=json`, true);
+    xhr.open('GET', `./?${paramId}&mode=json&target=${targetEnvironment}`, true);
     xhr.responseType = "json";
     xhr.onload = (e) => {
       resolve(e.currentTarget.response);
@@ -133,7 +133,7 @@ function copyToClipboard(text) {
 }
 
 async function downloadAsUdonarium() {
-  const characterDataJson = await getJsonData();
+  const characterDataJson = await getJsonData('udonarium');
   const characterId = characterDataJson.characterName || characterDataJson.monsterName || characterDataJson.aka || '無題';
   const image = await output.getPicture(characterDataJson.imageURL || defaultImage, "image."+characterDataJson.image);
   const udonariumXml = output.generateUdonariumXml(generateType, characterDataJson, location.href, image.hash);
@@ -143,7 +143,7 @@ async function downloadAsUdonarium() {
 
 function getCcfoliaJson() {
   return new Promise((resolve, reject)=>{
-    getJsonData().then((characterDataJson)=>{
+    getJsonData('ccfolia').then((characterDataJson)=>{
       output.generateCcfoliaJson(generateType,characterDataJson, location.href).then(resolve, reject);
     }, reject);
   });
@@ -230,9 +230,10 @@ async function downloadAsFullSet(){
   zip.file(name+'.json', await JSZipUtils.getBinaryContent(url+'&mode=json'));
   if(document.getElementById('chatPaletteBox')) zip.file(name+'_チャットパレット.txt', await JSZipUtils.getBinaryContent(url+'&mode=palette'));
   
-  const characterDataJson = await getJsonData();
   // ユドナリウム
   if(document.getElementById('downloadlist-udonarium')){
+    const characterDataJson = await getJsonData('udonarium');
+    
     const image = await output.getPicture(characterDataJson.imageURL || defaultImage, "image."+characterDataJson.image);
     const udonariumXml = output[`generateUdonariumXml`](generateType,characterDataJson, location.href, image.hash);
     const udonariumUrl = await generateUdonariumZipFile((characterDataJson.characterName||characterDataJson.aka), udonariumXml, image);


### PR DESCRIPTION
従来は対象環境を問わず、複数部位の魔物データを出力するとき、その防護点は `メモ` というキーに対する値に設定されていた。

例：
``` 
{
  "メモ": "防護:獅子頭9／山羊頭8／竜頭10／胴体6／翼8"
}
```

（これはゆとチャ.adv向けのフォーマットだと思われる）

ところが、 Udonarium におけるインベントリ（ユニット一覧的なもの）等のＵＩでは、インベントリ側で設定した項目しか表示されないという挙動をする。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/685074b6-5aea-4d10-a99e-e7b73342c2cc)
（表示項目に「防護」が含まれているが、（複数部位であるところの）キマイラのデータにはそのような項目がない）

ここで、「メモ」を表示項目に含めればむろんそれは表示されるのであるが、「メモ」はきわめて普遍的なラベルであり、他の用途に使われることも考えられる。

そのようなさまざまな情況を考慮するに、 Udonarium においては、複数部位のキャラクターであっても、単一部位のキャラクターと共通して「防護」の項目によって防護点を確認できるほうが、現実的な便宜に適うと考える。

よって、 Udonarium にかぎり、以下のような出力をするように変更した。

``` 
{
  "防護": "獅子頭9／山羊頭8／竜頭10／胴体6／翼8"
}
```

![image](https://github.com/yutorize/ytsheet2/assets/44130782/3aee0357-e8d6-424c-ae0d-7fb910a9aca6)

（見てのとおりキマイラくらい長いと途切れて見えるのだが、これはもうゆとシ側からはどうしようもないので、このまま使うか手動で「獅9／山8／竜10／胴6／翼8」や「9/8/10/6/8」などに調整してもらうしかない。また、このように大した量のテキストを表示できない有り様なので、「メモ」欄に防護点とほかの内容を合わせて記入するようなことは現実的ではない）

---

対称性のため、ココフォリア向けの JSON を得る際にもパラメータ `target=ccforia` を指定するようにしてある。
現状ではとくに出力内容への変化はない。