### PR TITLE
[SW2] 名誉アイテムの名称欄に、括弧の入力候補を追加

### DIFF
--- a/_core/lib/sw2.0/edit-chara.pl
+++ b/_core/lib/sw2.0/edit-chara.pl
@@ -1213,7 +1213,7 @@ print <<"HTML";
 HTML
 foreach my $num ('TMPL',1 .. $pc{honorItemsNum}){
   if($num eq 'TMPL'){ print '<template id="honor-item-template">' }
-  print '<tr id="honor-item'.$num.'"><td class="handle"><td>'.(input "honorItem${num}", "text").'<td><span class="honor-pt"><select name="honorItem'.$num.'PtType" oninput="calcHonor()" data-type="human">'.(option "honorItem${num}PtType",@honortypes).'</select><span class="honor-select-view"></span>'.(input "honorItem${num}Pt", "number", "calcHonor").'</span>';
+  print '<tr id="honor-item'.$num.'"><td class="handle"><td>'.(input "honorItem${num}", "text", '', 'list="list-honor-item"').'<td><span class="honor-pt"><select name="honorItem'.$num.'PtType" oninput="calcHonor()" data-type="human">'.(option "honorItem${num}PtType",@honortypes).'</select><span class="honor-select-view"></span>'.(input "honorItem${num}Pt", "number", "calcHonor").'</span>';
   if($num eq 'TMPL'){ print '</template>' }
 }
 print <<"HTML";

--- a/_core/lib/sw2/edit-chara-datalist.pl
+++ b/_core/lib/sw2/edit-chara-datalist.pl
@@ -37,6 +37,11 @@ sub printCharaDataList {
       <option value="振2H">
       <option value="突2H">
   </datalist>
+  <datalist id="list-honor-item">
+      <option value="〈〉">
+      <option value="【】">
+      <option value="《》">
+  </datalist>
   <datalist id="list-grow">
       <option value="器用">
       <option value="敏捷">

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -1196,7 +1196,7 @@ print <<"HTML";
 HTML
 foreach my $num ('TMPL',1 .. $pc{honorItemsNum}){
   if($num eq 'TMPL'){ print '<template id="honor-item-template">' }
-  print '<tr id="honor-item-row'.$num.'"><td class="handle"><td>'.(input "honorItem${num}", "text").'<td>'.(input "honorItem${num}Pt", "number", "calcHonor");
+  print '<tr id="honor-item-row'.$num.'"><td class="handle"><td>'.(input "honorItem${num}", "text", '', 'list="list-honor-item"').'<td>'.(input "honorItem${num}Pt", "number", "calcHonor");
   if($num eq 'TMPL'){ print '</template>' }
 }
 print <<"HTML";


### PR DESCRIPTION
名誉アイテムの名称入力欄に、括弧のための _datalist_ を設定

* `〈〉`：一般的なアイテム全般（典型的には流派アイテムなど）
* `【】`：流派、秘伝魔法
* `《》`：秘伝