### PR TITLE
[SW2.5] Fix: デーモンルーラーの命中力判定の行を表示する条件を修正＆閲覧画面にも同様の条件を適用

### DIFF
--- a/_core/lib/ar2e/json-sub.pl
+++ b/_core/lib/ar2e/json-sub.pl
@@ -8,8 +8,8 @@ sub addJsonData {
   my %pc = %{ $_[0] };
   my $type = $_[1];
   
-  %pc = data_update_chara(\%pc);
-  
+  %pc = data_update_chara(\%pc) if $pc{ver};
+
   ## 誓約
   my @geises;
   foreach my $num (1..$pc{geisesNum}){

--- a/_core/lib/blp/json-sub.pl
+++ b/_core/lib/blp/json-sub.pl
@@ -8,8 +8,8 @@ sub addJsonData {
   my %pc = %{ $_[0] };
   my $type = $_[1];
   
-  %pc = data_update_chara(\%pc);
-  
+  %pc = data_update_chara(\%pc) if $pc{ver};
+
   ### 簡易プロフィール --------------------------------------------------
   my @classes;
   foreach (@data::class_names){

--- a/_core/lib/dx3/convert.pl
+++ b/_core/lib/dx3/convert.pl
@@ -117,7 +117,6 @@ sub convertHokanjoToYtsheet {
     skillNegotiate => $in{'skill_tokugi'}[ 9], skillAddNegotiate => $in{'skill_sonota'}[ 9],
     skillProcure   => $in{'skill_tokugi'}[10], skillAddProcure   => $in{'skill_sonota'}[10],
     skillInfo1     => $in{'skill_tokugi'}[11], skillAddInfo1     => $in{'skill_sonota'}[11], skillInfo1Name => '情報:'.$in{'skill_memo'}[11],
-    '' => $in{''},
   );
   ##名前
   ($pc{characterName},$pc{characterNameRuby}) = convertNameRuby($in{'pc_name'} || $in{'data_title'});
@@ -126,6 +125,7 @@ sub convertHokanjoToYtsheet {
   ## 技能
   my %skills = (1=>'Ride', 2=>'Art', 3=>'Know', 4=>'Info');
   my %skillsjp = (1=>'運転', 2=>'芸術', 3=>'知識', 4=>'情報');
+  $pc{skillRideNum} = $pc{skillArtNum} = $pc{skillKnowNum} = $pc{skillInfoNum} = 2;
   my $i = 12;
   foreach my $id (@{$in{'V_skill_id'}}){
     my $num = 2;

--- a/_core/lib/dx3/edit-chara.js
+++ b/_core/lib/dx3/edit-chara.js
@@ -743,10 +743,31 @@ function calcCombo(num){
   }
 }
 // 追加
-function addCombo(){
+function addCombo(copyBaseNum){
   const row = createRow('combo','comboNum');
-  document.querySelector("#combo-list").append(row);
+  const num = form.comboNum.value;
+  document.querySelector(`#combo-list > div:nth-of-type(${copyBaseNum||num-1})`).after(row);
 
+  if(copyBaseNum){
+    row.querySelectorAll('[name]').forEach(node => {
+      const copyBaseName = node.getAttribute('name').replace(/^(combo)\d+(.+)$/, `$1${copyBaseNum}$2`)
+      if(node.type === 'checkbox'){
+        node.checked = form[copyBaseName].checked;
+      }
+      else { node.value = form[copyBaseName].value; }
+    });
+    calcCombo(form.comboNum.value);
+    row.classList.add('slide-once');
+
+    let i = 1;
+    document.querySelectorAll(`#combo-list > div`).forEach(obj => {
+      replaceSortedNames(obj,i,/^(combo)[0-9]+(.*)$/);
+      replaceSortedNames(obj,i,/^(combo)[0-9]+((?:Stt|SkillLv)[0-9])$/,'id');
+      replaceSortedNames(obj,i,/^(calcCombo\()[0-9]+(\))$/,'oninput');
+      replaceSortedNames(obj,i,/^(addCombo\()[0-9]+(\))$/,'onclick');
+      i++;
+    })
+  }
   comboSkillSet(form.comboNum.value);
   makeComboConditionUtility(row);
 }
@@ -758,6 +779,7 @@ function delCombo(){
 setSortable('combo', '#combo-list', 'div', (row, num) => {
   replaceSortedNames(row,num,/^(combo)[0-9]+((?:Stt|SkillLv)[0-9])$/,'id');
   replaceSortedNames(row,num,/^(calcCombo\()[0-9]+(\))$/,'oninput');
+  replaceSortedNames(row,num,/^(addCombo\()[0-9]+(\))$/,'onclick');
 })
 // 条件
 function makeComboConditionUtility(comboNode) {

--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -782,7 +782,7 @@ HTML
 print <<"HTML";
           </dl>
           <div class="combo-note"><textarea name="combo${num}Note" rows="3" placeholder="解説">$pc{"combo${num}Note"}</textarea></div>
-          <div class="combo-calc">@{[ checkbox "combo${num}Manual",'技能レベル・能力値を自動挿入しない',"calcCombo(${num})" ]}</div>
+          <div class="combo-other">@{[ checkbox "combo${num}Manual",'技能レベル・能力値を自動挿入しない',"calcCombo(${num})" ]} <span class="button" onclick="addCombo($num)">コンボ複製</span></div>
         </div>
 HTML
   if($num eq 'TMPL'){ print '</template>' }

--- a/_core/lib/dx3/json-sub.pl
+++ b/_core/lib/dx3/json-sub.pl
@@ -8,8 +8,8 @@ sub addJsonData {
   my %pc = %{ $_[0] };
   my $type = $_[1];
   
-  %pc = data_update_chara(\%pc);
-  
+  %pc = data_update_chara(\%pc) if $pc{ver};
+
   ## ロイス数
   my @dloises; $pc{loisHave} = 0; $pc{loisMax} = 0; $pc{titusHave} = 0; $pc{sublimated} = 0;
   foreach my $num (1..7){

--- a/_core/lib/edit.pl
+++ b/_core/lib/edit.pl
@@ -143,6 +143,7 @@ sub getSheetData {
     delete $pc{image};
     delete $pc{imageURL};
     delete $pc{protect};
+    $_ =~ s/"/&quot;/g foreach(values %pc);
     if($::in{backupJSON}){
       $message = '<span class="data-imported backup-loaded">入力途中の新規シートを復元しました</span>';
     }

--- a/_core/lib/gs/json-sub.pl
+++ b/_core/lib/gs/json-sub.pl
@@ -15,7 +15,7 @@ sub addJsonData {
   }
   ### キャラクター --------------------------------------------------
   else {
-    %pc = data_update_chara(\%pc);
+    %pc = data_update_chara(\%pc) if $pc{ver};
     ## 簡易プロフィール
     my @classes;
     foreach (@data::class_names){

--- a/_core/lib/json.pl
+++ b/_core/lib/json.pl
@@ -63,6 +63,14 @@ elsif($::in{url}){
   require $set::lib_convert;
   %pc = dataConvert($::in{url});
   $type = $pc{type};
+  if(!$pc{ver}){
+    require $set::lib_calc_char;
+    %pc = data_calc(\%pc);
+  }
+  foreach(keys %pc){
+    $pc{$_} = pcEscape($pc{$_});
+    delete $pc{$_} if($pc{$_} eq '');
+  }
 }
 
 

--- a/_core/lib/kiz/json-sub.pl
+++ b/_core/lib/kiz/json-sub.pl
@@ -8,7 +8,7 @@ sub addJsonData {
   my %pc = %{ $_[0] };
   my $type = $_[1];
   
-  %pc = data_update_chara(\%pc);
+  %pc = data_update_chara(\%pc) if $pc{ver};
 
   ### 簡易プロフィール
   my @classes;

--- a/_core/lib/ms/json-sub.pl
+++ b/_core/lib/ms/json-sub.pl
@@ -10,7 +10,7 @@ sub addJsonData {
   if ($pc{type} eq 'c'){
   }
   else {
-    %pc = data_update_chara(\%pc);
+    %pc = data_update_chara(\%pc) if $pc{ver};
 
     ### 簡易プロフィール
     my @classes;

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1227,7 +1227,7 @@ function calcAttack() {
   document.getElementById("attack-enhancer-acc"  ).textContent = lv['Enh'] + bonus.Dex;
   document.getElementById("attack-enhancer-dmg"  ).textContent = lv['Enh'] + bonus.Str;
 
-  document.getElementById("attack-demonruler").style.display = lv['Dem'] >= 10 ? "" : modeZero && lv['Dem'] > 0 ? "" :"none";
+  document.getElementById("attack-demonruler").style.display = lv['Dem'] >= 11 ? "" : modeZero && lv['Dem'] > 0 ? "" :"none";
   document.getElementById("attack-demonruler-str").textContent = reqdStr;
   document.getElementById("attack-demonruler-acc").textContent = lv['Dem'] + bonus.Dex;
   document.getElementById("attack-demonruler-dmg").textContent = modeZero ? lv['Dem'] + bonus.Str : '―';

--- a/_core/lib/sw2/json-sub.pl
+++ b/_core/lib/sw2/json-sub.pl
@@ -54,7 +54,7 @@ sub addJsonData {
   }
   ### キャラクター --------------------------------------------------
   else {
-    %pc = data_update_chara(\%pc);
+    %pc = data_update_chara(\%pc) if $pc{ver};
     ## 簡易プロフィール
     my @classes;
     foreach (@data::class_names){

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -216,8 +216,9 @@ $pc{raceAbility} =~ s/［(.*?)］/<span>［$1］<\/span>/g;
 $SHEET->param(raceAbility => $pc{raceAbility});
 
 ### 穢れ --------------------------------------------------
-$SHEET->param(sin => '―') if !$pc{sin} && $pc{race} =~ /^(?:ルーンフォーク|フィー)$/;
-
+if (!$pc{sin}){ 
+  $SHEET->param(sin => ($pc{race} =~ /^(?:ルーンフォーク|フィー)$/) ? '―' : 0);
+}
 ### 信仰 --------------------------------------------------
 if($pc{faith} eq 'その他の信仰') { $SHEET->param(faith => $pc{faithOther}); }
 $pc{faith} =~ s/“(.*)”//;

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -579,6 +579,7 @@ if(!$pc{forbiddenMode}){
     next if !$pc{'lv'.$id};
     next if !($data::class{$name}{type} eq 'weapon-user' || $id =~ /Enh|Dem/);
     next if $id eq 'Enh' && !$enhance_attack_on;
+    next if $id eq 'Dem' && $pc{'lv'.$id} < 11 && !$::SW2_0;
     push(@atacck, {
       NAME => $name."<span class=\"small\">技能レベル</span>".$pc{'lv'.$id},
       STR  => ($id eq 'Fen' ? $pc{reqdStrF} : $pc{reqdStr}),

--- a/_core/lib/vc/json-sub.pl
+++ b/_core/lib/vc/json-sub.pl
@@ -8,7 +8,7 @@ sub addJsonData {
   my %pc = %{ $_[0] };
   my $type = $_[1];
   
-  %pc = data_update_chara(\%pc);
+  %pc = data_update_chara(\%pc) if $pc{ver};
   
   ### 簡易プロフィール --------------------------------------------------
   my $base  = "種族:$pc{race}クラス:$pc{class}\nスタイル:$pc{style1}／$pc{style2}";

--- a/_core/skin/dx3/css/edit.css
+++ b/_core/skin/dx3/css/edit.css
@@ -631,7 +631,7 @@ body:not(.mode-crc) .crc-only {
     "HNDL NAME COMB COMB"
     "HNDL   IN   IN  OUT"
     "HNDL NOTE NOTE  OUT"
-    "HNDL NOTE NOTE CALC"
+    "HNDL NOTE NOTE OTHR"
   ;
 }
 #combo .combo-table .handle {
@@ -639,9 +639,17 @@ body:not(.mode-crc) .crc-only {
   display: grid;
   place-items: center;
 }
-#combo .combo-table .combo-calc {
-  grid-area: CALC;
-  justify-self: end;
+#combo .combo-table .combo-other {
+  grid-area: OTHR;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 1px 2px .4rem;
+  
+  > .button {
+    font-size: 88%;
+    padding: 3px 4px 1px;
+    font-family: var(--font-proportional);
+  }
 }
 #combo .combo-table .combo-combo,
 #combo .combo-table .combo-in,
@@ -762,6 +770,7 @@ body:not(.mode-crc) .crc-only {
       "  IN   IN"
       " OUT  OUT"
       "NOTE NOTE"
+      "OTHR OTHR"
     ;
   }
   #combo .combo-table .combo-name {


### PR DESCRIPTION
# 編集画面

* 修正前：技能レベル10以上で表示
* 修正後：技能レベル11以上で表示

『2.5』においてデーモンルーラー技能で命中力判定をおこなうには、レベル11の魔法【デモンズブレード】が必要であるため。
（⇒『モンストラスロア』37頁）

# 閲覧画面

閲覧画面においてはそもそもレベルの検証がなかったようなので、検証自体を追加した