### PR TITLE
Fix: [SW2] 神格データの「格言」において、入力されていないものは表示しない

### DIFF
--- a/_core/skin/sw2/sheet-arts.html
+++ b/_core/skin/sw2/sheet-arts.html
@@ -160,9 +160,9 @@
           </section>
           <section class="box description">
             <h2>格言</h2>
-            <p>「<TMPL_VAR godMaxim1>」</p>
-            <p>「<TMPL_VAR godMaxim2>」</p>
-            <p>「<TMPL_VAR godMaxim3>」</p>
+            <TMPL_IF godMaxim1><p>「<TMPL_VAR godMaxim1>」</p></TMPL_IF>
+            <TMPL_IF godMaxim2><p>「<TMPL_VAR godMaxim2>」</p></TMPL_IF>
+            <TMPL_IF godMaxim3><p>「<TMPL_VAR godMaxim3>」</p></TMPL_IF>
           </section>
           <TMPL_IF godNote><section class="box description">
             <h2><TMPL_IF head_godNote><TMPL_VAR head_godNote><TMPL_ELSE>備考</TMPL_IF></h2>


### PR DESCRIPTION
神格データの「格言」のうち、入力されていない欄がある場合、閲覧画面では空の鉤括弧が表示されていた。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/8542acb6-9d03-4d8b-a94e-47aaf7d20b48)

これは不格好なので、入力されていない欄のものは表示しないようにする。