### PR TITLE
[SW2] アイテムのシートにおける防具データの「回避力」「防護点」が空の場合にデフォルト値に置き換える

### DIFF
--- a/_core/lib/sw2/view-item.pl
+++ b/_core/lib/sw2/view-item.pl
@@ -137,8 +137,8 @@ foreach (1 .. $pc{armourNum}){
   push(@armours, {
     USAGE => $pc{'armour'.$_.'Usage'},
     REQD  => $pc{'armour'.$_.'Reqd'},
-    EVA   => $pc{'armour'.$_.'Eva'},
-    DEF   => $pc{'armour'.$_.'Def'},
+    EVA   => $pc{'armour'.$_.'Eva'} // '―',
+    DEF   => $pc{'armour'.$_.'Def'} // 0,
     NOTE  => $pc{'armour'.$_.'Note'},
   } );
 }


### PR DESCRIPTION
387adcef00fc5108f8cad2b885cdb7afe7e53171 と似たような処理