### PR TITLE
[SW2] 【魔法指示】の回数をユニット出力に含める

### DIFF
--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -81,6 +81,22 @@ sub createUnitStatus {
       }
       push(@unitStatus, { '陣気' => '0' }) if $pc{lvWar};
     }
+
+    if ($pc{lvRid}) {
+      my $hasMagicIndication = undef;
+      my $hasMagicIndicationIncrement = undef;
+
+      foreach (1 .. $pc{lvRid}) {
+        my $riding = $pc{"craftRiding$_"};
+        $hasMagicIndication = 1 if $riding eq '魔法指示';
+        $hasMagicIndicationIncrement = 1 if $riding eq '魔法指示回数増加';
+      }
+
+      if ($hasMagicIndication) {
+        my $count = $hasMagicIndicationIncrement ? 4 : 2;
+        push(@unitStatus, { '魔法指示' => "$count/$count" });
+      }
+    }
   }
 
   foreach my $key (split ',', $pc{unitStatusNotOutput}){


### PR DESCRIPTION
# 変更内容

騎芸【魔法指示】の回数をユニット出力に含める。

# 理由

* 回数制限のある、それなりに強力な能力である
* 回数制限の単位が「１日」と長く、その１日のうちに何回使ったかを見失いやすい（「１日」のあいだに複数回の戦闘が発生する場合などに顕著）
* 貴重な枠をついやして能動的に選択する騎芸であり、習得している以上は実際に使用する蓋然性が高い

# 仕様

「ライダー技能のレベルが１以上」かつ「騎芸【魔法指示】を習得している」場合、 `魔法指示` という項目をユニットに追加する。

当該項目は最大値をともなう数値形式（ `n/n` ）とする。

数値は、騎芸【魔法指示回数増加】があるならば `4` 、さもなければ `2` とする。
