### PR TITLE
[SW2] アイテムデータのカテゴリが〈投擲〉〈ボウ〉〈クロスボウ〉〈ガン〉のいずれかであれば、武器データに「射程」の項目を設ける

### DIFF
--- a/_core/lib/sw2/edit-item.js
+++ b/_core/lib/sw2/edit-item.js
@@ -3,6 +3,7 @@ const gameSystem = 'sw2';
 
 window.onload = function() {
   setName('itemName');
+  checkCategory();
   changeColor();
 }
 
@@ -19,6 +20,15 @@ function formCheck(){
     return false;
   }
   return true;
+}
+
+// 入力値による挙動の変化 ----------------------------------------
+function checkCategory() {
+  const category = document.querySelector('[name="category"]').value?.trim() ?? '';
+  document.getElementById('section-common').classList.toggle(
+      'is-ranged-weapon',
+      /投擲|ボウ|クロスボウ|ガン/.test(category)
+  );
 }
 
 // 武器データ欄 ----------------------------------------

--- a/_core/lib/sw2/edit-item.pl
+++ b/_core/lib/sw2/edit-item.pl
@@ -176,7 +176,7 @@ HTML
       <dl><dt>基本取引価格<dd>@{[ input 'price','','','list="list-item-price"' ]}G</dl>
       <dl><dt>知名度  <dd>@{[ input 'reputation', 'text','','pattern="^[0-9\/／]+$"' ]} 数字と／のみ入力可</dl>
       <dl><dt>形状    <dd>@{[ input 'shape' ]}</dl>
-      <dl><dt>カテゴリ<dd>@{[ input 'category','text','','list="list-category"' ]}
+      <dl><dt>カテゴリ<dd>@{[ input 'category','text','checkCategory','list="list-category"' ]}
         複数カテゴリの場合、スペースで区切ってください。</dl>
       <dl><dt>製作時期<dd>@{[ input 'age','text','','list="list-age"' ]}</dl>
       <dl><dt>概要    <dd>@{[ input 'summary' ]}</dl>
@@ -187,7 +187,7 @@ HTML
       <h4 class="in-toc">武器データ</h4>
       <table class="input-arms-data" id="weapons-table">
         <thead>
-          <tr><th><th>用法<th>必筋<th>命中<th>威力<th>C値<th>追加D<th>備考
+          <tr><th><th>用法<th>必筋<th>命中<th>威力<th>C値<th>追加D<th class="range">射程<th>備考
         <tbody>
 HTML
 foreach my $num ('TMPL', 1 .. $pc{weaponNum}){
@@ -200,6 +200,7 @@ foreach my $num ('TMPL', 1 .. $pc{weaponNum}){
             <td>@{[ input "weapon${num}Rate" ]}
             <td>@{[ input "weapon${num}Crit" ]}
             <td>@{[ input "weapon${num}Dmg" ]}
+            <td class="range">@{[ input "weapon${num}Range",'','','list="list-weapon-range"' ]}
             <td>@{[ input "weapon${num}Note" ]}
           @{[ $num eq 'TMPL' ? "</template>" : '' ]}
 HTML
@@ -281,6 +282,14 @@ print <<"HTML";
     <option value="2H#">
     <option value="振2H">
     <option value="突2H">
+  </datalist>
+  <datalist id="list-weapon-range">
+    <option value="1(10m)">
+    <option value="2(20m)">
+    <option value="2(30m)">
+    <option value="2(40m)">
+    <option value="2(50m)">
+    <option value="2(60m)">
   </datalist>
   <datalist id="list-armour-usage">
     <option value="1H">

--- a/_core/lib/sw2/view-item.pl
+++ b/_core/lib/sw2/view-item.pl
@@ -124,6 +124,7 @@ foreach (1 .. $pc{weaponNum}){
     RATE  => $pc{'weapon'.$_.'Rate'},
     CRIT  => $pc{'weapon'.$_.'Crit'},
     DMG   => $pc{'weapon'.$_.'Dmg'} // '―',
+    RANGE => $pc{category} =~ /投擲|ボウ|クロスボウ|ガン/ ? $pc{'weapon'.$_.'Range'} : undef,
     NOTE  => $pc{'weapon'.$_.'Note'},
   } );
 }

--- a/_core/skin/sw2/css/edit.css
+++ b/_core/skin/sw2/css/edit.css
@@ -1564,6 +1564,12 @@ form#item .input-arms-data {
   & td { width: 5em; }
   & td:first-child { width: 1.5em; }
   & td:last-child { width: auto; }
+
+  #section-common:not(.is-ranged-weapon) & {
+    :is(th, td).range {
+      display: none;
+    }
+  }
 }
 
 form#item .input-data label {

--- a/_core/skin/sw2/css/item.css
+++ b/_core/skin/sw2/css/item.css
@@ -222,6 +222,15 @@ div.data {
         display: none;
       }
 
+      &:not(:has(td.range:not(:empty))) {
+        :is(th, td).range {
+          display: none;
+        }
+      }
+      td.range:empty::before {
+        content: "―";
+      }
+
       &.armour-table {
         &:not(:has(td.usage:not(:empty))) {
           .usage {

--- a/_core/skin/sw2/sheet-item.html
+++ b/_core/skin/sw2/sheet-item.html
@@ -109,6 +109,7 @@
               <th>威力
               <th>C値
               <th>追加D
+              <th class="range">射程
               <th class="note left">備考
             <TMPL_LOOP WeaponData><tr>
               <td><TMPL_VAR USAGE>
@@ -117,6 +118,7 @@
               <td><TMPL_VAR RATE>
               <td><TMPL_VAR CRIT>
               <td><TMPL_VAR DMG>
+              <td class="range"><TMPL_VAR RANGE></td>
               <td class="note left"><TMPL_VAR NOTE></td>
             </TMPL_LOOP>
           </table>


### PR DESCRIPTION
# 変更内容

アイテムシートの武器データに「射程」の列を追加する。

# 背景

基本ルールブックでは注記によって射程が規定されている（例⇒『Ⅰ』311頁）が、『エピックトレジャリー』においては射程の列が存在する（例⇒同書96頁）。
そのうえで、前者がそのような形式になっているのは、紙面の広さの問題だと考えられる。また、紙面の広さの問題さえなければ、射程の欄を明示的に設けるほうが、注記による規定よりも閲覧の便宜に優れる。
ここでゆとシートのアイテムシートについて考えると、面積（幅）にはいくらかの余裕があり、またウェブページであるため仮に（非常に長い文字列がどこかの列に入力されるなどして）折り返しが発生しても大きな問題にならないと思われる。

くわえて、アイテムを自作して運用するようなユーザーならびにセッションは、『エピックトレジャリー』を採用している蓋然性が高いと推測されることから、どちらかといえば『エピックトレジャリー』に合わせておくほうが好ましいとも考えられる。

# 仕様

## 編集画面

カテゴリの文字列に `投擲`, `ボウ`, `クロスボウ`, `ガン` のいずれかが含まれていれば、武器データの部分において、「射程」の列を表示する。そうでなければ、射程の列を表示しない。

なお、入力候補については、『エピックトレジャリー』に掲載されている〈投擲〉〈ボウ〉〈クロスボウ〉〈ガン〉の射程を網羅するかたちをとった。

## 閲覧画面

カテゴリの文字列に `投擲`, `ボウ`, `クロスボウ`, `ガン` のいずれかが含まれており、かつ、いずれかひとつ以上の用法において「射程」が入力されていたなら、「射程」の列を表示する。そうでなければ、射程の列を表示しない。

〈アックス〉と〈投擲〉双方の機能をあわせもつ武器などで、射程が不要な用法がある場合（この例でいえば〈アックス〉のほう）場合は、その入力値が空であれば、閲覧画面では `―` を表示する。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/76890f49-4127-4d2c-8bf9-3e999d0d411f)

## 備考

上記以外で射程をもつカテゴリとして〈ブロウガン〉があるが、これは `ガン` と一致するので結果的に射程が表示される。