### PR TITLE
[SW2] 武器の用法に「1H騎」を追加

### DIFF
--- a/_core/lib/sw2/edit-chara-datalist.pl
+++ b/_core/lib/sw2/edit-chara-datalist.pl
@@ -32,6 +32,7 @@ sub printCharaDataList {
       <option value="1H投">
       <option value="1H拳">
       <option value="1H両">
+      <option value="1H騎">
       <option value="2H">
       <option value="2H#">
       <option value="振2H">

--- a/_core/lib/sw2/edit-item.pl
+++ b/_core/lib/sw2/edit-item.pl
@@ -272,6 +272,7 @@ print <<"HTML";
     <option value="1H投">
     <option value="1H拳">
     <option value="1H両">
+    <option value="1H騎">
     <option value="2H">
     <option value="2H#">
     <option value="振2H">


### PR DESCRIPTION
# 変更内容

武器の用法に「1H騎」を追加

## 対象

* キャラクターシートの武器の記入欄
* アイテムシートの武器データ