### PR TITLE
[SW2] 閲覧画面における魔法データの各欄の左右に padding を追加

### DIFF
--- a/_core/skin/sw2/css/arts.css
+++ b/_core/skin/sw2/css/arts.css
@@ -391,6 +391,8 @@ article {
 .data-magic dl.element  dd {
   font-family: var(--font-proportional);
   white-space: nowrap;
+  padding-left: 0.25em;
+  padding-right: 0.25em;
 }
 .data-magic h3.name,
 .data-magic dl.name     dd,


### PR DESCRIPTION
テキストの長さが上限いっぱい以上だとボーダーとテキストがほとんど密着することになっており不格好だったので

# 例

【フェアリーロード】（⇒『ＭＡ』131頁）の「消費」を入力したもの

**before**
![image](https://github.com/yutorize/ytsheet2/assets/44130782/11883e46-b9a5-4f61-a7c8-54f301c21a96)

**after**

![image](https://github.com/yutorize/ytsheet2/assets/44130782/a54f115b-5450-4896-9ffe-a2e4a5be9843)


