### PR TITLE
[SW2] 特殊神聖魔法の「消費」にも入力候補を提供する

### DIFF
--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -309,7 +309,7 @@ foreach my $lv (2,4,7,10,13){
 print <<"HTML";
           <h2 class="in-toc">特殊神聖魔法 ${lv}レベル</h2>
           <dl class="name    "><dt>名称      <dd>【@{[ input "godMagic${lv}Name",'' ]}】<br>@{[ checkbox "godMagic${lv}ActionTypeMinor",'補助動作' ]}@{[ checkbox "godMagic${lv}ActionTypeSetup",'戦闘準備' ]}</dl>
-          <dl class="cost    "><dt>消費      <dd>@{[ input "godMagic${lv}Cost" ]}</dl>
+          <dl class="cost    "><dt>消費      <dd>@{[ input "godMagic${lv}Cost",'','','list="list-cost"' ]}</dl>
           <dl class="target  "><dt>対象      <dd>@{[ input "godMagic${lv}Target",'','','list="list-target"' ]}</dl>
           <dl class="range   "><dt>射程／形状<dd>@{[ input "godMagic${lv}Range",'','','list="list-range"' ]}／@{[ input "godMagic${lv}Form",'','','list="list-form"' ]}</dl>
           <dl class="duration"><dt>時間      <dd>@{[ input "godMagic${lv}Duration",'','','list="list-duration"' ]}</dl>


### PR DESCRIPTION
独立した魔法データでは「消費」の入力候補が存在したが、神格に付随する特殊神聖魔法からは参照されていなかった