### PR TITLE
[SW2] 武器カテゴリに「魔導書」を追加

### DIFF
--- a/_core/lib/sw2/data-items.pl
+++ b/_core/lib/sw2/data-items.pl
@@ -19,6 +19,7 @@ our @weapons = (
   ['クロスボウ',    'crossbow'],
   ['ブロウガン',    'blowgun'],
   ['ガン',          'gun'],
+  ['魔導書',        'book'],
 );
 
 our @weapon_names;


### PR DESCRIPTION
武器カテゴリに「魔導書」が無かったので追加しました。