### PR TITLE
[SW2] セージ／バードを習得していなければ言語の選択欄において当該技能のものを表示しない

### DIFF
--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -147,6 +147,7 @@ function changeLv() {
   checkRace();
   calcPackage();
   checkFeats();
+  checkLanguage();
 }
 
 // レベル計算 ----------------------------------------
@@ -1692,6 +1693,10 @@ setSortable('mysticMagic','#mystic-magic-list','li');
 
 // 言語欄 ----------------------------------------
 function checkLanguage(){
+  const languageTable = document.getElementById('language-table');
+  languageTable.classList.toggle('sag-available', parseInt(form['lvSag'].value) > 0);
+  languageTable.classList.toggle('bar-available', parseInt(form['lvBar'].value) > 0);
+
   let count = {}; let acqT = {}; let acqR = {};
   if(SET.races[race]?.language){
     for(let data of SET.races[race].language){ acqT[data[0]] = data[1]; acqR[data[0]] = data[2]; }

--- a/_core/skin/sw2/css/edit.css
+++ b/_core/skin/sw2/css/edit.css
@@ -464,6 +464,11 @@
       &[data-type="listen"] + .lang-select-view { background: #77777722; }
       &[data-type="listen"] + .lang-select-view::before { content: '△'; }
     }
+
+    &:not(.sag-available) select option[value="Sag"],
+    &:not(.bar-available) select option[value="Bar"] {
+      display: none;
+    }
   }
 }
 #language #language-notice {


### PR DESCRIPTION
習得していない技能の存在を前提とする選択肢があっても実質的な意味がないので