### PR TITLE
Fix: [SW2.5] 編集画面の不名誉称号の導出が安定していない不具合を修正

### DIFF
--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1551,8 +1551,9 @@ function calcDishonor(){
   }
   pointTotal -= Number(form.honorOffset.value);
   document.getElementById("dishonor-value").textContent = pointTotal;
-  for(const key in SET.nRank){
-    if(pointTotal >= SET.nRank[key].num) { document.getElementById("notoriety").textContent = key; }
+  const orderedRanks = Object.entries(SET.nRank).map(x => {return {name: x[0], num: x[1].num};}).sort((x, y) => x.num - y.num);
+  for(const rank of orderedRanks){
+    if(pointTotal >= rank.num) { document.getElementById("notoriety").textContent = rank.name; }
   }
 }
 


### PR DESCRIPTION
# 現象

編集画面において、不名誉称号の等級が不名誉点に対して正しくないケースがあった。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/7fa9a711-5cad-4a15-a835-e70f323b7fef)

# 原因

オブジェクトのキーという順序の不安定なものに対して順次的な処理をしていたため。

https://github.com/yutorize/ytsheet2/blob/develop/_core/lib/sw2/edit-chara.js#L1554-L1556

![image](https://github.com/yutorize/ytsheet2/assets/44130782/f87d6245-2408-4098-b207-1b6e0f831395)

# 対処

不名誉称号の導出の前にソートする。