### PR TITLE
[SW2.5] 冒険者ランクをもたないキャラクターであればランクを（空ではなく） `―` と表示する

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -939,7 +939,7 @@ if($::SW2_0){
   }
 }
 else {
-  $SHEET->param(rank => $pc{rank}.$pc{rankStar});
+  $SHEET->param(rank => ($pc{rank} // '―').$pc{rankStar});
   foreach (@set::adventurer_rank){
     my ($name, $num, undef) = @$_;
     if($pc{rank}=~/★$/ && $pc{rankStar} >= 2){ $num += ($pc{rankStar}-1)*500 }


### PR DESCRIPTION

![image](https://github.com/yutorize/ytsheet2/assets/44130782/aac86da0-fb20-4c46-a595-d53bd89b5fcb)

![image](https://github.com/yutorize/ytsheet2/assets/44130782/01a4aae4-6af9-45ca-b784-ae7af55f7f60)
