### PR TITLE
Fix: [SW2] 制限移動距離が移動力を超えないように

### DIFF
--- a/_core/lib/sw2/calc-chara.pl
+++ b/_core/lib/sw2/calc-chara.pl
@@ -435,7 +435,7 @@ sub data_calc {
   $pc{mobilityBase} = $pc{mobilityBase} * 2 + $own_mobility  if ($pc{raceAbility} =~ /［半馬半人］/);
   $pc{mobilityTotal} = $pc{mobilityBase} + s_eval($pc{mobilityAdd});
   $pc{mobilityFull} = $pc{mobilityTotal} * 3;
-  $pc{mobilityLimited} = $pc{footwork} ? 10 : 3;
+  $pc{mobilityLimited} = min($pc{footwork} ? 10 : 3, $pc{mobilityTotal});
 
   ## 判定パッケージ
   my @pack_lore;

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1080,7 +1080,7 @@ function calcMobility() {
     }
   }
   const mobility = mobilityBase + Number(form.mobilityAdd.value) + mobilityOwn;
-  document.getElementById("mobility-limited").textContent = feats['足さばき'] ? 10 : 3;
+  document.getElementById("mobility-limited").textContent = Math.min(feats['足さばき'] ? 10 : 3, mobility);
   document.getElementById("mobility-base").textContent = mobilityBase + mobilityOwn;
   document.getElementById("mobility-total").textContent = mobility;
   document.getElementById("mobility-full").textContent = mobility * 3;

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -387,6 +387,9 @@ foreach my $class (@data::class_names){
 $SHEET->param(CraftLists => \@craft_lists);
 $SHEET->param(craftNone => $craft_none);
 
+### 移動力 --------------------------------------------------
+$SHEET->param(mobilityLimited => $pc{mobilityTotal}) if $pc{mobilityLimited} > $pc{mobilityTotal}; # 古いデータのための処理
+
 ### 言語 --------------------------------------------------
 my @language;
 if($pc{forbiddenMode}){


### PR DESCRIPTION
# 現象

「制限移動」の距離は移動力を超えることはないというルールがある（⇒『Ⅱ』58頁）が、それが考慮されていなかった。
（つまり、移動力が３（※《足さばき》下では10）を下回る状態でも、３（10）が制限移動の欄に表示されていた）

## 例

現実にそのようなキャラクターが運用されるのかはともかくとして、

* ドワーフ（⇒『Ⅰ』67頁）
* 学者生まれ（⇒『Ⅱ』28頁）
* 作成時の能力値の「Ｂ」が１
* アビスカース「鈍重な」（⇒『Ⅱ』284頁）の効果を受ける

というような条件で、移動力が３を下回るケースはルール上ありうる。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/9723ef52-acfa-4278-9f55-1435950bd45d)

なお、《足さばき》を仮定すれば、移動力が制限移動の「10」を下回るケースはより簡単に発生しうる。

# 修正

制限移動の距離が移動力を超えないように。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/f31bd3e8-6f74-4a27-bc43-8614ec7361e8)

## 備考

_view-chara.pl_ に対する処理は、すでに存在するデータへの補正。
（制限移動距離の計算は保存時になされるため、すでに存在するデータには本来の修正が（ふたたび保存されるまで）適用されない）