### PR TITLE
[SW2.5] “穢れ”のあるキャラクターの場合、フェローデータの閲覧画面にも“穢れ”を表示する

### DIFF
--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1144,6 +1144,19 @@ dl#level {
     "PROF PROF  IMG  IMG"
     "PROF PROF   MP CHCK"
   ;
+
+  &:has(#f-sin) {
+    grid-template-areas:
+      " LVL NAME NAME  IMG  IMG"
+      " LVL  PLN  PLN  IMG  IMG"
+      "RACE RACE  SIN  IMG  IMG"
+      " PER  PER  PER  IMG  IMG"
+      " CLS  CLS  CLS  IMG  IMG"
+      "LANG LANG LANG  IMG  IMG"
+      "PROF PROF PROF  IMG  IMG"
+      "PROF PROF PROF   MP CHCK"
+    ;
+  }
 }
 #f-image-none,
 #f-image          { grid-area: IMG; }
@@ -1151,6 +1164,7 @@ dl#level {
 #f-character-name { grid-area: NAME; }
 #f-player-name    { grid-area: PLN; }
 #f-race           { grid-area: RACE; }
+#f-sin            { grid-area: SIN; }
 #f-personal       { grid-area: PER; }
 #f-classes        { grid-area: CLS ; }
 #f-language       { grid-area: LANG; }
@@ -1256,6 +1270,7 @@ dl#level {
 }
 
 #f-race,
+#f-sin,
 #f-personal {
   display: flex;
   justify-content:space-between;

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -637,6 +637,11 @@
       <dl id="f-race">
         <dt>種族<dd><TMPL_VAR race>
       </dl>
+      <TMPL_IF sin>
+      <dl id="f-sin">
+        <dt>穢れ<dd><TMPL_VAR sin></dd>
+      </dl>
+      </TMPL_IF>
       <dl id="f-personal">
         <dt>性別<dd><TMPL_VAR gender>
         <dt>年齢<dd><TMPL_VAR age>


### PR DESCRIPTION
# 変更内容

“穢れ”を１点以上もつキャラクターであれば、そのフェローデータ画面においても“穢れ”の値を表示する。

## 表示例

![image](https://github.com/yutorize/ytsheet2/assets/44130782/21e979c4-4011-4af0-ad68-283035651fe1)

# 理由

- とくに後天的な“穢れ”であれば、キャラクター性に寄与している場合がすくなからずある。
- 『バルバロスレイジ』によって蛮族のキャラクターを利用することが大きく増えるという想定のもと、フェローが蛮族である場合もまた想定され、（フェローは不利益効果を受けないとはいえ）“守りの剣”の影響を意識するようなセッションでは、キャラクター表現上でフェローの“穢れ”を意識することに意義がありうる。
- （2024/07/17 16:57追記）〈穢れの一撃加工〉（⇒『バルバロスレイジ』64頁）や［吸精］（⇒『アーケインレリック』16頁）など、“穢れ”の値によって効果量が変わるデータが一部存在し、それがフェローデータから参照される可能性がある。
