### PR TITLE
セッション履歴の数値項目において、数字列の途中で改行されないように

### DIFF
--- a/_core/lib/view.pl
+++ b/_core/lib/view.pl
@@ -208,8 +208,9 @@ sub stylizeWords {
 # 数字列を成形する
 sub formatHistoryFigures {
   my $text = shift;
-  $text =~ s/[0-9]+/$&<wbr>/g;
   $text =~ s/[0-9]+/commify($&);/ge;
+  $text =~ s/[0-9,]+/$&<wbr>/g;
+  $text =~ s#([0-9,]+)#<span class="number">$1</span>#g;
   return $text;
 }
 ### メニュー --------------------------------------------------

--- a/_core/lib/view.pl
+++ b/_core/lib/view.pl
@@ -209,8 +209,7 @@ sub stylizeWords {
 sub formatHistoryFigures {
   my $text = shift;
   $text =~ s/[0-9]+/commify($&);/ge;
-  $text =~ s/[0-9,]+/$&<wbr>/g;
-  $text =~ s#([0-9,]+)#<span class="number">$1</span>#g;
+  $text =~ s#[0-9,]+#<span class="number">$&</span><wbr>#g;
   return $text;
 }
 ### メニュー --------------------------------------------------

--- a/_core/skin/_common/css/sheet.css
+++ b/_core/skin/_common/css/sheet.css
@@ -1272,6 +1272,9 @@ aside#loglist #log-naming form input {
   & td {
     font-size: .85em;
   }
+  & tbody td .number {
+    word-break: keep-all;
+  }
   & tbody td.date a,
   & tbody td a[data-num] {
     display: block;


### PR DESCRIPTION
従来は、数字列（厳密には「カンマを含む数字列」）の途中で改行（折り返し）が発生する場合があった。

例（ `5,890` のカンマの前で折り返されている）：
![image](https://github.com/yutorize/ytsheet2/assets/44130782/cb3908c8-cf3d-44d6-b738-0a22ef5e77e1)

これは数値を読み取るうえで不便なので、カンマを含む数字列の途中に折り返しが発生しないようにする。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/086dab57-3975-4cc9-869f-59e2330a5c24)
