### PR TITLE
[SW2] 魔物データの命中力が空か `―` であり、かつ、打撃点がデフォルト値なら、打撃点を `―` に置き換える

### DIFF
--- a/_core/lib/sw2/view-mons.pl
+++ b/_core/lib/sw2/view-mons.pl
@@ -167,6 +167,9 @@ my @status_row;
 foreach (1 .. $pc{statusNum}){
   if ($pc{'status'.$_.'Accuracy'} ne ''){ $pc{'status'.$_.'Accuracy'} = $pc{'status'.$_.'Accuracy'}.(!$pc{statusTextInput} && !$pc{mount}?' ('.$pc{'status'.$_.'AccuracyFix'}.')':'') }
   if ($pc{'status'.$_.'Evasion'}  ne ''){ $pc{'status'.$_.'Evasion'}  = $pc{'status'.$_.'Evasion'} .(!$pc{statusTextInput} && !$pc{mount}?' ('.$pc{'status'.$_.'EvasionFix'}.')' :'') }
+
+  $pc{'status'.$_.'Damage'} = '―' if $pc{'status'.$_.'Damage'} eq '2d+' && ($pc{'status'.$_.'Accuracy'} eq '' || $pc{'status'.$_.'Accuracy'} eq '―');
+
   push(@status_row, {
     LV       => $pc{lvMin},
     STYLE    => $pc{'status'.$_.'Style'},
@@ -185,6 +188,9 @@ foreach my $lv (2 .. ($pc{lvMax}-$pc{lvMin}+1)){
   my @status_row;
   foreach (1 .. $pc{statusNum}){
     my $num = "$_-$lv";
+
+    $pc{'status'.$num.'Damage'} = '―' if $pc{'status'.$num.'Damage'} eq '2d+' && ($pc{'status'.$num.'Accuracy'} eq '' || $pc{'status'.$num.'Accuracy'} eq '―');
+
     push(@status_row, {
       LV       => $lv+$pc{lvMin}-1,
       STYLE    => $pc{'status'.$_.'Style'},


### PR DESCRIPTION
# 変更内容

「魔物データの命中力が空か `―` であり、かつ、打撃点がデフォルト値である」なら、打撃点を `―` に置き換える挙動を追加。

命中力が `―` （空）であるなら、その魔物（部位）は近接攻撃能力をもたない（⇒『Ⅰ』433頁，『ＭＬ』61頁）ため。
また実際のところ、命中力が定義されていない時点で打撃点があってもそれは無意味であるため。

ルール上は、命中力が空であるかぎりは問答無用で置き換えていいような気はするが、ユーザー作成のデータにおいて「近接攻撃能力はもたないが、打撃点のみ定義されており、特殊能力から参照する」ようなものがすでに作られていないとは断言できないため、後方互換性を考慮してデフォルト値 `2d+` でなければ置き換えないようにした。