### PR TITLE
性別の英語略記に対応

### DIFF
--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -404,8 +404,8 @@ sub stylizeGender {
   my $m_flag; my $f_flag; my $n_flag;
   $gender =~ s/^(.+?)[\(（].*?[）\)]$/$1/;
   $gender =~ tr/Ａ-Ｚａ-ｚ/A-Za-z/;
-  if($gender =~ /男|おとこ|オトコ|♂|雄|オス|爺|漢|(?<!fe)male|(?<!wo)man/i) { $m_flag = 1 }
-  if($gender =~ /女|おんな|オンナ|♀|雌|メス|婆|娘|female|woman/i)           { $f_flag = 1 }
+  if($gender =~ /男|おとこ|オトコ|♂|雄|オス|爺|漢|(?<!fe)m(ale|$)|(?<!wo)man/i) { $m_flag = 1 }
+  if($gender =~ /女|おんな|オンナ|♀|雌|メス|婆|娘|f(em(ale)?|$)|woman/i)       { $f_flag = 1 }
   if($gender =~ /無|なし|^[\-ー‐‑–—―−ｰ]$|non/i)               { $n_flag = 1 }
   if($gender =~ /両|半|トランス|ノンバ|non|Ft[MX]|Mt[FX]|^[XA]/i) { $m_flag = 1; $f_flag = 1 }
 


### PR DESCRIPTION
- `m` を男として判定するように
- `f`, `fem` を女として判定するように
