### PR TITLE
[SW2] ＭＰをもたない魔物の場合は、セッションツールへの出力時にＭＰを除外する

### DIFF
--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -38,10 +38,13 @@ sub createUnitStatus {
         my $mp  = s_eval($pc{"status${i}Mp"});
         my $def = s_eval($pc{"status${i}Defense"});
         push(@hp , {$partname.':HP' => "$hp/$hp"});
-        push(@mp , {$partname.':MP' => "$mp/$mp"});
+        push(@mp , {$partname.':MP' => "$mp/$mp"}) unless isEmptyValue($mp);
         push(@def, $partname.$def);
       }
-      @unitStatus = ( @hp, @mp, {'メモ' => '防護:'.join('／',@def)} );
+      @unitStatus = ();
+      push(@unitStatus, @hp);
+      push(@unitStatus, @mp) if $#mp >= 0;
+      push(@unitStatus, {'メモ' => '防護:'.join('／',@def)});
     }
     else { # 1部位
       my $i = 1;
@@ -54,11 +57,9 @@ sub createUnitStatus {
       my $hp = s_eval($pc{"status${i}Hp"});
       my $mp = s_eval($pc{"status${i}Mp"});
       my $def = s_eval($pc{"status${i}Defense"});
-      @unitStatus = (
-        { 'HP' => "$hp/$hp" },
-        { 'MP' => "$mp/$mp" },
-        { '防護' => $def },
-      );
+      push(@unitStatus, { 'HP' => "$hp/$hp" });
+      push(@unitStatus, { 'MP' => "$mp/$mp" }) unless isEmptyValue($mp);
+      push(@unitStatus, { '防護' => $def });
     }
   }
   else {
@@ -370,6 +371,11 @@ sub data_update_arts {
   $pc{ver} = $main::ver;
   $pc{lasttimever} = $ver;
   return %pc;
+}
+
+sub isEmptyValue {
+  my $value = shift;
+  return defined($value) && $value ne '' && $value !~ /^[-ー－―]$/ ? 0 : 1;
 }
 
 1;


### PR DESCRIPTION
# 変更内容

魔物データにおいて、ＭＰをもたない魔物（部位）であれば、セッションツールへの出力にＭＰを含めないように。

# 理由

実質的に意味のない項目が出力されることによって、セッションツール上でよけいな面積を占有するような事態を避けるため。

## 例

たとえば「ドラゴンフォートレス」（⇒『モンストラスロア』166頁）のような魔物データを作成し、ゆとチャadv.にポーティングした場合、次のようになる。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/27310663-2bd3-428e-b894-054cb786170f)

意味のないステータス項目が７つも発生しており、ゆとチャ上での参照性などに問題をきたすことがままある。

（これとはべつに、まあ有意なＭＰをもつ部位がたくさんある魔物だと依然としてかなり面積をとってしまうという問題はあるのだが、それは有意な項目がある以上はあるていど仕方がないものとして、置いておく。本件は、「省略可能なものは省略しておいたほうが便宜に資する」という意図）