### PR TITLE
[DX3] ４番目以降のロイス枠が完全に空であれば、閲覧画面では表示しない

### DIFF
--- a/_core/lib/dx3/view-chara.pl
+++ b/_core/lib/dx3/view-chara.pl
@@ -312,6 +312,19 @@ foreach (1 .. 7){
   # 感情の内容もチェックもなく、状態ももたないなら、感情を無効にする.
   my $noEmotion = !($pc{'lois'.$_.'EmoPosi'} || $pc{'lois'.$_.'EmoPosiCheck'} || $pc{'lois'.$_.'EmoNega'} || $pc{'lois'.$_.'EmoNegaCheck'} || $pc{'lois'.$_.'State'});
 
+  if ($_ > 3) {
+    if (
+        ($pc{'lois' . $_ . 'Relation'} // '') eq ''
+            && ($pc{'lois' . $_ . 'Name'} // '') eq ''
+            && $noEmotion
+            && ($pc{'lois' . $_ . 'Color'} // '') eq ''
+            && ($pc{'lois' . $_ . 'Note'} // '') eq ''
+            && ($pc{'lois' . $_ . 'State'} eq '' || $pc{'lois' . $_ . 'State'} eq 'ロイス')
+    ) {
+      next;
+    }
+  }
+
   push(@loises, {
     "RELATION" => $pc{'lois'.$_.'Relation'},
     "NAME"     => $pc{'lois'.$_.'Name'},


### PR DESCRIPTION
# 変更内容

４番目以降のロイス枠が完全に空であれば、閲覧画面では表示しないように。

## 表示例
![image](https://github.com/yutorize/ytsheet2/assets/44130782/5b6c4653-8fe6-4f04-8dca-d117b0fa155b)

# 理由

固定ロイス（ＰＣがセッション外で静的に保有するロイス）の数は原則「３」であり、（レコードシートではなく）キャラクターシートに記載する数もまたそれに等しい。
（cf. 『ルールブック１』P60～61、同P217、同P223、ならびに、公式のキャラクターシート等）

公式のキャラクターシートの例：
- 『ルールブック１』付属 https://www.fear.co.jp/dbx3rd/download/dc3_charasheet.pdf
- 『リンケージマインド』付属 https://www.fear.co.jp/dbx3rd/download/dc3_lm_csv5.pdf

ゆとシートが、セッション中の便宜のために、固定ロイス以外のロイスもとりあつかえるようにしていることは認識しているが、「記入されていなければ表示せず、記入されていれば表示する」という挙動であれば、その意図には支障をきたさないと考える。

# 実装方法に関する補足

CSS による表示の調整ではなく DOM 自体を生成しないかたちで実装したのは、歯抜けの可能性（４番目が空で５番目が埋まっている、というようなケース）を考慮すると、 CSS による実装では、行に交互に色をつける挙動と折り合いがつけづらいため。