### PR TITLE
[SW2] 単一部位の魔物はチャットパレットに部位名・攻撃手段を出力しない

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -465,7 +465,9 @@ sub palettePreset {
     $text .= "2d+{精神抵抗}+{精神抵抗修正} 精神抵抗力\n";
     foreach (1 .. $::pc{statusNum}){
       (my $part   = $::pc{'status'.$_.'Style'}) =~ s/^.+?[（(](.+?)[)）]$/$1/;
-      $text .= "2d+{回避$_}+{回避修正} 回避／".$part."\n" if $::pc{'status'.$_.'Evasion'} ne '';
+      $part = '' if $::pc{partsNum} == 1;
+      $part = "／$part" if $part ne '';
+      $text .= "2d+{回避$_}+{回避修正} 回避".$part."\n" if $::pc{'status'.$_.'Evasion'} ne '';
     }
     $text .= "\n";
 
@@ -475,8 +477,10 @@ sub palettePreset {
       (my $part   = $::pc{'status'.$_.'Style'}) =~ s/^.+?[（(](.+?)[)）]$/$1/;
       (my $weapon = $::pc{'status'.$_.'Style'}) =~ s/^(.+?)[（(].+?[)）]$/$1/;
       if($part ne $weapon){ $weapon = $::pc{'status'.$_.'Style'}; }
-      $text .= "2d+{命中$_}+{命中修正} 命中力／$weapon\n" if $::pc{'status'.$_.'Accuracy'} ne '';
-      $text .= "{ダメージ$_}+{打撃修正} ダメージ／".$weapon."\n" if $::pc{'status'.$_.'Damage'} ne '';
+      $weapon = '' if $::pc{partsNum} == 1;
+      $weapon = "／$weapon" if $weapon ne '';
+      $text .= "2d+{命中$_}+{命中修正} 命中力$weapon\n" if $::pc{'status'.$_.'Accuracy'} ne '';
+      $text .= "{ダメージ$_}+{打撃修正} ダメージ".$weapon."\n" if $::pc{'status'.$_.'Damage'} ne '';
       $text .= "\n";
     }
     my $skills = $::pc{skills};


### PR DESCRIPTION
# 変更内容

単一部位の魔物であれば、チャットパレットに部位名・攻撃手段を出力しないように。

## 例

たとえば次のような魔物を仮定したとき、

![image](https://github.com/yutorize/ytsheet2/assets/44130782/8e965c2d-d9dd-4181-bc83-9770bb0193f5)

従来は

```
命中力／武器 2d+3+{命中修正}
ダメージ／武器 2d+2+{打撃修正}
```

のように出力されていたが、
これを、

```
命中力 2d+3+{命中修正}
ダメージ 2d+2+{打撃修正}
```

のようにする。

# 目的

より簡潔にするため。