### PR TITLE
[SW2.5] フェローのプレイヤー名が空なら表示しない

### DIFF
--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1243,6 +1243,11 @@ dl#level {
     text-align: center;
   }
 }
+#f-player-name {
+  &:has(dd:empty) {
+    display: none;
+  }
+}
 
 #f-race,
 #f-personal {

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1242,8 +1242,6 @@ dl#level {
   > dd {
     text-align: center;
   }
-}
-#f-player-name {
   &:has(dd:empty) {
     display: none;
   }

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -626,7 +626,7 @@
         <dt>名前<dd><TMPL_IF aka><span class="aka">“<TMPL_VAR aka>”</span></TMPL_IF><span><TMPL_VAR characterName></span>
       </dl>
       <dl id="f-player-name">
-        <dt>プレイヤー名<dd><TMPL_VAR playerName>
+        <dt>プレイヤー名<dd><TMPL_VAR playerName></dd>
       </dl>
       <dl id="f-race">
         <dt>種族<dd><TMPL_VAR race>


### PR DESCRIPTION
# 変更内容

フェローデータの閲覧画面において、プレイヤー名が空であるなら、項目ごと表示しない。

## 表示例

![image](https://github.com/yutorize/ytsheet2/assets/44130782/e7b9a5ba-a3b0-468f-9775-cfec859b6212)

（通常は「名前」と「種族」のあいだに「プレイヤー名」が存在するのだが、それがなくなっている）

# 目的

主に、「シナリオに付属するＮＰＣをフェローとして実装する」ようなケースを想定している。

このような運用は本来的なフェロールールの想定の外ではある（フェローは「ＰＣ」を元とするものである，『Ⅰ』217頁）が、

- 「データを有し、協力的にゲームに寄与するＮＰＣ」を実装するにあたって、それなりの規格化がなされているフェロールールはそれなりに都合がよく、実際にそのように作られるシナリオはある
- 公式文書においても、シナリオ型サプリメントのたぐいでフェローデータが収録されたことがある

という事情をかんがみると、「ＰＣを母体としないフェロー」は現実的な需要として存在すると考えられる。

そのようなケースにおいて、そのフェローには、ふつう“プレイヤー”が存在しないのであるから、プレイヤー名の表記は必要が生じない。（制作者は制作者であって、そのフェローのプレイヤーではない）
よって、プレイヤー名の項目を表示しないほうが妥当であると考える。

あくまで「記入されていなければ表示しない」という挙動であるので、一般的な（ＰＣを母体とする）フェローには悪影響はなく、また「当初からＮＰＣとしてつくるフェローに（なんらかの理由で）“プレイヤー名”を表記したい」という需要も妨げることはない。