### PR TITLE
[SW2] 妖精の属性をあらわす能力から生成される妖精魔法のチャットパレットを、より明瞭にする

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -483,6 +483,7 @@ sub palettePreset {
     $skills =~ tr/０-９（）/0-9\(\)/;
     $skills =~ s/\|/｜/g;
     $skills =~ s/<br>/\n/gi;
+    $skills = convertFairyAttribute($skills) if $::pc{taxa} eq '妖精';
     $skills =~ s/^
       (?:$skill_mark)+
       (?<name>.+?)
@@ -783,6 +784,7 @@ sub paletteProperties {
     $skills =~ tr/０-９（）/0-9\(\)/;
     $skills =~ s/\|/｜/g;
     $skills =~ s/<br>/\n/g;
+    $skills = convertFairyAttribute($skills) if $::pc{taxa} eq '妖精';
     $skills =~ s/^(?:$skill_mark)+(.+?)(?:[0-9]+(?:レベル|LV)|\(.+\))*[\/／](?:魔力)([0-9]+)[(（][0-9]+[）)]/push @propaties, "\/\/$1=$2";/megi;
 
     $skills =~ s/^
@@ -812,6 +814,20 @@ sub paletteProperties {
     $note =~ s/「?(?<dice>[0-9]+[DＤ][0-9]*[+\-*\/()0-9]*)」?点の(?<elm>.+属性)?の?(?<dmg>物理|魔法|落下|確定)?ダメージ/$out .= "\/\/${name}ダメージ=$+{dice}\n";/egi;
     return $out;
   }
+}
+
+sub convertFairyAttribute {
+  my $skills = shift;
+  $skills =~ s/^
+      [○◯〇]
+      (?:古代種[\/／])?
+      属性[:：]
+      ([土水・氷炎風光闇&＆]+)
+      [\/／]
+      (魔力\d+[(（]\d+[）)])
+      (\n|$)
+      /▶妖精魔法($1)／$2$3/x;
+  return $skills;
 }
 
 1;


### PR DESCRIPTION
# 変更内容

妖精の属性をあらわす能力から生成される妖精魔法のチャットパレットを、より明瞭な文言にする。

## 例

### 能力の定義

```
◯属性：光／魔力５（12）
```

### チャットパレット

#### 従来

```
属性：光 2d+5
```

#### 変更後

```
妖精魔法 2d+5
```

# 理由

従来も（「魔力」の文言を参照して魔法用のコマンドが生成されるため）コマンド自体は生成されていたが、それは `属性：～ 2d+n` というようなものだった。

しかし、実際のセッション中に妖精魔法を行使させるにあたって、そのときに送信されるメッセージが `属性：～` では、いまひとつ直感的ではないという問題があった。
（とくにテキストセッションにおいて顕著であると思われる）

これを、一般的な（妖精）魔法の能力定義から生成されるものと同様のコマンド（ `妖精魔法 2d+n` ）に改めることで、よりゲーム上の宣言を明瞭にしたい。

