### PR TITLE
[SW2] 魔物データの部位数と内訳の入力を自動化する

### DIFF
--- a/_core/lib/sw2/edit-mons.js
+++ b/_core/lib/sw2/edit-mons.js
@@ -4,6 +4,7 @@ const gameSystem = 'sw2';
 window.onload = function() {
   setName();
   rewriteMountLevel();
+  updatePartsAutomatically();
   selectInputCheck(form.taxa,'その他')
   checkMount();
 
@@ -137,6 +138,7 @@ function addStatus(copy){
   });
   form.statusNum.value = num;
   statusTextInputToggle();
+  updatePartsAutomatically();
 }
 function addStatusInsert(target, num, copy){
   const lv = target.dataset.lv ? '-'+target.dataset.lv : '';
@@ -158,7 +160,7 @@ function addStatusInsert(target, num, copy){
   tr.innerHTML = `
     <th class="mount-only"></th>
     <td ${ lv ? '' : `class="handle"`}></td>
-    <td ${ lv ? 'class="name"' : ``} data-style="${num}">${ lv ? form[`status${num}Style`].value : `<input name="status${num}${lv}Style" type="text" value="${ini.style}" oninput="checkStyle(${num}${lv})">` }</td>
+    <td ${ lv ? 'class="name"' : ``} data-style="${num}">${ lv ? form[`status${num}Style`].value : `<input name="status${num}${lv}Style" type="text" value="${ini.style}" oninput="checkStyle(${num}${lv}); updatePartsAutomatically();">` }</td>
     <td>
       <input name="status${num}${lv}Accuracy" type="text" oninput="calcAcc('${num}${lv}')" value="${ini.accuracy}"><span class="monster-only calc-only"><br>
       (<input name="status${num}${lv}AccuracyFix" type="text" oninput="calcAccF('${num}${lv}')" value="${ini.accuracyFix}">)</span>
@@ -201,6 +203,7 @@ function delStatus(){
     num--;
     form.statusNum.value = num;
   }
+  updatePartsAutomatically();
 }
 // ソート
 (() => {
@@ -254,6 +257,7 @@ function delStatus(){
         }
       });
       rewriteMountLevel();
+      updatePartsAutomatically();
     }
   });
 })();
@@ -267,6 +271,52 @@ function statusTextInputToggle(){
     form[`status${i}Evasion`].type     = on ? 'text'   : 'number';
   }
   form.classList.toggle('not-calc', on)
+}
+// 部位数・内訳の自動入力
+function updatePartsAutomatically() {
+  const manualModeCheckbox = document.querySelector('input[type="checkbox"][name="partsManualInput"]');
+  const partsNumInput = document.querySelector('.parts input[name="partsNum"]');
+  const partsNamesInput = document.querySelector('.parts input[name="parts"]');
+
+  if (manualModeCheckbox.checked) {
+    partsNumInput.removeAttribute('readonly');
+    partsNamesInput.removeAttribute('readonly');
+    return;
+  }
+
+  let partCount = 0;
+  const partNames = [];
+  document.querySelectorAll('#status-tbody input[name$="Style"]').forEach(
+      input => {
+        partCount++;
+
+        const style = input.value.trim();
+        const m = style.match(/.*[(（](.+?)[）)]$/);
+        if (m == null) {
+          return;
+        }
+        partNames.push(m[1].trim());
+      }
+  );
+
+  partsNumInput.setAttribute('readonly', '');
+  partsNumInput.value = partCount.toString();
+  partsNumInput.dispatchEvent(new Event('input'));
+
+  partsNamesInput.setAttribute('readonly', '');
+  partsNamesInput.value = partNames.length === 0 ? '' : partNames.reduce(
+      (previous, currentPartName) => {
+        const previousPartTexts = previous.split('／');
+        const lastPartText = previousPartTexts[previousPartTexts.length - 1];
+        const m = lastPartText.match(/^(.+?)(?:×(\d+))?$/);
+        const lastPartName = m[1];
+        const lastPartCount = m[2] ? parseInt(m[2]) : 1;
+        return currentPartName === lastPartName
+            ? `${previousPartTexts.length > 1 ? `${previousPartTexts.slice(0, -1).join('／')}／` : ''}${lastPartName}×${lastPartCount + 1}`
+            : `${previous}／${currentPartName}`;
+      }
+  );
+  partsNamesInput.dispatchEvent(new Event('input'));
 }
 
 // 戦利品欄 ----------------------------------------

--- a/_core/lib/sw2/edit-mons.js
+++ b/_core/lib/sw2/edit-mons.js
@@ -279,8 +279,8 @@ function updatePartsAutomatically() {
   const partsNamesInput = document.querySelector('.parts input[name="parts"]');
 
   if (manualModeCheckbox.checked) {
-    partsNumInput.removeAttribute('readonly');
-    partsNamesInput.removeAttribute('readonly');
+    partsNumInput.readOnly = false;
+    partsNamesInput.readOnly = false;
     return;
   }
 
@@ -299,11 +299,11 @@ function updatePartsAutomatically() {
       }
   );
 
-  partsNumInput.setAttribute('readonly', '');
+  partsNumInput.readOnly = true;
   partsNumInput.value = partCount.toString();
   partsNumInput.dispatchEvent(new Event('input'));
 
-  partsNamesInput.setAttribute('readonly', '');
+  partsNamesInput.readOnly = true;
   partsNamesInput.value = partNames.length === 0 ? '' : partNames.reduce(
       (previous, currentPartName) => {
         const previousPartTexts = previous.split('／');

--- a/_core/lib/sw2/edit-mons.pl
+++ b/_core/lib/sw2/edit-mons.pl
@@ -38,6 +38,8 @@ if($mode eq 'blanksheet'){
 setDefaultColors();
 
 ## その他
+$pc{partsManualInput} = 0 if $mode eq 'blanksheet';
+$pc{partsManualInput} = 1 if !exists($pc{partsManualInput}) && $pc{ver} le '1.25.010';
 $pc{partsNum}  ||= 1;
 $pc{statusNum} ||= 1;
 $pc{lootsNum}  ||= 2;
@@ -301,7 +303,7 @@ foreach my $num (1 .. $pc{statusNum}){
         <tr id="status-row${num}">
           <th class="mount-only">
           <td class="handle">
-          <td>@{[ input "status${num}Style",'text',"checkStyle(${num})" ]}
+          <td>@{[ input "status${num}Style",'text',"checkStyle(${num}); updatePartsAutomatically()" ]}
           <td>@{[ input "status${num}Accuracy",($status_text_input ? 'text':'number'),"calcAcc($num)" ]}<span class="monster-only calc-only"><br>(@{[ input "status${num}AccuracyFix",'number',"calcAccF($num)" ]})</span>
           <td>@{[ input "status${num}Damage" ]}
           <td>@{[ input "status${num}Evasion",($status_text_input ? 'text':'number'),"calcEva($num)" ]}<span class="monster-only calc-only"><br>(@{[ input "status${num}EvasionFix",'number',"calcEvaF($num)" ]})</span>
@@ -348,6 +350,7 @@ print <<"HTML";
       @{[input('statusNum','hidden')]}
       </div>
       <div class="box parts in-toc" data-content-title="部位数・コア部位">
+        @{[ checkbox 'partsManualInput', '部位数と内訳を手動入力する', 'updatePartsAutomatically' ]}
         <dl><dt>部位数<dd>@{[ input 'partsNum','number','','min="1"' ]} (@{[ input 'parts' ]}) </dl>
         <dl><dt>コア部位<dd>@{[ input 'coreParts' ]}</dl>
       </div>

--- a/_core/skin/sw2/css/monster.css
+++ b/_core/skin/sw2/css/monster.css
@@ -234,8 +234,9 @@ table.status {
 /* // Parts
 ---------------------------------------------------------------------------------------------------- */
 .parts {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-rows: repeat(2, max-content);
+  grid-template-columns: repeat(2, max-content);
   margin: .5rem 0;
   padding: .3em 1rem;
   background: var(--box-base-bg-color);
@@ -251,8 +252,59 @@ table.status {
       font-weight: normal;
     }
   }
-}
 
+  & label:has([name="partsManualInput"]) {
+    grid-row: 1 / 2;
+    grid-column: 1 / -1;
+    display: block;
+    width: max-content;
+    margin-bottom: 0.25em;
+  }
+
+  & dl:nth-of-type(1) {
+    grid-row: 2 / 3;
+    grid-column: 1 / 2;
+  }
+
+  & dl:nth-of-type(2) {
+    grid-row: 2 / 3;
+    grid-column: 2 / 3;
+  }
+}
+@media screen and (max-width: 735px) {
+  .parts {
+    grid-template-rows: repeat(3, max-content);
+    grid-template-columns: 1fr;
+
+    & label:has([name="partsManualInput"]),
+    & dl:nth-of-type(1),
+    & dl:nth-of-type(2) {
+      grid-column: 1 / -1;
+    }
+
+    & label:has([name="partsManualInput"]) {
+      grid-row: 1 / 2;
+    }
+
+    & dl:nth-of-type(1),
+    & dl:nth-of-type(2) {
+      width: max-content;
+      margin-right: 0;
+
+      & dd {
+        width: max-content;
+      }
+    }
+
+    & dl:nth-of-type(1) {
+      grid-row: 2 / 3;
+    }
+
+    & dl:nth-of-type(2) {
+      grid-row: 3 / 4;
+    }
+  }
+}
 
 /* // Skills
 ---------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
# 変更内容

魔物データの部位数と内訳（※次の画像の部分）の入力を自動的におこなうように。

![image](https://github.com/yutorize/ytsheet2/assets/44130782/66ef5a77-f88c-437f-935e-27d6f3208647)

# 目的

大半のケースにおいては上のステータスセクション（攻撃方法や命中力などを入力する箇所）に入力するものと一致するにもかかわらず、手動で（重複的な）入力を要求されていたのを解消するため。

（ようするに、ステータスセクションに「牙（胴体）」「翼（翼）」「翼（翼）」と入力したなら、自動的に、部位数は「 3」 、部位内訳は「胴体／翼×2」になってほしい、という意味）

# 仕様

「攻撃方法（部位）」欄を参照する。

## 基本仕様

### 部位数

ステータス欄に作られている部位の数をそのまま部位数とする。

### 部位名

`攻撃方法（部位）` 形式で記述されていることを前提に、 `（部位）` の部分を抽出する。

### 部位内訳

前述の“部位名”を `／` で連結する。
同名の部位が連続して存在する場合（「ドレイク（竜形態）」（⇒『モンストラスロア』77頁）の「翼」「翼」のような場合）、それを `×n` （ _n_ はその名称の部位の数）の形式でまとめる。

## 手動入力オプション

上述の自動入力をデフォルトの挙動とするが、（従来同様の）手動入力を可能とするオプションも提供している。

部位数と内訳の入力欄の上にある「部位数と内訳を自動入力する」にチェックを入れると、自動入力が無効化され、手動で入力できるようになる。（※このチェックを入れるまでは、これらのフィールドは _readonly_ となっている）

![image](https://github.com/yutorize/ytsheet2/assets/44130782/6d64b2b9-0678-4f64-8b97-7ce2c2fb05e4)

![image](https://github.com/yutorize/ytsheet2/assets/44130782/04d24309-af62-4e3a-a5b1-3bde997d3d4a)

大半のケースは自動入力で解決できるはずだが、「ヒドラ」（⇒『モンストラスロア』114頁）のように変則的な部位の規定をもつ場合には、手動入力オプションをもちいる想定である。

## 互換性

### 新規作成

以降、新規に作成するときは、自動入力がデフォルトである。

### 既存データ（後方互換性）

既存データは、その内容にかかわらず、手動入力オプションの有効相当で動作する。

#### ⚠️ 注意

この後方互換性のために、_core/lib/sw2/edit-mons.pl_ には具体的なバージョンをリテラルで指定している箇所があります（ `'1.25.010'` ）。
ひとまず現在の最新バージョンを入力していますが、反映時には適切なバージョン（これを反映する瞬間のバージョン）に置き換える必要があります。