### PR TITLE
ゆとチャadv. のユニットステータス操作コマンドらしきものはスワップしないように

### DIFF
--- a/_core/lib/palette.pl
+++ b/_core/lib/palette.pl
@@ -89,7 +89,7 @@ sub outputChatPalette {
 sub swapWordAndCommand {
   my @palette = split(/\n/, shift);
   foreach (@palette){
-    if($_ =~ /^[0-9a-z:+\-\{]/i){
+    if($_ =~ /^[0-9a-z:+\-\{]/i && $_ !~ /^[^\d].+?\@[^\d].+?[-+]/){
       my ($command, $word) = split(/ /, $_, 2);
       if($command && $word){
         $_ = "$word $command";


### PR DESCRIPTION
チャットパレットの、ゆとチャadv.用の後置記法とBCDice用の前置記法を入れ替える処理において、ゆとチャadv.でのステータス操作コマンドを置き換えてしまわないように。

---

ゆとチャのステータス操作コマンドをもちいたチャットパレットとして、次のようなものを仮定する。

```
@MP-3 【キャッツアイ】
```

これをチャットパレットに記述しておくと、前置記法と後置記法を入れ替える処理において、 `【キャッツアイ】 @MP-3` のように置き換えられてしまう。

しかし、ゆとチャのステータス操作コマンドは、前置での記述にしか対応していない。（ `【キャッツアイ】 @MP-3` はステータス操作コマンドとして解決できない）

---

なので、ステータス操作コマンドらしきものを入れ替えないようにする。

正規表現でふわっと識別しているだけなので、なんらかの副作用があるような気はかなりしている……。

というかたぶん GS, VC の BCDice の判定コマンドが、クリティカル値の指定があるときに誤判定される。
ダブルクロスはシンプルな記法なら問題なさそうだが、場合によっては誤判定されるかも。
ソード・ワールド2.x も `@` でクリティカル値を指定した威力表コマンドはあやしいかもしれない。

……ダメでは？