### PR TITLE
[SW2] アイテム名の山括弧を入力補完から入力したとき、キャレットを括弧内に移動する

### DIFF
--- a/_core/lib/sw2.0/edit-chara.pl
+++ b/_core/lib/sw2.0/edit-chara.pl
@@ -970,7 +970,7 @@ print <<"HTML";
                 <td>@{[input("weapon${num}Own",'checkbox','calcWeapon')]}
                 <td><select name="weapon${num}Category" oninput="calcWeapon()">@{[option("weapon${num}Category",@data::weapon_names,'ガン（物理）','盾')]}</select>
                 <td><select name="weapon${num}Class" oninput="calcWeapon()">@{[option("weapon${num}Class",@weapon_users,'自動計算しない')]}</select>
-                <td rowspan="2"><span class="button" onclick="addWeapons(${num});">複<br>製</span>
+                <td rowspan="2"><span class="button" onclick="addWeapons(${num});setupBracketInputCompletion()">複<br>製</span>
               <tr>
                 <td colspan="3">@{[input("weapon${num}Note",'','calcWeapon','placeholder="備考"')]}
 HTML
@@ -983,7 +983,7 @@ print <<"HTML";
             <li>Ｃ値は自動計算されません。
             <li id="artisan-annotate" @{[ display $pc{masteryArtisan} ]}>※備考欄に<code>〈魔器〉</code>と記入すると魔器習熟が反映されます。
           </ul>
-          <div class="add-del-button"><a onclick="addWeapons()">▼</a><a onclick="delWeapons()">▲</a></div>
+          <div class="add-del-button"><a onclick="addWeapons();setupBracketInputCompletion()">▼</a><a onclick="delWeapons()">▲</a></div>
           @{[input('weaponNum','hidden')]}
         </div>
         <div class="box" id="evasion-classes">
@@ -1102,7 +1102,7 @@ HTML
             @{[ input 'armourNum','hidden' ]}
             <tfoot>
               <tr><td colspan="8">
-                <div class="add-del-button"><a onclick="addArmour()">▼</a><a onclick="delArmour()">▲</a></div>
+                <div class="add-del-button"><a onclick="addArmour();setupBracketInputCompletion()">▼</a><a onclick="delArmour()">▲</a></div>
               <tr>
                 <th colspan="2">使用技能
                 <th colspan="2" class="small" style="vertical-align:bottom">チェックを入れた防具の数値で合算▼

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1289,6 +1289,7 @@ function calcFairy() {
   document.getElementById('fairy-rank').textContent = result;
 }
 
+// アイテム名称欄の入力補完時 ----------------------------------------
 function setupBracketInputCompletion() {
   document.querySelectorAll('input[type="text"]:is([list="list-item-name"], [list="list-weapon-name"]):not(.support-bracket-input-completion)').forEach(
       input => {

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -88,6 +88,7 @@ window.onload = function() {
   calcHonor();
   calcDishonor();
   calcCommonClass();
+  setupBracketInputCompletion();
   
   imagePosition();
   changeColor();
@@ -1286,6 +1287,39 @@ function calcFairy() {
   if(rank[i]){ result = rank[i][lv['Fai']] || '×'; }
   else { result = '×'; }
   document.getElementById('fairy-rank').textContent = result;
+}
+
+function setupBracketInputCompletion() {
+  document.querySelectorAll('input[type="text"]:is([list="list-item-name"], [list="list-weapon-name"]):not(.support-bracket-input-completion)').forEach(
+      input => {
+        let lastValue = input.value ?? '';
+
+        input.addEventListener(
+            'input',
+            e => {
+              const newValue = input.value ?? '';
+
+              if (
+                  newValue.includes('〈〉') &&
+                  (
+                      lastValue === '' ||
+                      newValue.includes(lastValue) // 部分的に入力されている状態から入力補完が選ばれたケース
+                  ) &&
+                  !lastValue.includes('〈〉') // 空の括弧がある状態から何かが入力されたときは動作させない（括弧内の前に `[魔]` などを入力するときを想定した措置）
+              ) {
+                if (input.selectionStart === input.selectionEnd) { // 範囲選択になっていないときのみ動作させる
+                  const indexOfEmptyBracket = newValue.indexOf('〈〉');
+                  input.selectionStart = input.selectionEnd = indexOfEmptyBracket + 1;
+                }
+              }
+
+              lastValue = newValue;
+            }
+        );
+
+        input.classList.add('support-bracket-input-completion');
+      }
+  );
 }
 
 // 部位データ計算 ----------------------------------------

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -976,7 +976,7 @@ print <<"HTML";
                 <td>@{[input("weapon${num}Own",'checkbox','calcWeapon')]}
                 <td><select name="weapon${num}Category" oninput="calcWeapon()">@{[option("weapon${num}Category",@data::weapon_names,'ガン（物理）','盾')]}</select>
                 <td><select name="weapon${num}Class" oninput="calcWeapon()">@{[option("weapon${num}Class",@weapon_users,'自動計算しない')]}</select>
-                <td rowspan="2"><span class="button" onclick="addWeapons(${num});">複<br>製</span>
+                <td rowspan="2"><span class="button" onclick="addWeapons(${num});setupBracketInputCompletion()">複<br>製</span>
               <tr>
                 <td colspan="3">@{[input("weapon${num}Note",'','calcWeapon','placeholder="備考"')]}
 HTML
@@ -984,7 +984,7 @@ HTML
 }
 print <<"HTML";
           </table>
-          <div class="add-del-button"><a onclick="addWeapons()">▼</a><a onclick="delWeapons()">▲</a></div>
+          <div class="add-del-button"><a onclick="addWeapons();setupBracketInputCompletion()">▼</a><a onclick="delWeapons()">▲</a></div>
           <ul class="annotate">
             <li>Ｃ値は自動計算されません。
             <li id="artisan-annotate" @{[ display $pc{masteryArtisan} ]}>備考欄に<code>〈魔器〉</code>と記入すると魔器習熟が反映されます。
@@ -1102,7 +1102,7 @@ HTML
             @{[ input 'armourNum','hidden' ]}
             <tfoot>
               <tr><td colspan="8">
-                <div class="add-del-button"><a onclick="addArmour()">▼</a><a onclick="delArmour()">▲</a></div>
+                <div class="add-del-button"><a onclick="addArmour();setupBracketInputCompletion()">▼</a><a onclick="delArmour()">▲</a></div>
               <tr>
                 <th colspan="2">使用技能
                 <th colspan="2" class="small" style="vertical-align:bottom">チェックを入れた防具の数値で合算▼


### PR DESCRIPTION
# 変更内容

アイテム名の山括弧 〈〉 を入力補完（ _datalist_ ）から入力した（っぽい）とき、キャレットを括弧の内側へと自動的に移動する。

![ytsheet-move_caret_into_item_brackets](https://github.com/yutorize/ytsheet2/assets/44130782/f1140555-a723-43ee-8f15-1b4541764d9d)

# 理由

いちいち一文字分（ `〈〉[刃][打]` のようなケースなら数文字分）手動でもどるのがだいぶ面倒だったため。

入力補完なんだからキャレットの位置もいい感じに整えてほしくなった。（ゆとチャadv.のタグ挿入がそうであるように）