### PR TITLE
[DX3] 編集画面において、技能に消費された経験点の小計が 0 未満のとき、小計の色を変える

### DIFF
--- a/_core/lib/dx3/edit-chara.js
+++ b/_core/lib/dx3/edit-chara.js
@@ -229,8 +229,15 @@ function calcSkill() {
     else { exps['skill']  -= 10 }
   }
   document.getElementById('freepoint-skill').textContent = (free > 5) ? 5 : free;
-  document.getElementById('exp-skill'      ).textContent = exps['skill'];
-  document.getElementById('exp-used-skill' ).textContent = exps['skill'];
+
+  const expSkillElement = document.getElementById('exp-skill');
+  expSkillElement.textContent = exps['skill'];
+  expSkillElement.classList.toggle('minus', exps['skill'] < 0);
+
+  const expUsedSkillElement = document.getElementById('exp-used-skill');
+  expUsedSkillElement.textContent = exps['skill'];
+  expUsedSkillElement.classList.toggle('minus', exps['skill'] < 0);
+
   calcExp();
   calcComboAll();
 }

--- a/_core/lib/dx3/edit-chara.js
+++ b/_core/lib/dx3/edit-chara.js
@@ -230,13 +230,11 @@ function calcSkill() {
   }
   document.getElementById('freepoint-skill').textContent = (free > 5) ? 5 : free;
 
-  const expSkillElement = document.getElementById('exp-skill');
-  expSkillElement.textContent = exps['skill'];
-  expSkillElement.classList.toggle('minus', exps['skill'] < 0);
-
-  const expUsedSkillElement = document.getElementById('exp-used-skill');
-  expUsedSkillElement.textContent = exps['skill'];
-  expUsedSkillElement.classList.toggle('minus', exps['skill'] < 0);
+  for(let name of ['exp-skill','exp-used-skill']){
+    const elm = document.getElementById(name);
+    elm.textContent = exps['skill'];
+    elm.classList.toggle('minus', exps['skill'] < 0);
+  }
 
   calcExp();
   calcComboAll();

--- a/_core/skin/dx3/css/edit.css
+++ b/_core/skin/dx3/css/edit.css
@@ -206,6 +206,9 @@ body:not(.mode-crc) .crc-only {
 }
 
 
+#status > summary #exp-skill.minus {
+  color: #e70;
+}
 #status dl#status-table > *:nth-of-type(even),
 #status dl#skill-table > *:nth-of-type(even) {
   background-color: var(--box-even-rows-bg-color);
@@ -855,4 +858,8 @@ body:not(.mode-crc) .crc-only {
   background: var(--bg-color);
   font-size: 85%;
   font-weight: bold;
+
+  .minus {
+    color: #e70;
+  }
 }


### PR DESCRIPTION
# 変更内容

編集画面において、技能に消費されている経験点の小計が 0 より小さいとき、当該小計値の文字色を変える。

## 表示例

![image](https://github.com/user-attachments/assets/983f8e01-def6-49b9-b6cb-15fec578802c)

![image](https://github.com/user-attachments/assets/5b55d906-b811-4792-9d3b-cf79eb5d0766)

# 目的

ルールに照らしての誤りに、より気づきやすくするため。