### PR TITLE
[SW2] 騎獣の価格に数値以外のものが入力されている場合に適切に整形する

### DIFF
--- a/_core/lib/sw2/view-mons.pl
+++ b/_core/lib/sw2/view-mons.pl
@@ -150,7 +150,13 @@ $SHEET->param(Tags => \@tags);
 
   foreach (@prices) {
     (my $term, my $value) = @{$_};
-    $price .= "<dt>$term</dt><dd>$value<small>G</small></dd>" if $value;
+    my $annotation = $value =~ s/([(（].+?[）)])$// ? $1 : '';
+    my $unit = $value =~ /\d$/ ? 'G' : '';
+
+    $unit = "<small>$unit</small>" if $unit ne '';
+    $annotation = "<small>$annotation</small>" if $annotation ne '';
+
+    $price .= "<dt>$term</dt><dd>$value$unit$annotation</dd>" if $value;
   }
 
   if(!$price){ $price = '―' }

--- a/_core/lib/sw2/view-mons.pl
+++ b/_core/lib/sw2/view-mons.pl
@@ -141,9 +141,18 @@ $SHEET->param(Tags => \@tags);
 ### 価格 --------------------------------------------------
 {
   my $price;
-  $price .= "<dt>購入</dt><dd>$pc{price}<small>G</small></dd>" if $pc{price};
-  $price .= "<dt>レンタル</dt><dd>$pc{priceRental}<small>G</small></dd>"     if $pc{priceRental};
-  $price .= "<dt>部位再生</dt><dd>$pc{priceRegenerate}<small>G</small></dd>" if $pc{priceRegenerate};
+
+  my @prices = (
+      ['購入', $pc{price}],
+      ['レンタル', $pc{priceRental}],
+      ['部位再生', $pc{priceRegenerate}],
+  );
+
+  foreach (@prices) {
+    (my $term, my $value) = @{$_};
+    $price .= "<dt>$term</dt><dd>$value<small>G</small></dd>" if $value;
+  }
+
   if(!$price){ $price = '―' }
   $SHEET->param(price => "<dl class=\"price\">$price</dl>");
 }


### PR DESCRIPTION
# 変更内容

- 必要でなさそうなときは単位 `G` をつけない
- 末尾の括弧書きは単位の後ろに回す

## 必要でなさそうなときは単位 `G` をつけない

従来は、騎獣の価格に常に単位 `G` がついていた。
![image](https://github.com/user-attachments/assets/95deca6b-be22-4801-acce-2bffb0c61102)

が、金額以外のものが記入されたときに不自然なことになるので、価格（の末尾）が数字でなければ単位をつけないようにした。

なお、金額以外のものが入力される具体例としては、（2.0時代の表現だが）『ルミエルレガシィ』137頁の「レンタル不能」などが考えられる。

## 末尾の括弧書きは単位の後ろに回す

`（非売品）` など、末尾に括弧書きがある場合、その部分を単位より後ろに回すようにした。

該当する表現の例は、やはり『ルミエルレガシィ』137頁などにある。

![image](https://github.com/user-attachments/assets/523d53dc-5ced-4211-a98f-937a09ea1df6)
