### PR TITLE
[SW2] 秘伝の「リスク」の入力候補に `—` を追加

### DIFF
--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -594,6 +594,7 @@ print <<"HTML";
     <option value="10秒（1ラウンド）持続">
   </datalist>
   <datalist id="list-arts-risk">
+    <option value="—">
     <option value="なし">
     <option value="回避力判定-1">
     <option value="回避力判定-2">


### PR DESCRIPTION
主動作型または常時型においては、公式文献において一般的にリスクは `—` となっている。

以下は該当する例：
- 《ディスエンゲージ》（主動作型、『バトルマスタリー』45頁）
- 《鉄拳鈍輝》（常時型、『バトルマスタリー』47頁）