### PR TITLE
[SW2] Fix: 流派データをコンバートしようとしたときに、元データの流派名にかかわらず「無題」と表示される不具合を修正

### DIFF
--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -41,7 +41,7 @@ my $mode_make = ($mode =~ /^(blanksheet|copy|convert)$/) ? 1 : 0;
 
 ### 出力準備 #########################################################################################
 if($message){
-  my $name = unescapeTags($pc{category} eq 'magic' ? $pc{magicName} : $pc{category} eq 'god' ? $pc{godAka}.$pc{godName} : '無題');
+  my $name = unescapeTags($pc{category} eq 'magic' ? $pc{magicName} : $pc{category} eq 'god' ? $pc{godAka}.$pc{godName} : $pc{category} eq 'school' ? $pc{schoolName} : '無題');
   $message =~ s/<!NAME>/$name/;
 }
 ### 製作者名 --------------------------------------------------


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2068ebf1-e29b-4256-b104-4d72a6800e82)
