### PR TITLE
[MS] Fix: クランデータをコンバートしようとしたときに、元データのクラン名にかかわらず「無題」と表示される不具合を修正

### DIFF
--- a/_core/lib/ms/edit-clan.pl
+++ b/_core/lib/ms/edit-clan.pl
@@ -18,7 +18,7 @@ my $mode_make = ($mode =~ /^(blanksheet|copy|convert)$/) ? 1 : 0;
 
 ### 出力準備 #########################################################################################
 if($message){
-  my $name = unescapeTags($pc{characterName} || $pc{aka} || '無題');
+  my $name = unescapeTags($pc{clanName} || '無題');
   $message =~ s/<!NAME>/$name/;
 }
 ### プレイヤー名 --------------------------------------------------


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/92e698b9-72f2-4dc3-a07a-6d73106bb704)
