### PR TITLE
[GC] Fix: 国データをコンバートしようとしたときに、元データの国名にかかわらず「無題」と表示される不具合を修正

### DIFF
--- a/_core/lib/gc/edit-country.pl
+++ b/_core/lib/gc/edit-country.pl
@@ -20,7 +20,7 @@ my $mode_make = ($mode =~ /^(blanksheet|copy|convert)$/) ? 1 : 0;
 
 ### 出力準備 #########################################################################################
 if($message){
-  my $name = unescapeTags($pc{characterName} || $pc{aka} || '無題');
+  my $name = unescapeTags($pc{countryName} || '無題');
   $message =~ s/<!NAME>/$name/;
 }
 ### プレイヤー名 --------------------------------------------------


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fff89e81-5244-44cc-a861-c6545f836018)
