### PR TITLE
[SW2] アイテムシートの防具データにおいて「用法」がひとつも設定されていなければ、表示画面で「用法」の列を表示しない

### DIFF
--- a/_core/skin/sw2/css/item.css
+++ b/_core/skin/sw2/css/item.css
@@ -221,6 +221,14 @@ div.data {
       &:not(:has(tbody td.note:not(:empty))) tr > *.note {
         display: none;
       }
+
+      &.armour-table {
+        &:not(:has(td.usage:not(:empty))) {
+          .usage {
+            display: none;
+          }
+        }
+      }
     }
     & > :is(dt,dd):nth-of-type(n+2) {
       border-top-width: 1px;

--- a/_core/skin/sw2/sheet-item.html
+++ b/_core/skin/sw2/sheet-item.html
@@ -122,15 +122,15 @@
           </table>
         </TMPL_IF>
         <TMPL_IF ArmourData>
-          <table class="weapon-table">
+          <table class="weapon-table armour-table">
             <tr>
-              <th>用法
+              <th class="usage">用法
               <th>必筋
               <th>回避
               <th>防護
               <th class="note left">備考
             <TMPL_LOOP ArmourData><tr>
-              <td><TMPL_VAR USAGE>
+              <td class="usage"><TMPL_VAR USAGE></td>
               <td><TMPL_VAR REQD>
               <td><TMPL_VAR EVA>
               <td><TMPL_VAR DEF>


### PR DESCRIPTION
鎧（〈非金属鎧〉〈金属鎧〉）は「用法」をもたないが、これまでは常に「用法」の列が表示されていた。

![image](https://github.com/user-attachments/assets/56085e28-0088-4d00-8a05-2852184f7522)

これは無意味かつ表示上の据わりがわるいので、防具データにおいて「用法」がひとつも指定されていなければ列ごと非表示にする。

![image](https://github.com/user-attachments/assets/67936af9-e6c6-4a38-af92-38563e3137c5)
