### PR TITLE
[SW2] Fix: 閲覧画面において、騎獣の価格と適正レベルのあいだのマージンが二重に存在していたのを修正

### DIFF
--- a/_core/skin/sw2/css/monster.css
+++ b/_core/skin/sw2/css/monster.css
@@ -148,6 +148,7 @@ div.status dl {
   }
   & dl.price {
     align-items: end;
+    margin-right: 0;
   }
   & dl.price dt {
     font-size: 85%;


### PR DESCRIPTION
内側の `dl` にもマージンが適用されていた。
結果的として、他の項目間の二倍のマージンがとられていた。

![image](https://github.com/user-attachments/assets/2a84bb82-79e7-42ec-a5a6-99e614d58601)
