### PR TITLE
[SW2][KIZ] `unitStatus` に数値型が含まれる現象を回避

### DIFF
--- a/_core/lib/kiz/subroutine-sub.pl
+++ b/_core/lib/kiz/subroutine-sub.pl
@@ -14,7 +14,7 @@ sub createUnitStatus {
   my @unitStatus = (
     { '耐久値' => $pc{endurance} },
     { '作戦力' => $pc{operation} },
-    { '励起値' => 0 },
+    { '励起値' => '0' },
   );
   
   foreach my $key (split ',', $pc{unitStatusNotOutput}){

--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -57,7 +57,7 @@ sub createUnitStatus {
       @unitStatus = (
         { 'HP' => "$hp/$hp" },
         { 'MP' => "$mp/$mp" },
-        { '防護' => $def },
+        { '防護' => "$def" },
       );
     }
   }


### PR DESCRIPTION
# 変更内容
　unitStatus に含まれる各項目の値を、 number 型ではなく string 型に固定する。

# 背景
　v1.23 までは、 unitStatus の各項目の値は、原則として string 型をとっていました。
　v1.24 以降は、 unitStatus の各項目の値に、 number 型をとるケースができました。
　具体的な例としては、 SW2 の**単一部位**の魔物データにおける「防護」においてこの差異が観測できます。
　（なお、 KIZ については v1.23 でも number 型の項目がありました）

　ここで、 Udonarium 等ではおそらく問題が起こっていないのですが、現行のゆとチャadv. では number 型の（厳密には“ string 型でない”）項目があるとエラー（例外）が発生します。（ string オブジェクトであることを前提としたコードがあるため）
　ゆとチャadv. 側でこれを解消するすべはすでにわかっており、実装は容易なのですが（ → https://github.com/yutorize/ytchat-adv/pull/92 ）、ゆとチャadv. の本流の更新は今しばらくされないであろうことと、仮に更新版がリリースされた場合にもセッションツールの更新は（進行中のセッションが終わるまでなど）保留される可能性が想定されることから、ゆとシート側で応急的な措置を講じておくのが現実的な利益に適うと考えます（――とくにゆと工公式のゆとシートについては）。