### PR TITLE
[SW2] 能力値Ａ～Ｆのとりうる範囲を明示する

### DIFF
--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -2293,10 +2293,16 @@ function calcPointBuy() {
   
   let points = 0;
   let errorFlag = 0;
-  ['A','B','C','D','E','F'].forEach((i) => { form[`sttBase${i}`].classList.remove('error') });
+  ['A','B','C','D','E','F'].forEach((i) => {
+    form[`sttBase${i}`].classList.remove('error');
+    delete document.querySelector(`#stt-base-${i} > dt:first-child`).dataset['range'];
+  });
   if(SET.races[race]?.dice){
     ['A','B','C','D','E','F'].forEach((i) => {
       const dice = String(SET.races[race].dice[i]);
+      const min = Number(dice) + (SET.races[race].dice[`${i}+`] ?? 0);
+      const max = min + Number(dice) * 5;
+      document.querySelector(`#stt-base-${i} > dt:first-child`).dataset.range = `${min}～${max}`;
       let num  = Number(form[`sttBase${i}`].value);
       if(SET.races[race].dice[`${i}+`]){ num -= SET.races[race].dice[`${i}+`]; }
       if(pointBuyList[type] && pointBuyList[type][dice] && pointBuyList[type][dice][num] != null){

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -246,6 +246,20 @@ header nav ul li.character-format {
 #status dl dt {
   font-size: 1.3rem;
 }
+#status dl[id^="stt-base-"] {
+  dt[data-range] {
+    display: flex;
+    flex-flow: row;
+    justify-content: space-between;
+    align-items: flex-end;
+
+    &::after {
+      content: "(" attr(data-range) ")";
+      font-size: 70%;
+      font-weight: normal;
+    }
+  }
+}
 #status dl dd {
   flex-grow: 1;
   display: flex;

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -246,20 +246,6 @@ header nav ul li.character-format {
 #status dl dt {
   font-size: 1.3rem;
 }
-#status dl[id^="stt-base-"] {
-  dt[data-range] {
-    display: flex;
-    flex-flow: row;
-    justify-content: space-between;
-    align-items: flex-end;
-
-    &::after {
-      content: "(" attr(data-range) ")";
-      font-size: 70%;
-      font-weight: normal;
-    }
-  }
-}
 #status dl dd {
   flex-grow: 1;
   display: flex;

--- a/_core/skin/sw2/css/edit.css
+++ b/_core/skin/sw2/css/edit.css
@@ -85,6 +85,20 @@
   }
 }
 
+#status dl[id^="stt-base-"] {
+  dt[data-range] {
+    display: flex;
+    flex-flow: row;
+    justify-content: space-between;
+    align-items: flex-end;
+
+    &::after {
+      content: "(" attr(data-range) ")";
+      font-size: 70%;
+      font-weight: normal;
+    }
+  }
+}
 #status dl[id^="stt-add"]::before {
   left: -.6rem;
 }


### PR DESCRIPTION
# 変更内容

編集画面において、能力値決定のＡ～Ｆそれぞれのとりうる範囲を表示する。

## 表示例
![image](https://github.com/user-attachments/assets/9a0d7e62-d4f1-4795-93fc-57fa153e4bbf)

# 目的
「ポイント割り振りによるキャラクター作成」ルールの運用時においては、各値のとりうる範囲を意識する必要があるが、従来は視覚的に確認できなかった。
（不足または超過ではエラー表示がされるが、どこからがエラーになるのかわからなかった）

これをより直接的に目視で確認できるようにする。