### PR TITLE
[SW2] キャラクターの防具の回避力修正が正の値であれば `+` をつける

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -803,7 +803,7 @@ else {
       TYPE => $pc{'armour'.$_.'Type'},
       NAME => $pc{'armour'.$_.'Name'},
       REQD => $pc{'armour'.$_.'Reqd'},
-      EVA  => $pc{'armour'.$_.'Eva'} // ($pc{'armour'.$_.'Category'} =~ /[鎧盾]/ ? '―' : ''),
+      EVA  => $pc{'armour'.$_.'Eva'} ? addNum($pc{'armour'.$_.'Eva'}) : ($pc{'armour'.$_.'Category'} =~ /[鎧盾]/ ? '―' : ''),
       DEF  => $pc{'armour'.$_.'Def'} // ($pc{'armour'.$_.'Category'} =~ /[鎧盾]/ ? '0' : ''),
       OWN  => $pc{'armour'.$_.'Own'},
       NOTE => $pc{'armour'.$_.'Note'},


### PR DESCRIPTION
# 変更内容
防具の「回避」の欄が正の値であれば、数字の前に `+` をつけるように。

# 理由

公式文書のアイテムデータでは、防具の回避力修正が正の値のときは、プラス記号が付記されている。
（例：『Ⅰ』317頁〈ポイントガード〉、同319頁〈カイトシールド〉など）

サンプルキャラクターのデータを見るかぎり、キャラクターシート上でも同様である。
（例：『Ⅰ』31頁の〈バックラー〉の欄）

上記をふまえ、公式文書の表記により近づけるようにする。

# 表示例

**before**
![image](https://github.com/user-attachments/assets/376c2ca2-3e5e-4732-b33a-1ac56bb7bdb9)

**after**
![image](https://github.com/user-attachments/assets/f475c1db-4040-41b2-ac9c-8d041a791e1c)
