### PR TITLE
[SW2] 流派装備の名称に山括弧 `〈〉` をつける

### DIFF
--- a/_core/lib/sw2/edit-arts.js
+++ b/_core/lib/sw2/edit-arts.js
@@ -160,8 +160,12 @@ async function addSchoolItem(){
       if(data.itemName == null){ alert('アイテムデータではありません。'); return; }
       let tr = document.createElement('tr');
       tr.setAttribute('class','item-data');
+      let itemName = ruby(data.itemName||'');
+      if (!/〈.*〉/.test(itemName)) {
+        itemName = `〈${itemName}〉`;
+      }
       tr.innerHTML = `
-        <td><a href="${url}">${ruby(data.itemName||'')}</a></td>
+        <td><a href="${url}">${itemName}</a></td>
         <td>${data.category||''}</td>
         <td>${data.summary ||''}</td>
         <td class="button" onclick="delSchoolItem(this,'${url}')">×</td>

--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -348,6 +348,7 @@ foreach my $set_url (split ',',$pc{schoolItemList}){
   $item{category} =~ s/\s/<hr>/;
   print "<tr>";
   if(exists $item{itemName}) {
+    $item{itemName} = "〈$item{itemName}〉" if $item{itemName} !~ /〈.*〉/;
     print "<td><a href=\"${set_url}\" target='_blank'>".unescapeTags($item{itemName})."</a>";
   }
   else {

--- a/_core/lib/sw2/view-arts.pl
+++ b/_core/lib/sw2/view-arts.pl
@@ -287,6 +287,7 @@ foreach my $set_url (split ',',$item_urls){
   if(exists$item{itemName}){
     $item{price} =~ s/[+＋]/<br>＋/;
     $item{category} =~ s/\s/<hr>/;
+    $item{itemName} = "〈$item{itemName}〉" if $item{itemName} !~ /〈.*〉/;
     push(@items, {
       "NAME"      => "<a href=\"$set_url\" target=\"_blank\">".unescapeTags($item{itemName})."</a>",
       "PRICE"     => unescapeTags($item{price}),


### PR DESCRIPTION
# 変更内容

流派装備の名称に山括弧 `〈〉` をつけるように。

# 仕様

元々の文字列に山括弧が含まれていない場合、全体を山括弧でくくる。

# 表示例

![image](https://github.com/user-attachments/assets/8ce54065-424d-4ee3-8f47-a0b9945c7e3e)

![image](https://github.com/user-attachments/assets/88d741ff-13d0-415c-a1e9-279ab7ddbb87)
