### PR TITLE
[SW2] 魔物のユニット出力に「弱点」を含める

### DIFF
--- a/_core/lib/sw2/json-sub.pl
+++ b/_core/lib/sw2/json-sub.pl
@@ -46,9 +46,10 @@ sub addJsonData {
     my $data1 = "知能:$pc{intellect}　知覚:$pc{perception}".($pc{mount}?'':"　反応:$pc{disposition}");
        $data1 .= "　穢れ:$pc{sin}" if $pc{sin};
     my $data2  = "言語:$pc{language}".($pc{mount}?'':"　生息地:$pc{habitat}");
-    my $data3  = "弱点:$pc{weakness}\n".($pc{mount}?'':"先制値:$pc{initiative}　")."生命抵抗力:${vitresist}　精神抵抗力:${mndresist}";
-    $pc{sheetDescriptionS} = $taxa."\n".$data3;
-    $pc{sheetDescriptionM} = $taxa."　".$data1."\n".$data2."\n".$data3;
+    my $data3  = $pc{unitStatusNotOutput} =~ /(?:^|,)弱点(?:,|$)/ ? "弱点:$pc{weakness}" : '';
+    my $data4  = ($pc{mount}?'':"先制値:$pc{initiative}　")."生命抵抗力:${vitresist}　精神抵抗力:${mndresist}";
+    $pc{sheetDescriptionS} = $taxa."\n".($data3 ne '' ? $data3."\n" : '').$data4;
+    $pc{sheetDescriptionM} = $taxa."　".$data1."\n".$data2."\n".($data3 ne '' ? $data3."\n" : '').$data4;
     
     if($pc{statusNum} > 1){ $pc{unitExceptStatus} = { 'HP'=>1,'MP'=>1,'防護'=>1 } }
   }

--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -61,6 +61,8 @@ sub createUnitStatus {
       push(@unitStatus, { 'MP' => "$mp/$mp" }) unless isEmptyValue($mp);
       push(@unitStatus, { '防護' => "$def" });
     }
+
+    push(@unitStatus, {'弱点' => $pc{weakness}}) if $pc{weakness};
   }
   else {
     @unitStatus = (


### PR DESCRIPTION
# 変更内容

魔物のユニット出力に「弱点」を含める。

# 目的

「弱点」は、ゲーム進行のうえでそれが参照（適用）される頻度が高い。
にもかかわらず、魔物ごとに異なる内容が設定されていることから、記憶しておくのは比較的むずかしく、現実的には、つど確認するような運用が多い。

そのような状況下で、確認をより容易におこなうため。

# 備考（2024-10-06 17:12追記）
_json-sub.pl_ への変更は、本件によって `unitStatus` 側に弱点が含まれたとき、ゆとチャadv.上で `sheetDescriptionS`, `sheetDescriptionM` と弱点の表記が重複してしまうのを防ぐためのもの。