### PR TITLE
[SW2] 騎獣の名称を隅付き括弧でくくる

### DIFF
--- a/_core/lib/sw2/calc-mons.pl
+++ b/_core/lib/sw2/calc-mons.pl
@@ -26,6 +26,7 @@ sub data_calc {
 
   ### newline --------------------------------------------------
   my $name = $pc{characterName} ? $pc{characterName} : $pc{monsterName};
+  $name = "【${name}】" if $name eq $pc{monsterName} && $pc{mount};
   $name =~ s/[|｜]([^|｜]+?)《.+?》/$1/g;
   $pc{hide} = 'IN' if(!$pc{hide} && $pc{description} =~ /#login-only/i);
   my $taxa = ($pc{mount} ? '騎獣／':'')

--- a/_core/skin/sw2/css/monster.css
+++ b/_core/skin/sw2/css/monster.css
@@ -103,6 +103,18 @@ article {
     font-size: 70%;
     line-height: 1;
   }
+
+  .mount & {
+    &:not(:has(.monster-name)) {
+      &::before {
+        content: "【";
+      }
+
+      &::after {
+        content: "】";
+      }
+    }
+  }
 }
 #area-name .taxa {
   position: absolute;

--- a/_core/skin/sw2/sheet-monster.html
+++ b/_core/skin/sw2/sheet-monster.html
@@ -89,7 +89,7 @@
       <div id="area-name" class="color-set">
         <TMPL_UNLESS mount><div class="lv"><TMPL_VAR lv></div></TMPL_UNLESS>
         <div class="name-taxa">
-          <h1><TMPL_IF characterName><TMPL_VAR characterName><TMPL_IF monsterName><small>（<TMPL_VAR monsterName>）</small></TMPL_IF><TMPL_ELSE><TMPL_VAR monsterName></TMPL_IF></h1>
+          <h1><TMPL_IF characterName><TMPL_VAR characterName><TMPL_IF monsterName><small class="monster-name">【<TMPL_VAR monsterName>】</small></TMPL_IF><TMPL_ELSE><TMPL_VAR monsterName></TMPL_IF></h1>
           <div class="taxa">分類：<TMPL_IF mount>騎獣／</TMPL_IF><TMPL_VAR taxa></div>
         </div>
       </div>


### PR DESCRIPTION
# 変更内容

騎獣の名称を隅付き括弧【】でくくる。

該当箇所は下記のふたつ：
- 各騎獣データの閲覧画面
- 魔物データ一覧の騎獣の部分

# 理由

公式文書ではそのような表現をされている。
（例：『Ⅲ』257・263頁，『エピックトレジャリー』150・154頁）

このことをかんがみ、見た目を公式文書に寄せる。

# 仕様

- 種族名を【】でくくる
- 個体名はくくらない

とした。

これは、【】は、定義のあるデータをあらわすニュアンスがつよいであろうことから、個体名をくくるのは不自然だろうと考えたことによる。

上記の挙動を実現するにあたって、一覧画面に対しては、**保存時**に括弧が付加されるようになっている。（個別のデータを保存したときに、一覧画面側に括弧が追加される）
これは、 _monslist.cgi_ に含まれている情報では種族名なのか個体名なのかを判別できないことによる。

# 表示例

**個別ページ・個体名なし**
![image](https://github.com/user-attachments/assets/07282b50-f257-4ab4-bfbd-bcdb53727dfd)

**個別ページ・個体名あり**
![image](https://github.com/user-attachments/assets/b18a67c9-b9ea-4a82-a2d5-b96d0e18af9a)

**一覧ページ**
![image](https://github.com/user-attachments/assets/239d7d21-f505-4bc1-bd75-e6eeed30abc6)
