### PR TITLE
表組みのセルを中央揃え／右揃えにする記法を追加

### DIFF
--- a/_core/lib/edit.pl
+++ b/_core/lib/edit.pl
@@ -654,6 +654,8 @@ sub textRuleArea {
         　　　　　　<code>|~テキスト|</code>のようにセル頭に~で見出しセルになります。<br>
         　　　　　　<code>|&gt;|テキスト|</code>のように&gt;単独で右のセルと結合します。<br>
         　　　　　　<code>|~|</code>のように~単独で上のセルと結合します。<br>
+        　　　　　　<code>|CENTER: セルの内容|</code>のようにセル頭に<code>CENTER:</code>で中央揃えになります。<br>
+        　　　　　　<code>|RIGHT: セルの内容|</code>のようにセル頭に<code>RIGHT:</code>で右揃えになります。<br>
         定義リスト：<code>:項目名|説明文</code><br>
         　　　　　　<code>:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|説明文2行目</code> 項目名を記入しないか、半角スペースで埋めると上と結合します。<br>
         折り畳み：行頭に<code>[>]項目名</code>：以降のテキストがすべて折り畳みになります。<br>

--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -609,14 +609,17 @@ sub generateTable {
     foreach my $col (@{$row}){
       my $rowspan = 1;
       my $td = 'td';
+      my @classes = ();
       while($data[$row_num+$rowspan][$col_num] eq '~'){ $rowspan++; }
       $col_num++;
       if   ($col eq '&gt;'){ $colspan++; next; }
       elsif($col eq '~')   { next; }
       elsif($col =~ s/^~//){ $td = 'th' }
+      elsif($col =~ s/^(LEFT|CENTER|RIGHT)://i){ push(@classes, 'align-' . lc($1)); }
       $output .= "<$td";
       if($colspan > 1){ $output .= ' colspan="'.$colspan.'"'; $colspan = 1; }
       if($rowspan > 1){ $output .= ' rowspan="'.$rowspan.'"'; }
+      $output .= ' class="' . join(' ', @classes) . '"' if $#classes >= 0;
       $output .= ">$col</$td>";
     }
     $output .= "</tr>";

--- a/_core/skin/_common/css/sheet.css
+++ b/_core/skin/_common/css/sheet.css
@@ -592,6 +592,14 @@ table.note-table {
   }
   & td {
     text-align: left;
+
+    &.align-center {
+      text-align: center;
+    }
+
+    &.align-right {
+      text-align: right;
+    }
   }
 }
 dl.note-description {


### PR DESCRIPTION
# 変更内容

表組みのセルを中央揃え／右揃えにする記法を追加。

# 記法

- セルの先頭に `CENTER:` とあれば中央揃えにする。
- セルの先頭に `RIGHT:` とあれば右揃えにする。

通常の（表組み外の）中央揃え／右揃えの記法と同様にした。
またこれは、 Pukiwiki の表組みの中央揃え／右揃えの記法と同様でもある。

なお、対称性のために `LEFT:` も解釈するコードにしてあるが、そもそもデフォルトで左揃えになっているため、 `LEFT:` と書こうが書くまいが閲覧画面での見た目には影響しない。

# 例

## 記述例
```
|~左揃え  |~中央揃え  |~右寄せ   |
|LEFT: XXX|CENTER: YYY|RIGHT: ZZZ|
```

## 表示例
![image](https://github.com/user-attachments/assets/863a23e7-fdab-4a14-adde-d9a5dea449d3)

# ヘルプ
ヘルプにも追加してある。

![image](https://github.com/user-attachments/assets/3c5882e4-775d-4baa-a9d6-91189bb6f3d1)
