### PR TITLE
[SW2] アイテムの地方特産品・流派（2.0版／アルフレイム／2.5テラスティア）アイコンを表現する記法を追加

### DIFF
--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -484,6 +484,8 @@ sub unescapeTags {
       $text =~ s/(\[[常準主補宣]\])+/&textToIcon($&);/egi;
       $text =~ s/「((?:[○◯〇△＞▶〆☆≫»□☐☑🗨]|&gt;&gt;)+)/"「".&textToIcon($1);/egi;
     }
+
+    $text =~ s|\[([特流アテ])\]|<i class="i-icon" data-kind="$1"><span class="raw">[$1]</span></i>|g;
   }
   
   

--- a/_core/lib/sw2.0/edit-chara.pl
+++ b/_core/lib/sw2.0/edit-chara.pl
@@ -1688,6 +1688,8 @@ my $text_rule = <<"HTML";
         　魔法のアイテム：<code>[魔]</code>：<img class="i-icon" src="${set::icon_dir}wp_magic.png"><br>
         　刃武器　　　　：<code>[刃]</code>：<img class="i-icon" src="${set::icon_dir}wp_edge.png"><br>
         　打撃武器　　　：<code>[打]</code>：<img class="i-icon" src="${set::icon_dir}wp_blow.png"><br>
+        　地方特産品　　：<code>[特]</code>：<i class="i-icon" data-kind="特"><span class="raw">[特]</span></i><br>
+        　流派装備　　　：<code>[流]</code>：<i class="i-icon" data-kind="流"><span class="raw">[流]</span></i><br>
         　常時型　　：<code>[常]</code>：<i class="s-icon passive  "><span class="raw">[常]</span></i><br>
         　主動作型　：<code>[主]</code>：<i class="s-icon major0   "><span class="raw">[主]</span></i><br>
         　補助動作型：<code>[補]</code>：<i class="s-icon minor0   "><span class="raw">[補]</span></i><br>

--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -438,7 +438,19 @@ my $text_rule = <<"HTML";
         　魔法のアイテム：<code>[魔]</code>：<img class="i-icon" src="${set::icon_dir}wp_magic.png"><br>
         　刃武器　　　　：<code>[刃]</code>：<img class="i-icon" src="${set::icon_dir}wp_edge.png"><br>
         　打撃武器　　　：<code>[打]</code>：<img class="i-icon" src="${set::icon_dir}wp_blow.png"><br>
+        　地方特産品　　：<code>[特]</code>：<i class="i-icon" data-kind="特"><span class="raw">[特]</span></i><br>
 HTML
+if ($::SW2_0) {
+$text_rule .= <<"HTML";
+        　流派装備　　　：<code>[流]</code>：<i class="i-icon" data-kind="流"><span class="raw">[流]</span></i><br>
+HTML
+}
+else {
+$text_rule .= <<"HTML";
+        　アルフレイム大陸由来の流派装備：<code>[ア]</code>：<i class="i-icon" data-kind="ア"><span class="raw">[ア]</span></i><br>
+        　テラスティア大陸由来の流派装備：<code>[テ]</code>：<i class="i-icon" data-kind="テ"><span class="raw">[テ]</span></i><br>
+HTML
+}
 print textRuleArea( $text_rule,'「効果」「備考」「由来・逸話など」' );
 
 print <<"HTML";

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -1796,6 +1796,9 @@ my $text_rule = <<"HTML";
         　魔法のアイテム：<code>[魔]</code>：<img class="i-icon" src="${set::icon_dir}wp_magic.png"><br>
         　刃武器　　　　：<code>[刃]</code>：<img class="i-icon" src="${set::icon_dir}wp_edge.png"><br>
         　打撃武器　　　：<code>[打]</code>：<img class="i-icon" src="${set::icon_dir}wp_blow.png"><br>
+        　地方特産品　　：<code>[特]</code>：<i class="i-icon" data-kind="特"><span class="raw">[特]</span></i><br>
+        　アルフレイム大陸由来の流派装備：<code>[ア]</code>：<i class="i-icon" data-kind="ア"><span class="raw">[ア]</span></i><br>
+        　テラスティア大陸由来の流派装備：<code>[テ]</code>：<i class="i-icon" data-kind="テ"><span class="raw">[テ]</span></i><br>
         　常時型　　：<code>[常]</code>：<i class="s-icon passive"><span class="raw">[常]</span></i><br>
         　戦闘準備型：<code>[準]</code>：<i class="s-icon setup  "><span class="raw">[準]</span></i><br>
         　主動作型　：<code>[主]</code>：<i class="s-icon major  "><span class="raw">[主]</span></i><br>

--- a/_core/lib/sw2/edit-item.pl
+++ b/_core/lib/sw2/edit-item.pl
@@ -255,7 +255,19 @@ my $text_rule = <<"HTML";
         　魔法のアイテム：<code>[魔]</code>：<img class="i-icon" src="${set::icon_dir}wp_magic.png"><br>
         　刃武器　　　　：<code>[刃]</code>：<img class="i-icon" src="${set::icon_dir}wp_edge.png"><br>
         　打撃武器　　　：<code>[打]</code>：<img class="i-icon" src="${set::icon_dir}wp_blow.png"><br>
+        　地方特産品　　：<code>[特]</code>：<i class="i-icon" data-kind="特"><span class="raw">[特]</span></i><br>
 HTML
+if ($::SW2_0) {
+$text_rule .= <<"HTML";
+        　流派装備　　　：<code>[流]</code>：<i class="i-icon" data-kind="流"><span class="raw">[流]</span></i><br>
+HTML
+}
+else {
+$text_rule .= <<"HTML";
+        　アルフレイム大陸由来の流派装備：<code>[ア]</code>：<i class="i-icon" data-kind="ア"><span class="raw">[ア]</span></i><br>
+        　テラスティア大陸由来の流派装備：<code>[テ]</code>：<i class="i-icon" data-kind="テ"><span class="raw">[テ]</span></i><br>
+HTML
+}
 print textRuleArea( $text_rule,'「効果」「解説」' );
 
 print <<"HTML";

--- a/_core/skin/_common/css/sheet.css
+++ b/_core/skin/_common/css/sheet.css
@@ -687,6 +687,19 @@ i.term-em {
   background-color: hsla(var(--box-base-bg-color-h,230),40%,70%,0.3);
 }
 
+
+/* アイコン内の生テキスト */
+.i-icon, .s-icon {
+  > .raw {
+    display: block;
+    position: absolute;
+    transform: scaleX(0.5) translateX(-1em);
+    text-wrap: nowrap;
+    color: transparent;
+    text-shadow: none;
+  }
+}
+
 /* アイテムアイコン */
 .i-icon {
   width: 1em;
@@ -704,15 +717,6 @@ i.term-em {
   font-style: normal;
   line-height: 1;
   vertical-align: text-bottom;
-
-  > .raw {
-    display: block;
-    position: absolute;
-    transform: scaleX(0.5) translateX(-1em);
-    text-wrap: nowrap;
-    color: transparent;
-    text-shadow: none;
-  }
 
   &::before,
   &::after {

--- a/_core/skin/sw2/css/icons.css
+++ b/_core/skin/sw2/css/icons.css
@@ -63,3 +63,101 @@
     .night &[data-color="白"]::before { color: #bbb; font-variation-settings: 'FILL' 1; }
   }
 }
+
+i.i-icon[data-kind] {
+  position: relative;
+  font-style: normal;
+  vertical-align: 0.25em;
+  margin: 0 0.15em;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  --main-color: var(--text-color);
+  --reversed-color: var(--bg-color);
+  --reversed-color-half: var(--input-bg-color);
+
+  > .raw {
+    transform: scaleX(0.5);
+  }
+
+  &::before {
+    font-size: 60%;
+    content: attr(data-kind);
+    line-height: 100%;
+    color: var(--main-color)
+  }
+
+  &[data-kind="特"],
+  &[data-kind="流"] {
+    .night & {
+      --main-color: var(--bg-color);
+      --reversed-color: var(--text-color);
+    }
+
+    background-color: var(--main-color);
+
+    &::before {
+      color: var(--reversed-color);
+    }
+  }
+
+  &[data-kind="特"] {
+    border-radius: 0.15em;
+
+    .night & {
+      border: 1px solid var(--main-color);
+    }
+
+    &::before {
+      font-weight: normal;
+      font-size: 65%;
+      margin-top: 1px;
+    }
+  }
+
+  &[data-kind="流"] {
+    vertical-align: 0.3em;
+    border-radius: 0.5em;
+    border-width: 3px;
+    border-style: double;
+
+    &::before {
+      font-size: 55%;
+    }
+  }
+
+  &[data-kind="ア"],
+  &[data-kind="テ"] {
+    border: 1px solid var(--main-color);
+    border-radius: 0.15em;
+
+    &[data-kind="ア"] {
+      border-width: 4px;
+      border-style: groove;
+
+      .night & {
+        border-style: ridge;
+      }
+
+      &::before {
+        text-shadow: 1px 1px 0 var(--reversed-color-half);
+      }
+    }
+
+    &[data-kind="テ"] {
+      &::before {
+        font-size: 65%;
+        margin-top: 1px;
+      }
+    }
+
+    &::before {
+      font-weight: bold;
+    }
+  }
+
+  #text-rule & {
+    font-size: 120%;
+    top: 0.2em;
+  }
+}


### PR DESCRIPTION
# 変更内容

SW2.x の、アイテムの地方特産品・流派（2.0版／アルフレイム／2.5テラスティア）アイコンを表現する記法を追加。

# 記法
刃武器／打撃武器の記法と似た構造にした。

## 地方特産品
`[特]`

公式文書での定義⇒『ルミエルレガシィ』20頁

## 流派

### 2.0版（大陸の区別がないもの）
`[流]`

公式文書での定義⇒『ルミエルレガシィ』20頁

### アルフレイム大陸の流派
`[ア]`

公式文書での定義⇒『バトルマスタリー』80頁

### テラスティア大陸の流派（2.5においてテラスティア由来であることを明示するためのもの）
`[テ]`

公式文書での定義⇒『バトルマスタリー』80頁

# 利用例

※ `[魔]` はサイズ比較用

## 入力
```
[魔][特][流][ア][テ]
```

## 出力（閲覧画面）

### ライトテーマ
![image](https://github.com/user-attachments/assets/b2a84d21-952a-4154-8cf9-e40481077872)

### ダークテーマ
![image](https://github.com/user-attachments/assets/862cff2a-fed5-4e4d-8e45-b77d4b23bade)



# ヘルプ

2.5 と 2.0 で分けてある。

なお、利用自体はどこでもできるが、 `[刃]` `[打]` に倣って、魔物シートのヘルプには載せていない。

## 2.5
![image](https://github.com/user-attachments/assets/ed1e8ebc-a2ab-40fd-bdd8-f8f3f96f7c53)

## 2.0
![image](https://github.com/user-attachments/assets/179e5f2b-2611-417f-830a-edbec991bc44)
