### PR TITLE
Fix: [SW2] 魔物データが攻撃能力のない部位を有するときに余計な空行がチャットパレットに出力されないように

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -498,7 +498,7 @@ sub palettePreset {
       $weapon = "／$weapon" if $weapon ne '';
       $text .= "2d+{命中$_}+{命中修正} 命中力$weapon\n" if $::pc{'status'.$_.'Accuracy'} ne '';
       $text .= "{ダメージ$_}+{打撃修正} ダメージ".$weapon."\n" if $::pc{'status'.$_.'Damage'} ne '';
-      $text .= "\n";
+      $text .= "\n" if $::pc{'status'.$_.'Accuracy'} ne '' || $::pc{'status'.$_.'Damage'} ne '';
     }
     my $skills = $::pc{skills};
     $skills =~ tr/０-９（）/0-9\(\)/;


### PR DESCRIPTION
# 変更内容

魔物データが攻撃能力のない部位を有するとき、それに由来する余計な空行がチャットパレットに出力されないように

## 具体例
『モンストラスロア』160頁「ドムズヴァー」のような魔物データがあるとき、

![image](https://github.com/user-attachments/assets/c008bcfe-7975-44ad-9eb5-11cd6248eac1)

上のような部位データから、

![image](https://github.com/user-attachments/assets/ae97416b-fcfa-4679-b9f1-dac3cd2618f9)

上のようなチャットパレットが生成されていた。

これをよく見ると、攻撃能力をもたない部位のところに、余計な空行（改行）が発生していた。
この余計な空行（改行）が発生しないようにする。