### PR TITLE
Fix: [SW2] 魔物の特殊能力の末尾に見出しのみの能力がある場合、そのチャットパレットが生成されない不具合を修正

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -527,8 +527,10 @@ sub palettePreset {
         )
         (?<other>.+?)
       )
+      (?:
       \s
       (?<note>[\s\S]*?)
+      )?
       (?=^$skill_mark|^●|\z)
       /
       $text .= convertMark($+{mark})."$+{name}／$+{fix}$+{other}\n"


### PR DESCRIPTION
# 現象
魔物の特殊能力欄の末尾に、見出しのみの能力がある場合、それに対応するチャットパレットが出力されない。

## 例

再現サンプル：
https://yutorize.2-d.jp/ytsheet/sw2.5/?id=YQhOyS

### 特殊能力の入力内容
```
▶砂塵のブレス／11（18）／生命抵抗力／半減

▶氷雪のブレス／12（19）／生命抵抗力／半減

▶火炎のブレス／13（20）／生命抵抗力／半減
```

### 生成されるチャットパレット
```
//生命抵抗修正=0
//精神抵抗修正=0
//回避修正=0
生命抵抗力 2d++{生命抵抗修正}
精神抵抗力 2d++{精神抵抗修正}

//命中修正=0
//打撃修正=0
ダメージ 2d++{打撃修正}

[主]砂塵のブレス／18／生命抵抗力／半減
[主]砂塵のブレス／生命抵抗力／半減 2d+11

[主]氷雪のブレス／19／生命抵抗力／半減
[主]氷雪のブレス／生命抵抗力／半減 2d+12

### ■パラメータ

```

※「火炎のブレス」に対応するチャットパレットが生成されていない