### PR TITLE
[SW2] 騎獣リストにおいて、購入／レンタルそれぞれの価格の定義がないものは `―` として表示する

### DIFF
--- a/_core/lib/sw2/list-mons.pl
+++ b/_core/lib/sw2/list-mons.pl
@@ -214,6 +214,9 @@ foreach (@list) {
     $image, $tags, $hide, $parts, $habitat, $price
   ) = (split /<>/, $_)[0..19];
   
+  $price =~ s#^／#―／#;
+  $price =~ s#／$#／―#;
+  
   #グループ
   my $taxa_full = $taxa =~ s/^その他://r;
   $taxa_full = "<span class=\"small\">$taxa_full</span>" if length($taxa_full) >= 6;

--- a/_core/lib/sw2/list-mons.pl
+++ b/_core/lib/sw2/list-mons.pl
@@ -214,9 +214,6 @@ foreach (@list) {
     $image, $tags, $hide, $parts, $habitat, $price
   ) = (split /<>/, $_)[0..19];
   
-  $price =~ s#^／#―／#;
-  $price =~ s#／$#／―#;
-  
   #グループ
   my $taxa_full = $taxa =~ s/^その他://r;
   $taxa_full = "<span class=\"small\">$taxa_full</span>" if length($taxa_full) >= 6;
@@ -244,6 +241,10 @@ foreach (@list) {
   ){
     next;
   }
+
+  # 価格
+  $price =~ s#^／#―／#;
+  $price =~ s#／$#／―#;
 
   #タグ
   my $tags_links;


### PR DESCRIPTION
# 変更内容

騎獣リストにおいて、「購入」「レンタル」それぞれの価格の定義がないものは `―` として表示するように。

# 背景

従来は単純に空文字列のまま表示され、結果として下の画像のようになっていた。

![image](https://github.com/user-attachments/assets/1e95d623-9e47-49b4-9e1e-9d3a280f470f)

これはあきらかに不自然で、記入漏れや誤植、ないしは表示の誤りなどを疑いかねない。

なので、なんらかの「購入・レンタルができないこと」を示す表現に改める必要があった。

~~`―` のように表示することも考えたが、購入またはレンタルの価格が入力されないケースはおそらくそれを実行させないケースなので、 `不可` のほうが実態に則している……ような気がする。~~
~~`不可` だとたくさん並んだときの圧がつよいので、やっぱり `―` のほうが無難かもしれない。（でも記入のない騎獣データがそんなに大量に並ぶこともないかもしれない）~~

ゆと工公式にある騎獣データをざっと眺めたかぎり、価格が記入されていないケースは、「単純な記入漏れっぽい」「ルールブック記載の内容と同一なので省略された」「専有騎獣のデータなので購入した前提で購入価格のみを記入してレンタル価格を空欄にする」などがあるもよう。

# 表示例
![image](https://github.com/user-attachments/assets/bdd916f3-e03e-4f24-aa3c-f23784b2d06b)

