### PR TITLE
[SW2] Fix: 魔法／神格／流派シートの編集画面において、ヘッダメニュー内の表記をデータ種別に応じて変化させる

### DIFF
--- a/_core/lib/sw2/edit-arts.js
+++ b/_core/lib/sw2/edit-arts.js
@@ -66,6 +66,20 @@ function checkCategory(){
     setName();
   }
   else { document.getElementById('data-none').style.display = 'block'; }
+
+  let sheetKind;
+  switch (category) {
+    case 'magic':
+      sheetKind = "魔法";
+      break;
+    case 'god':
+      sheetKind = '神格';
+      break;
+    case 'school':
+      sheetKind = '流派';
+      break;
+  }
+  document.querySelector('#header-menu .menu-items > .sheet-main .sheet-kind').textContent = sheetKind ?? '';
 }
 
 // 魔法系統 ----------------------------------------

--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -149,8 +149,8 @@ print <<"HTML";
             
       <div id="header-menu">
         <h2><span></span></h2>
-        <ul>
-          <li onclick="sectionSelect('common');"><span>魔法</span><span>データ</span>
+        <ul class="menu-items">
+          <li onclick="sectionSelect('common');" class="sheet-main"><span class="sheet-kind"></span><span>データ</span>
           <li onclick="sectionSelect('color');" class="color-icon" title="カラーカスタム">
           <li onclick="view('text-rule')" class="help-icon" title="テキスト整形ルール">
           <li onclick="nightModeChange()" class="nightmode-icon" title="ナイトモード切替">


### PR DESCRIPTION
従来は、データの種別にかかわらず常に「魔法データ」と表示されていた。
![image](https://github.com/user-attachments/assets/f9855e2b-ac2b-4af7-a0d5-9e03763f4fb2)

魔法データを選択していない状態では、これは事実に反するので、選択状況に応じて当該箇所のテキストが変化するように。

- 未選択状態：（修飾なしの）`データ`
- 魔法： `魔法データ`
- 神格： `神格データ`
- 流派： `流派データ`