### PR TITLE
[SW2] 武器／装飾品による回避力／防護点の上昇を機械的に解決する記法を追加

### DIFF
--- a/_core/lib/sw2.0/edit-chara.pl
+++ b/_core/lib/sw2.0/edit-chara.pl
@@ -982,6 +982,7 @@ print <<"HTML";
           </table>
           <ul class="annotate">
             <li>Ｃ値は自動計算されません。
+            <li><code>\@防護点+1</code>や<code>\@回避力+1</code>のように記述すると、<span class="text-em">常時</span>有効な上昇効果が自動計算されます。
             <li id="artisan-annotate" @{[ display $pc{masteryArtisan} ]}>※備考欄に<code>〈魔器〉</code>と記入すると魔器習熟が反映されます。
           </ul>
           <div class="add-del-button"><a onclick="addWeapons()">▼</a><a onclick="delWeapons()">▲</a></div>
@@ -1234,7 +1235,7 @@ foreach (
         <option value="HP" @{[ $pc{"accessory@$_[1]Own"} eq 'HP' ? 'selected':'']}>HP</option>
         <option value="MP" @{[ $pc{"accessory@$_[1]Own"} eq 'MP' ? 'selected':'' ]}>MP</option>
       </select>
-    <td>@{[input('accessory'.@$_[1].'Note')]}
+    <td>@{[input('accessory'.@$_[1].'Note','','calcDefense')]}
 HTML
 }
 print <<"HTML";
@@ -1242,6 +1243,7 @@ print <<"HTML";
           </table>
         <ul class="annotate">
           <li>左のボックスにチェックを入れると欄が一つ追加されます
+          <li><code>\@防護点+1</code>のように記述すると、<span class="text-em">常時</span>有効な防護点の上昇が自動計算されます
         </ul>
         </div>
       </div>

--- a/_core/lib/sw2/calc-chara.pl
+++ b/_core/lib/sw2/calc-chara.pl
@@ -604,6 +604,14 @@ sub data_calc {
 
   
   ## 回避力・防護点
+  my @modifications = @{extractModifications(\%pc)};
+  my $evasionModificationTotal = 0;
+  my $defenseModificationTotal = 0;
+  foreach (@modifications) {
+    my %mod = %{$_};
+    $evasionModificationTotal += $mod{evasion} // 0;
+    $defenseModificationTotal += $mod{defense} // 0;
+  }
   foreach my $i (1..$pc{defenseNum}){
     my $class = $pc{"evasionClass$i"};
     my $id = $data::class{$class}{id};
@@ -666,6 +674,9 @@ sub data_calc {
     }
     $eva += $lv ? $lv + int(($agi+$own_agi)/6) : 0;
     $def += $artisan;
+    
+    $eva += $evasionModificationTotal;
+    $def += $defenseModificationTotal;
     
     $pc{"defenseTotal${i}Eva"} = $eva;
     $pc{"defenseTotal${i}Def"} = $def;

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1489,6 +1489,8 @@ function calcWeapon() {
       document.getElementById("weapon"+i+"-dmg-total").textContent = dmgBase + Number(form["weapon"+i+"Dmg"].value);
     }
   }
+
+  calcDefense(); // 武器由来の回避力・防護点の再計算
 }
 
 // 防御計算 ----------------------------------------
@@ -1564,6 +1566,38 @@ function calcDefense() {
   // 部位即応
   document.getElementById("parts-enhance-def").style.display = crafts['部位極強化'] || crafts['部位超強化'] || crafts['部位即応＆強化'] ? '' : 'none';
   document.getElementById("parts-enhance-eva").textContent = (crafts['部位極強化']?1:0)+(crafts['部位超強化']?1:0)+(crafts['部位即応＆強化']?1:0);
+  
+  // 武器と装飾品
+  document.querySelectorAll(':is(#weapons-table, #accessories-table) input[name$="Note"]').forEach(
+      input => {
+        const note = input.value ?? '';
+
+        if (input.getAttribute('name').includes('_')) {
+          // 拡張枠は有効化されていなければ無視する
+
+          const nameToAdd = input.getAttribute('name').replace('_Note', 'Add');
+          if (!document.getElementsByName(nameToAdd)[0].checked) {
+            return;
+          }
+        }
+
+        {
+          const m = note.match(/[@＠]防(?:護点?)?[+＋](\d+)/);
+
+          if (m != null) {
+            defBase += parseInt(m[1]);
+          }
+        }
+
+        {
+          const m = note.match(/[@＠]回避力?[+＋](\d+)/);
+
+          if (m != null) {
+            evaAdd += parseInt(m[1]);
+          }
+        }
+      }
+  );
   
   calcArmour(evaAdd,defBase);
 }
@@ -1860,6 +1894,8 @@ function addAccessory(name){
   else {
     document.querySelector(`#accessories [data-type="${name}_"]`).style.display = 'none';
   }
+
+  calcDefense(); // 装飾品由来の回避力・防護点の再計算
 }
 // ソート
 (() => {

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -983,6 +983,7 @@ print <<"HTML";
           <div class="add-del-button"><a onclick="addWeapons()">▼</a><a onclick="delWeapons()">▲</a></div>
           <ul class="annotate">
             <li>Ｃ値は自動計算されません。
+            <li><code>\@防護点+1</code>や<code>\@回避力+1</code>のように記述すると、<span class="text-em">常時</span>有効な上昇効果が自動計算されます。
             <li id="artisan-annotate" @{[ display $pc{masteryArtisan} ]}>備考欄に<code>〈魔器〉</code>と記入すると魔器習熟が反映されます。
           </ul>
           @{[input('weaponNum','hidden')]}
@@ -1231,13 +1232,16 @@ foreach (
         <option value="HP" @{[ $pc{"accessory@$_[1]Own"} eq 'HP' ? 'selected':'']}>HP</option>
         <option value="MP" @{[ $pc{"accessory@$_[1]Own"} eq 'MP' ? 'selected':'' ]}>MP</option>
       </select>
-    <td>@{[input('accessory'.@$_[1].'Note')]}
+    <td>@{[input('accessory'.@$_[1].'Note','','calcDefense')]}
 HTML
 }
 print <<"HTML";
           </tbody>
           </table>
-          <ul class="annotate"><li>左のボックスにチェックを入れると欄が一つ追加されます</ul>
+          <ul class="annotate">
+            <li>左のボックスにチェックを入れると欄が一つ追加されます
+            <li><code>\@防護点+1</code>のように記述すると、<span class="text-em">常時</span>有効な防護点の上昇が自動計算されます
+          </ul>
         </div>
       </div>
       <div id="area-items">

--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -143,6 +143,83 @@ sub fairyRank {
   return $rank{$i}[$lv] || '×';
 }
 
+### 補正値記法の解釈 --------------------------------------------------
+sub extractModifications {
+  my %pc = %{shift;};
+
+  my @modifications = ();
+
+  sub extractModification {
+    my $name = shift;
+    my $note = shift;
+
+    my $evasion;
+    my $defense;
+
+    if ($note =~ s/[\@＠]回避力?[+＋](\d+)//) {
+      $evasion = $1;
+    }
+
+    if ($note =~ s/[\@＠]防(?:護点?)?[+＋](\d+)//) {
+      $defense = $1;
+    }
+
+    unless ($evasion || $defense) {
+      return {};
+    }
+
+    return {
+        name    => $name,
+        evasion => $evasion // 0,
+        defense => $defense // 0,
+    };
+  }
+
+  foreach (1 .. $pc{weaponNum}) {
+    my $nameKey = "weapon${_}Name";
+    my $noteKey = "weapon${_}Note";
+
+    my $name = $pc{$nameKey} // '';
+    my $note = $pc{$noteKey} // '';
+
+    $name = $name ne '' ? $name : '武器';
+
+    my %modification = %{extractModification($name, $note)};
+    next unless %modification;
+
+    push(@modifications, \%modification);
+  }
+
+  for my $slot ('Head', 'Face', 'Ear', 'Neck', 'Back', 'HandR', 'HandL', 'Waist', 'Leg', 'Other', 'Other2', 'Other3', 'Other4') {
+    for my $suffix ('', '_', '__') {
+      my $nameKey = "accessory${slot}${suffix}Name";
+      my $noteKey = "accessory${slot}${suffix}Note";
+
+      if ($suffix ne '') {
+        # 拡張枠は有効化されていなければ無視する
+
+        my $addingKey = "accessory${slot}${suffix}";
+        $addingKey =~ s/_$//;
+        $addingKey .= 'Add';
+
+        next unless $pc{$addingKey};
+      }
+
+      my $name = $pc{$nameKey} // '';
+      my $note = $pc{$noteKey} // '';
+
+      $name = $name ne '' ? $name : '装飾品';
+
+      my %modification = %{extractModification($name, $note)};
+      next unless %modification;
+
+      push(@modifications, \%modification);
+    }
+  }
+
+  return \@modifications;
+}
+
 ### バージョンアップデート --------------------------------------------------
 sub data_update_chara {
   my %pc = %{$_[0]};

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -899,13 +899,11 @@ else {
     if (@$_[1] =~ /_$/) {
       next unless $pc{'accessory'.substr(@$_[1],0,-1).'Add'};
     }
-    my $name = formatItemName($pc{'accessory'.@$_[1].'Name'});
-    my $note = $pc{'accessory'.@$_[1].'Note'};
     push(@accessories, {
       TYPE => @$_[0],
-      NAME => $name,
+      NAME => $pc{'accessory'.@$_[1].'Name'},
       OWN  => $pc{'accessory'.@$_[1].'Own'},
-      NOTE => replaceModificationNotation $note,
+      NOTE => replaceModificationNotation $pc{'accessory'.@$_[1].'Note'},
     } );
   }
   $SHEET->param(Accessories => \@accessories);

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -765,6 +765,30 @@ dl#level {
   }
 }
 
+/* // modifications
+---------------------------------------------------------------------------------------------------- */
+#weapons,
+#accessories {
+  .data-table tbody td {
+    span.modification {
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      font-size: 90%;
+      height: 1.6em;
+      background-color: rgb(210, 210, 210);
+      border: 1px dotted rgb(190, 190, 190);
+      border-radius: 0.8em;
+      padding: 0 0.6em;
+
+      .night & {
+        background-color: rgb(46, 46, 46);
+        border-color: rgb(66, 66, 66);
+      }
+    }
+  }
+}
+
 /* // Area-Equipment
 ---------------------------------------------------------------------------------------------------- */
 #area-equipment {


### PR DESCRIPTION
# 変更内容

「武器または装飾品による、回避力または防護点の上昇」を機械的に解決する記法を追加
（なに言ってるのかよくわからなかったら、一番下にある「例」を見てください）

# 経緯

これまでは、回避力および防護点の算出において、「防具でも定義済みで自動計算されるもの（種族特徴や戦闘特技など）でもないもの」を機械的に取り扱う真っ当な方法がなかった。
（防具の一種として記入するような、強引な方法はあった）

しかし、（本質的に一時的効果である練技や賦術などはともかく、）武器や装飾品がもつ常在的な効果は、実際のゲームプレイ上ではほぼ常に適用されるものとみなしてよいケースが多い。
（わかりやすい一例として〈ブラックベルト〉（⇒『エピックトレジャリー』147頁を取り上げると、このアイテムをプレイ中に着脱するような運用をすることは非常に稀である）

このような、“実質的には常時効果として計算してしまっても（まあ防具と同じくらいには）問題がない”ものを取り扱えるようにしたい。
（防具の一種として強引に記入する場合、武器や装飾品の欄と防具欄とで、重複記入になるという問題もあったので、それも避けたかった）

なお、種族特徴によって装飾品の変更が容易な「レプラカーン」で起こるような、現実的に着脱を想定したキャラクター（運用）の場合には、この機能をもちいずに従来どおりの（＝シート外での）管理をする、という想定である。

## 該当するゲームデータ

| 区分 | 回避力 | 防護点 |
|-|-|-|
| 武器    |〈マンゴーシュ〉|〈クォータースタッフ〉等|
| 装飾品 | 該当なし             |〈ブラックベルト〉等|

回避力判定への恒常的な恩恵は、防護点のそれとくらべると稀であるが、〈マンゴーシュ〉（⇒『エピックトレジャリー』114頁）という実例があることと、ゆとシート上ではひとまとめに表示されていることから、対称性も考慮して対応している。

# 仕様

武器または装飾品の備考欄に、特定の記法が含まれている場合、それを回避力・防護点への恒常的な変更として反映する。

## 記法

いずれも `n` は自然数を想定している。

`@＊＊+n` というかたちをとったのは、ゆとチャadv.のステータス操作コマンドをすこし意識している。

### 回避力
`@回避力+n`

省略形として、 `@回避+n` も許容する。

### 防護点
`@防護点+n`

省略形として、 `@防護+n`, `@防+n` も許容する。

# 例

## 記入例
![image](https://github.com/user-attachments/assets/77a7ed85-1da7-400c-ba44-28a44e11d0c7)

編集画面では、（［鱗の皮膚］の下あたりに）具体的な名称・値を反映していない。
これは、反映しようとすると、そこのリストの長さが変わることになり、（武器はまだしも）そこよりも下にある装飾品を編集するうえでわずらわしい、という問題を考慮したため。

## 表示例
![image](https://github.com/user-attachments/assets/17134dea-df8e-4cff-acd1-a97955fd53c6)
