### PR TITLE
[SW2] 秘伝の「使用」欄に入力候補を提供

### DIFF
--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -378,7 +378,7 @@ print <<"HTML";
             <dl class="type    "><dt>タイプ    <dd>@{[ input "schoolArts${num}Type",'','','list="list-arts-type"' ]}</dl>
             <dl class="premise "><dt>前提      <dd>@{[ input "schoolArts${num}Premise",'','','list="list-arts-base"' ]}</dl>
             <dl class="equip   "><dt>限定条件  <dd>@{[ input "schoolArts${num}Equip" ]}</dl>
-            <dl class="use     "><dt>使用      <dd>@{[ input "schoolArts${num}Use" ]}</dl>
+            <dl class="use     "><dt>使用      <dd>@{[ input "schoolArts${num}Use",'','','list="list-arts-use"' ]}</dl>
             <dl class="apply   "><dt>適用      <dd>@{[ input "schoolArts${num}Apply",'','','list="list-arts-apply"' ]}</dl>
             <dl class="risk    "><dt>リスク    <dd>@{[ input "schoolArts${num}Risk",'','','list="list-arts-risk"' ]}</dl>
             <dl class="summary "><dt>概要      <dd>@{[ input "schoolArts${num}Summary" ]}</dl>
@@ -584,6 +584,20 @@ print <<"HTML";
     <option value="主動作型">
     <option value="《》変化型">
     <option value="独自宣言型">
+  </datalist>
+  <datalist id="list-arts-use">
+    <option value="ファイター技能">
+    <option value="グラップラー技能">
+    <option value="フェンサー技能">
+    <option value="バトルダンサー技能">
+    <option value="ファイター技能 or バトルダンサー技能">
+    <option value="ファイター技能 or フェンサー技能 or バトルダンサー技能">
+    <option value="フェンサー技能 or バトルダンサー技能">
+    <option value="シューター技能">
+    <option value="近接攻撃武器">
+    <option value="魔法使い系技能">
+    <option value="特殊">
+    <option value="―">
   </datalist>
   <datalist id="list-arts-apply">
     <option value="1回の武器攻撃">


### PR DESCRIPTION
具体的な内容は、『バトルマスタリー』掲載流派をふまえて、以下の考えのもとに用意した。

## 単一の戦士系技能

- ファイター技能
- グラップラー技能
- フェンサー技能
- バトルダンサー技能
- シューター技能

「フェンサー技能」「バトルダンサー技能」については、『バトルマスタリー』内にこれらの単一の技能を要求する秘伝は存在しないが、対称性の観点と、“特定の技能での利用を前提とした流派”というのはごく自然に作成されるだろうと想定されることから、用意してある。

## 複数の戦士系技能

- ファイター技能 or バトルダンサー技能
- ファイター技能 or フェンサー技能 or バトルダンサー技能
- フェンサー技能 or バトルダンサー技能

いずれも『バトルマスタリー』内に存在する。

「ファイター技能 or バトルダンサー技能」は、“重い武器をあつかうような秘伝”が想定される。実例は《激怒セシ熊ノ一撃》（⇒『バトルマスタリー』43頁）など。

「ファイター技能 or フェンサー技能 or バトルダンサー技能」は、“通常の近接武器をあつかう秘伝一般”というニュアンス。実例は《怒レル熊ノ一撃》（⇒『バトルマスタリー』43頁）など。

「フェンサー技能 or バトルダンサー技能」は、“身軽な戦士があつかう秘伝”が想定される。実例は《見えざる敵に苛立て》（⇒『バトルマスタリー』65頁）など。

## 近接攻撃武器

【スホルテン騎乗戦技】（⇒『バトルマスタリー』61頁）の秘伝に見られる。

「ファイター技能 or フェンサー技能 or バトルダンサー技能」と書くのと何が違うのかいまいち定かではないが、同流派はライダー技能を念頭においたものであり具体的な戦士系技能の名称を挙げるよりも「近接攻撃武器」としたほうが直感的っぽいことと、戦士系技能をもたない騎手が当該秘伝をもちいる場合（※それでも騎獣に恩恵がある）が考慮されているのではないかと思われる。

## 魔法使い系技能

魔法にかかわる戦闘特技や秘伝において、ごく一般的に見られるもの。

## 特殊

実例は《乱風・双手分撃》（⇒『バトルマスタリー』66頁）。
なくてもいいような気はするが、あってもいいような気がしている。

## `―`

技能を格別に限定しないものや、技能との関わりをもたない性質のものなど。