### PR TITLE
[DX3] ヴィークルの「種別」に入力候補を提供

### DIFF
--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -1327,6 +1327,10 @@ print <<"HTML";
     <option value="エンブレム／防具（補助）">
     <option value="リレーション／防具">
   </datalist>
+  <datalist id="list-vehicle-type">
+    <option value="ヴィークル">
+    <option value="エンブレム／ヴィークル">
+  </datalist>
   <datalist id="list-item-type">
     <option value="コネ">
     <option value="一般">


### PR DESCRIPTION
_input_ 側の _list_ 属性はなぜか元から記述されていたので、 _datalist_ を追加したのみ