### PR TITLE
[SW2] 魔物データのコア部位入力欄において、部位内訳にもとづく入力候補を提供する

### DIFF
--- a/_core/lib/sw2/edit-mons.js
+++ b/_core/lib/sw2/edit-mons.js
@@ -5,6 +5,7 @@ window.onload = function() {
   setName();
   rewriteMountLevel();
   updatePartsAutomatically();
+  updatePartList();
   selectInputCheck(form.taxa,'その他')
   checkMount();
 
@@ -317,6 +318,33 @@ function updatePartsAutomatically() {
       }
   );
   partsNamesInput.dispatchEvent(new Event('input'));
+}
+function updatePartList() {
+  const partsText = document.querySelector('input[name="parts"]').value.trim();
+
+  const items =
+      partsText
+          .split(/[/／]/)
+          .map(x => x.trim())
+          .filter(x => x !== '')
+          .map(part => part.replace(/[*×][\d０１２３４５６７８９]+$/, '（すべて）'));
+
+  const datalist = document.getElementById('list-of-core-part');
+  datalist.innerHTML = '';
+
+  if (items.length === 0) {
+    return;
+  }
+
+  items.unshift("なし");
+
+  items.forEach(
+      item => {
+        const option = document.createElement('option');
+        option.textContent = item;
+        datalist.appendChild(option);
+      }
+  );
 }
 
 // 戦利品欄 ----------------------------------------

--- a/_core/lib/sw2/edit-mons.pl
+++ b/_core/lib/sw2/edit-mons.pl
@@ -353,8 +353,9 @@ print <<"HTML";
       </div>
       <div class="box parts in-toc" data-content-title="部位数・コア部位">
         @{[ checkbox 'partsManualInput', '部位数と内訳を手動入力する', 'updatePartsAutomatically' ]}
-        <dl><dt>部位数<dd>@{[ input 'partsNum','number','','min="1"' ]} (@{[ input 'parts' ]}) </dl>
-        <dl><dt>コア部位<dd>@{[ input 'coreParts' ]}</dl>
+        <dl><dt>部位数<dd>@{[ input 'partsNum','number','','min="1"' ]} (@{[ input 'parts','','updatePartList' ]}) </dl>
+        <dl><dt>コア部位<dd>@{[ input 'coreParts','','','list="list-of-core-part"' ]}</dl>
+        <datalist id="list-of-core-part"></datalist>
       </div>
       <div class="box">
         <h2 class="in-toc">特殊能力</h2>


### PR DESCRIPTION
# 変更内容

コア部位の入力欄において、部位内訳にもとづいて入力候補を提供する

# 目的

大多数の場合、コア部位は部位内訳に含まれるいずれかの部位に相当する字句となるはずなので、（すでに別途入力されているはずの）部位内訳を利用して、コア部位の入力を省力化したい

# 仕様

基本的には、部位内訳の入力内容を `／` で分割し、その各項を入力候補とする。

このとき、同名の部位が複数あった場合（例： `翼×2` など）は、その部位名＋ `（すべて）` のかたちで入力候補とする。（複数ある部位がコア部位とされるとき、たいていの場合は“すべて”であることから）

また、コア部位をもたない魔物を考慮して、 `なし` という候補も提供する。

以下の「具体例」も参照のこと。

# 具体例

## 重複のない部位構成の場合

「スカイホエール」（⇒『モンストラスロア』112頁）

- 部位内訳：頭部／胴体／尾びれ
- 入力候補：
  - なし
  - 頭部
  - 胴体
  - 尾びれ
- 実際のコア部位：頭部

## 重複のある部位構成の場合

### ①：当該部位はコア部位ではない場合

「ドラゴネット」（⇒『モンストラスロア』175頁）

- 部位内訳：胴体／翼×2
- 入力候補：
  - なし
  - 胴体
  - 翼（すべて）
- 実際のコア部位：胴体

### ②：当該部位がコア部位である場合

「ケルベロス」（⇒『モンストラスロア』203頁）

- 部位内訳：頭部×3／胴体
- 入力候補：
  - なし
  - 頭部（すべて）
  - 胴体
- 実際のコア部位：頭部（すべて）

## 実際のコア部位が入力候補に含まれない場合

これらのような場合は、手動で入力するしかない

### ①：部位名と完全には一致しない、包括的な表現がもちいられる場合

「キマイラ」（⇒『モンストラスロア』173頁）

- 部位内訳：獅子頭／山羊頭／竜頭／胴体／翼
- 入力候補：
  - なし
  - 獅子頭
  - 山羊頭
  - 竜頭
  - 胴体
  - 翼
- 実際のコア部位：頭（すべて）

※『モンストラスロア』時点で該当するのは「キマイラ」のみであり、きわめて稀

### ②：名称の異なる複数の部位の“すべて”をコア部位とする場合

「グリーントーチ」（⇒『モンストラスロア』125頁）

- 部位内訳：根／雄しべ／花弁×6
- 入力候補：
  - なし
  - 根
  - 雄しべ
  - 花弁（すべて）
- 実際のコア部位：根、雄しべ（すべて）

※『モンストラスロア』時点で該当するのは「グリーントーチ」「ドラゴンゾンビ」「エルトリアス」の三種のみであり、かなり稀（『アーケインレリック』掲載のボス級魔物にも該当が一種いるが、これは「エルトリアス」の亜種）

### ③：コア部位が「特殊」とされる場合

『モンストラスロア』時点で該当するのは「カースドアーティスト」（⇒同書139頁）のみであり、きわめて稀

### ④：複数の部位を指定しつつ“すべて”ではない場合

『Ⅰ』428頁に、「複数が書かれているだけの場合」としてルール定義が存在する。
……が、『モンストラスロア』、『エピックトレジャリー』（騎獣）、『バトルマスタリー』（通常の魔物＋ボス級魔物）、『アーケインレリック』（ボス級魔物）の範囲においてただの一種もそのような形式のデータは存在しないことから、現実的にこのかたちの魔物が作られることはほとんどないと思われる。