### PR TITLE
[SW2] 閲覧画面において、バトルダンサー技能による追加特技枠を識別できるように

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -282,7 +282,7 @@ foreach ('1bat',@set::feats_lv){
   (my $lv = $_) =~ s/^([0-9]+)[^0-9].*?$/$1/;
   if($_ =~ /bat/ && !$pc{lvBat}){ next; }
   next if $pc{level} < $lv;
-  push(@feats_lv, { NAME => $pc{'combatFeatsLv'.$_}, "LV" => $lv } );
+  push(@feats_lv, { NAME => $pc{'combatFeatsLv'.$_}, "LV" => $lv.($_ =~ /bat/ ? '+' : '') } );
   $acquired{$pc{'combatFeatsLv'.$_}} = 1;
 }
 if($pc{buildupAddFeats}){


### PR DESCRIPTION
バトルダンサー技能による宣言特技枠の追加では、「この枠で習得した宣言特技は、バトルダンサー技能を用いて命中力判定や回避力判定を行うときに限り、宣言することができます」という制約がつく。（『バトルマスタリー』６頁、右側「宣言特技枠追加」の節、第三段落）
そのため、その戦闘特技が追加枠での習得なのか否かは、キャラクター運用上で意識する必要がある。

しかし、これまでは、閲覧画面では追加枠による習得なのか否かが不明瞭だった。
（編集画面では、追加枠には「1+」のように表示され区別できたが、閲覧画面では「1」としか表示されておらず、通常の１レベルの枠とあいまいだった）

これを改善するために、閲覧画面においても、バトルダンサー技能による追加枠では「1+」のように表示するように変更する。

![image](https://github.com/user-attachments/assets/3d8c0a15-8d9f-4cc8-854a-a5554a424c2a)
