### PR TITLE
[SW2] セッション履歴の「ガメル」列の幅をすこし拡げる

### DIFF
--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1160,7 +1160,7 @@ dl#level {
 #history table {
   > thead {
     .exp    { width: 4.6em; } /* 経験点 */
-    .money  { width: 4.5em; } /* ガメル */
+    .money  { width: 5.5em; } /* ガメル */
     .honor  { width:   3em; } /* 名誉点 */
     .grow   { width: 3.5em; } /* 成長 */
   }


### PR DESCRIPTION
# 背景と変更内容

ガメルの額が７桁におよんだ場合、折り返してしまっていた。
![image](https://github.com/user-attachments/assets/a249ccac-6447-45b5-88d5-cf2751fc2bac)

これは不格好なので、７桁でも折り返さないくらいまで拡げておく。

# 備考

総計で７桁というのは、まあそれなりにありうる数値である。

具体的には、「高レベルキャラクター作成表」（『Ⅲ』72頁）の「15＋Ｃ」を採用した場合、まず作成時点で 550,000 ガメルを得る。
ここから、「高レベル冒険者の報酬」（『Ⅲ』308頁）の15レベルの目安にしたがって、１セッションあたり 50,000 ガメルを得ていくとすると、９セッション目が終わった時点で総額が 1,000,000 ガメルに達することになる。

この報酬の目安は、「そのほかの報酬」を過小に見積もっている節があり、実際には戦利品がかなり大きな額に膨れ上がることがままある（高レベルの冒険者は戦利品の出目に大きな修正を得ることが多い）。
そのため、実際のセッションにおいては、１セッションあたり 100,000 ガメルを超える収入を手にすることも頻繁であり、より早く総額が７桁におよぶことになる。