### PR TITLE
[SW2] 閲覧画面でも一般技能の合計レベルを表示する

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -268,12 +268,15 @@ if($pc{lvSeeker}){
 
 ### 一般技能 --------------------------------------------------
 my @common_classes;
+my $commonClassTotalLevel = 0;
 foreach (1..10){
   next if !$pc{'commonClass'.$_};
   $pc{'commonClass'.$_} =~ s#([（\(].+?[\)）])#<span class="small">$1</span>#g;
   push(@common_classes, { "NAME" => $pc{'commonClass'.$_}, "LV" => $pc{'lvCommon'.$_} } );
+  $commonClassTotalLevel += $pc{'lvCommon'.$_};
 }
 $SHEET->param(CommonClasses => \@common_classes);
+$SHEET->param(CommonClassTotalLevel => $commonClassTotalLevel);
 
 ### 戦闘特技 --------------------------------------------------
 my %acquired;

--- a/_core/skin/sw2.0/sheet-chara.html
+++ b/_core/skin/sw2.0/sheet-chara.html
@@ -227,7 +227,10 @@
           </TMPL_IF>
           <TMPL_IF CommonClasses>
           <section class="box" id="common-classes">
-            <h2>一般技能</h2>
+            <h2>
+              一般技能
+              <span class="total-level">合計レベル：<TMPL_VAR CommonClassTotalLevel></span>
+            </h2>
             <dl class="data-table side-margin">
               <TMPL_LOOP CommonClasses>
               <dt><TMPL_VAR NAME><dd><TMPL_VAR LV>

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -511,6 +511,20 @@ dl#level {
     margin: 0 -10%;
     transform: scaleX(0.8);
   }
+  #common-classes {
+    h2 {
+      display: flex;
+      flex-flow: row;
+      justify-content: space-between;
+      align-items: flex-end;
+      padding-right: 0.25em;
+
+      .total-level {
+        font-size: 80%;
+        font-weight: normal;
+      }
+    }
+  }
   #common-classes .small {
     display: inline-block;
   }

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -216,7 +216,10 @@
           </section>
           <TMPL_IF CommonClasses>
           <section class="box" id="common-classes">
-            <h2>一般技能</h2>
+            <h2>
+              一般技能
+              <span class="total-level">合計レベル：<TMPL_VAR CommonClassTotalLevel></span>
+            </h2>
             <dl class="data-table side-margin">
               <TMPL_LOOP CommonClasses>
               <dt><TMPL_VAR NAME><dd><TMPL_VAR LV>


### PR DESCRIPTION
一般技能の合計レベルについて、編集画面では表示されていたが、閲覧画面では表示されていなかった。

他のプレイヤーのシートを確認する場合においては、閲覧画面で表示されているほうが都合がよいので、閲覧画面でも表示することにする。

**表示例**
![image](https://github.com/user-attachments/assets/16b7e63f-4150-4b0d-b9c2-a749e6f720ff)
