### PR TITLE
[SW2] Fix: 【カオスエクスプロージョン】用のチャットパレットの生成条件を修正

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -268,6 +268,7 @@ sub palettePreset {
             next if($pows{$id}{$pow} > $::pc{'lv'.$id} && $id ne 'Fai');
             next if($id eq 'Wiz' && $pows{$id}{$pow} > min($::pc{lvSor},$::pc{lvCon}));
             next if($id eq 'Fai' && $pows{$id}{$pow} > fairyRank($::pc{lvFai},$::pc{fairyContractEarth},$::pc{fairyContractWater},$::pc{fairyContractFire },$::pc{fairyContractWind },$::pc{fairyContractLight},$::pc{fairyContractDark }));
+            next if($id eq 'Fai' && $pow == 80 && $::pc{lvFai} < 15);
           }
           else {
             my $eName = $data::class{$class}{craft}{eName};


### PR DESCRIPTION
https://github.com/yutorize/ytsheet2/pull/138 にて【カオスエクスプロージョン】用の威力コマンドが生成されるようになったが、その条件がさすがに妥当でなさすぎたのを修正。

https://github.com/yutorize/ytsheet2/pull/138 時点では「ランク10以上であれば」という条件になっており、これは【カオスエクスプロージョン】が行使可能となる15レベル時点の全属性契約の「10＆５」（⇒『メイガスアーツ』128頁）をふまえてのものだと思われるが、ランクしか参照していなかったため、（契約属性にかかわらず）【カオスエクスプロージョン】を行使しえないキャラクターに対しても出力されていた。
（たとえば、“フェアリーテイマー**11レベル**の３属性契約でランク14行使可能”というようなキャラクターでも、ランク14の部分がランク10条件を満たしてしまうため、出力されていた）

いかなる契約であっても行使しえない魔法の威力が出力されるのは明らかに誤りといえるため、レベル15未満の場合は威力80のコマンドを出力しないようにした。