### PR TITLE
[SW2] 「用法：1H投」「用法：2H投」の武器の用法にカテゴリを付記する

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -478,6 +478,7 @@ sub palettePreset {
           $text .= optimizeOperatorFirst "+$::pc{'paletteAttack'.$paNum.'Acc'}";
         }
         $text .= " 命中力／$::pc{'weapon'.$_.'Name'}$::pc{'weapon'.$_.'Usage'}";
+        $text .= "〈$::pc{'weapon'.$_.'Category'}〉" if $::pc{'weapon'.$_.'Usage'} =~ /H投/i && $::pc{'weapon'.$_.'Category'};
         $text .= "（${partName}）" if $partName;
         if($::pc{'paletteAttack'.$paNum.'Name'}){
           $text .= "＋$::pc{'paletteAttack'.$paNum.'Name'}";

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -700,7 +700,7 @@ else {
       PART     => $pc{'part'.$pc{'weapon'.$_.'Part'}.'Name'},
       ROWSPAN  => $rowspan,
       NAMEOFF  => $pc{'weapon'.$_.'NameOff'},
-      USAGE    => $pc{'weapon'.$_.'Usage'},
+      USAGE    => $pc{'weapon'.$_.'Usage'} . ($pc{'weapon'.$_.'Usage'} =~ /H投/i && $pc{'weapon'.$_.'Category'} ? "<span class=\"category\">〈$pc{'weapon'.$_.'Category'}〉</span>" : ''),
       REQD     => $pc{'weapon'.$_.'Reqd'},
       ACC      => addNum($pc{'weapon'.$_.'Acc'}),
       ACCTOTAL => $pc{'weapon'.$_.'AccTotal'},

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -910,6 +910,18 @@ dl#level {
     font-size: 80%;
   }
 }
+#weapons tbody {
+  tr {
+    td.usage {
+      .category {
+        display: inline-block;
+        font-size: 60%;
+        word-break: keep-all;
+        line-height: 100%;
+      }
+    }
+  }
+}
 
 
 /* Defense-Status */

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -913,11 +913,14 @@ dl#level {
 #weapons tbody {
   tr {
     td.usage {
+      &:has(.category){
+        line-height: 1;
+      }
       .category {
-        display: inline-block;
+        display: block;
+        margin-top: 1px;
         font-size: 60%;
         word-break: keep-all;
-        line-height: 100%;
       }
     }
   }


### PR DESCRIPTION
# 変更内容

「用法：1H投」「用法：2H投」の武器の用法にカテゴリを付記する。

## 該当箇所

- 閲覧画面
- チャットパレット

# 背景と目的

「nH投」という用法は、（「1H両」／「2H」のようなものとは異なり）、用法によって近接なのか投擲なのかが識別できない。
（これはゲームルールの問題）

そのため、近接にも投擲にももちいることができる「nH投」の武器をあつかうデータでは、それが近接／投擲のいずれであるのかが識別できないという問題がある。
仮に近接と投擲のデータがまったく同一になるのであれば実害はすくないが、実際には、**近接としてもちいる場合と投擲としてもちいる場合とでは属する「カテゴリ」が異なり**（⇒『Ⅰ』298頁）、そして《武器習熟／＊＊》はカテゴリを参照して追加ダメージを与えるため、近接と投擲とで追加ダメージが異なるというケースはそこそこ現実的に生じる。
また、そもそも近接と投擲とで数値設定の異なる武器というのも考えられる。（『Ⅲ』と『エピックトレジャリー』とで内容が異なるため誤植の疑いも濃いが、たとえば『エピックトレジャリー』の〈リマホーク〉（⇒88頁，96頁）は、近接か投擲かによって追加ダメージの値が異なる）

具体例として、[「用法：1H投」であり近接攻撃にも投擲にも使用できる武器〈ハンドアックス〉（⇒『Ⅰ』303頁，311頁）を採用し《武器習熟／アックス》を習得したキャラクターシート](https://yutorize.2-d.jp/ytsheet/sw2.5/?id=I1S31K )を仮定すると、武器欄は次の画像のようになり、二行それぞれが近接／投擲のいずれに対応するのかが定かでなくなる。
![image](https://github.com/user-attachments/assets/e307fcba-64c3-42d1-a72b-519171bf3807)

これだけであれば備考欄になにかしらを記述することで識別を図ることもできるが、そうした場合においても、チャットパレットには（備考欄は反映されないため）依然として同様の問題が残る。
![image](https://github.com/user-attachments/assets/df5ec84e-05a3-4742-bd23-230b1ccf2e70)

このような状況はゲームプレイ上に不便や無用の誤りをもたらしかねないため、「1H投」「2H投」の武器の運用データが近接なのか投擲なのかを明確に識別できるようにしたい。

# 仕様
用法が「1H投」か「2H投」であれば（厳密には `/H投/i` に一致すれば）、用法にカテゴリを付記する（編集画面ではカテゴリを指定する欄もあるので、カテゴリは既存の情報である）。
（カテゴリが〈投擲〉であればそれは遠隔攻撃にもちいるデータであることが自明であり、〈投擲〉以外の〈ソード〉や〈アックス〉などであれば近接攻撃にもちいるデータであることが自明となるので、カテゴリを識別に利用できる）

なお、カテゴリが未入力の場合は付記しない。

# 表示例

![image](https://github.com/user-attachments/assets/8f0d2e0a-b6b3-4a44-ac12-487ce3d38fda)

![image](https://github.com/user-attachments/assets/9e37a556-f13c-434e-90d8-760b81d311ac)
