### PR TITLE
[SW2] 技芸データ（練技・呪歌など）の「習得レベル」に入力候補を提供

### DIFF
--- a/_core/lib/sw2/edit-arts.js
+++ b/_core/lib/sw2/edit-arts.js
@@ -129,6 +129,14 @@ function checkMagicClass(){
   document.querySelector('#data-magic dl.type      dt').textContent = (magic == '鼓咆') ? '鼓咆の系統' : (magic == '占瞳') ? 'タイプなど' : (magic == '貴格') ? '形態' : '対応';
   document.querySelector('#data-magic dl.premise   dt').textContent = (magic == '呪印') ? '前提ＡＣ'   : '前提';
   document.querySelector('#data-magic dl.condition dt').textContent = (magic == '呪歌') ? '効果発生条件' : (magic == '陣率') ? '使用条件' : '条件';
+
+  const levelInput = document.querySelector('#data-magic dl.level dd input');
+  if (magic.length === 2) {
+    // 練技、呪歌など
+    levelInput.setAttribute('list', 'list-craft-required-level');
+  } else {
+    levelInput.removeAttribute('list');
+  }
 }
 function viewMagicInputs(items){
   document.querySelectorAll(`#data-magic dl`).forEach(obj => {

--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -446,6 +446,12 @@ print <<"HTML";
     <p class="notes">(C)Group SNE「ソード・ワールド2.0／2.5」</p>
     <p class="copyright">©<a href="https://yutorize.2-d.jp">ゆとらいず工房</a>「ゆとシートⅡ」ver.${main::ver}</p>
   </footer>
+  <datalist id="list-craft-required-level">
+    <option value="1">
+    <option value="5">
+    <option value="10">
+    <option value="超">
+  </datalist>
   <datalist id="list-cost">
     <option value="MP">
     <option value="MP＋魔晶石＿点">


### PR DESCRIPTION
技芸の要求レベルは一般的に「１」「５」「10」（と「超（越者）」）なので、技芸の場合は「習得レベル」にそれらを入力候補として提供するように。

技芸かどうかは、能力系統名称が２文字かどうかで判別するようにした。（現在までのところ技芸はすべて２文字で、これは意識してそのように統一的なネーミングをされていると思われるため）

（正規表現とかでやってもいいですが、技芸の系統が増えたときに対応漏れがありそうなので、こういうアプローチがいいかなあとおもいました）