### PR TITLE
[SW2] 魔装データの「適用部位」に入力候補を提供

### DIFF
--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -576,6 +576,20 @@ print <<"HTML";
     <option value="⤴♡">
     <option value="⤵♡">
   </datalist>
+  <datalist id="list-part">
+    <option value="―">
+    <option value="すべて">
+    <option value="コア部位">
+    <option value="その他部位">
+    <option value="その他部位すべて">
+    <option value="頭部">
+    <option value="胴体">
+    <option value="上半身">
+    <option value="翼">
+    <option value="邪眼">
+    <option value="蠍">
+    <option value="鋏">
+  </datalist>
   <datalist id="list-school-req">
     <option value="50名誉点">
   </datalist>


### PR DESCRIPTION
魔装の「適用部位」に入力候補を提供するように。

---

具体的な内容は、『バルバロスレイジ』をもとに、

普遍的な表現：
- `―`
- すべて
- コア部位
- その他部位
- その他部位すべて
（『バルバロスレイジ』掲載の魔装データにあるもの）

具体的な部位名：
- 頭部
- 胴体
- 上半身
- 翼
- 邪眼
- 蠍
- 鋏
（『バルバロスレイジ』58頁の部位定義より）

とした。

なお、このうち、「頭部」「上半身」「翼」については『バルバロスレイジ』の個別魔装データには存在しないが、対称性の観点からリストに入れることにした。

---

備考：
_input_ 側には _list_ 属性がもともと指定されていたが、当該 id をもつ _datalist_ が存在しなかった。（ので、 _datalist_ だけを追加している）