### PR TITLE
[SW2] 魔装データに「人間形態時」の項目を追加

### DIFF
--- a/_core/lib/sw2/edit-arts.js
+++ b/_core/lib/sw2/edit-arts.js
@@ -105,7 +105,7 @@ function checkMagicClass(){
     viewMagicInputs(['type','target','range','duration']);
   }
   else if(magic == '魔装'){
-    viewMagicInputs(['premise','part']);
+    viewMagicInputs(['premise','part','human-form']);
   }
   else if(magic == '呪印'){
     viewMagicInputs(['type','premise']);

--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -258,6 +258,7 @@ HTML
           <dl class="song     "><dt>楽素        <dd>基礎@{[ input 'magicSongBasePoint','','','list="list-songpoint"' ]} 巧奏値@{[ input 'magicSongSetPoint' ]} 追加@{[ input 'magicSongAddPoint','','','list="list-songpoint"' ]}</dl>
           <dl class="rider    "><dt>対応        <dd>@{[ checkbox 'magicMountTypeAnimal','動物' ]}@{[ checkbox 'magicMountTypeCryptid','幻獣' ]}@{[ checkbox 'magicMountTypeMachine','魔動機' ]}</dl>
           <dl class="part     "><dt>適用部位    <dd>@{[ input 'magicApplyPart','','','list="list-part"' ]}</dl>
+          <dl class="human-form"><dt>人間形態時  <dd>@{[ radios 'magicApplyHumanForm','','available=>有効','unavailable=>無効','=>指定なし（変身しない種族用）' ]}</dl>
           <dl class="rank     "><dt>ランク      <dd>@{[ input 'magicRank' ]}</dl>
           <dl class="commcost "><dt>陣気コスト  <dd>@{[ input 'magicCommandCost','number' ]}消費</dl>
           <dl class="command  "><dt>陣気蓄積    <dd>＋@{[ input 'magicCommandCharge','number' ]}</dl>

--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -258,7 +258,7 @@ HTML
           <dl class="song     "><dt>楽素        <dd>基礎@{[ input 'magicSongBasePoint','','','list="list-songpoint"' ]} 巧奏値@{[ input 'magicSongSetPoint' ]} 追加@{[ input 'magicSongAddPoint','','','list="list-songpoint"' ]}</dl>
           <dl class="rider    "><dt>対応        <dd>@{[ checkbox 'magicMountTypeAnimal','動物' ]}@{[ checkbox 'magicMountTypeCryptid','幻獣' ]}@{[ checkbox 'magicMountTypeMachine','魔動機' ]}</dl>
           <dl class="part     "><dt>適用部位    <dd>@{[ input 'magicApplyPart','','','list="list-part"' ]}</dl>
-          <dl class="human-form"><dt>人間形態時  <dd>@{[ radios 'magicApplyHumanForm','','available=>有効','unavailable=>無効','=>指定なし（変身しない種族用）' ]}</dl>
+          <dl class="human-form"><dt>人間形態時 <dd>@{[ radios 'magicApplyHumanForm','','available=>有効','unavailable=>無効','=>指定なし（変身しない種族用）' ]}</dl>
           <dl class="rank     "><dt>ランク      <dd>@{[ input 'magicRank' ]}</dl>
           <dl class="commcost "><dt>陣気コスト  <dd>@{[ input 'magicCommandCost','number' ]}消費</dl>
           <dl class="command  "><dt>陣気蓄積    <dd>＋@{[ input 'magicCommandCharge','number' ]}</dl>

--- a/_core/lib/sw2/view-arts.pl
+++ b/_core/lib/sw2/view-arts.pl
@@ -227,16 +227,11 @@ $SHEET->param(Tags => \@tags);
   }
   elsif   ($class eq '魔装'){
     $SHEET->param(magicClassEn => 'potential');
-    if ($pc{magicApplyHumanForm} eq 'available') {
-      $pc{magicApplyHumanForm} = '有効';
-    }
-    elsif ($pc{magicApplyHumanForm} eq 'unavailable') {
-      $pc{magicApplyHumanForm} = '無効';
-    }
-    else {
-      $pc{magicApplyHumanForm} = '―';
-    }
-    $SHEET->param(magicApplyHumanForm => $pc{magicApplyHumanForm});
+    $SHEET->param(magicApplyHumanForm =>
+      ($pc{magicApplyHumanForm} eq 'available')   ? '有効' :
+      ($pc{magicApplyHumanForm} eq 'unavailable') ? '無効' :
+      '―'
+    );
     magicItemViewOn('Premise','Part','HumanForm');
   }
   elsif   ($class eq '呪印'){

--- a/_core/lib/sw2/view-arts.pl
+++ b/_core/lib/sw2/view-arts.pl
@@ -227,7 +227,17 @@ $SHEET->param(Tags => \@tags);
   }
   elsif   ($class eq '魔装'){
     $SHEET->param(magicClassEn => 'potential');
-    magicItemViewOn('Premise','Part');
+    if ($pc{magicApplyHumanForm} eq 'available') {
+      $pc{magicApplyHumanForm} = '有効';
+    }
+    elsif ($pc{magicApplyHumanForm} eq 'unavailable') {
+      $pc{magicApplyHumanForm} = '無効';
+    }
+    else {
+      $pc{magicApplyHumanForm} = '―';
+    }
+    $SHEET->param(magicApplyHumanForm => $pc{magicApplyHumanForm});
+    magicItemViewOn('Premise','Part','HumanForm');
   }
   elsif   ($class eq '呪印'){
     $SHEET->param(magicClassEn => 'seal');

--- a/_core/skin/sw2/css/arts.css
+++ b/_core/skin/sw2/css/arts.css
@@ -152,6 +152,7 @@ article {
   & dl.addpoint  { grid-area: ADPT; }
   
   & dl.part      { grid-area: PART; }
+  & dl.human-form{ grid-area: HUMF; }
   
   & dl.ccost     { grid-area: CCST; }
   & dl.ccharge   { grid-area: CCHG; }
@@ -278,15 +279,19 @@ article {
   }
 }
 .data-magic.potential {
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   grid-template-areas:
-    "NAME NAME"
-    "PRMS PART"
-    "SMRY SMRY"
-    "EFCT EFCT"
+    "NAME NAME NAME"
+    "PRMS PART HUMF"
+    "SMRY SMRY SMRY"
+    "EFCT EFCT EFCT"
   ;
   > dl {
     grid-template-columns: 5em 1fr;
+
+    &.human-form {
+      grid-template-columns: 6em 1fr;
+    }
   }
 }
 .data-magic.seal {

--- a/_core/skin/sw2/css/arts.css
+++ b/_core/skin/sw2/css/arts.css
@@ -399,7 +399,6 @@ article {
 }
 .data-magic h3.name,
 .data-magic dl.name     dd,
-.data-magic dl.part     dd,
 .data-magic dl.summary  dd,
 .data-magic dl.effect > dd,
 .data-magic.song     dl.pet      dd,
@@ -407,8 +406,7 @@ article {
 .data-magic.lead     dl.condition dd,
 .data-magic.lead     dl.ccost dd,
 .data-magic.geomancy dl.duration dd,
-.data-magic.divination dl.type   dd,
-.data-magic.potential  dl.premise dd {
+.data-magic.divination dl.type   dd {
   display: block;
   padding: .2em .5em;
   text-align: left;

--- a/_core/skin/sw2/sheet-arts.html
+++ b/_core/skin/sw2/sheet-arts.html
@@ -117,6 +117,7 @@
           <TMPL_IF magicTypeOn     ><dl class="type     "><dt><TMPL_VAR magicTypeDt DEFAULT="対応"><dd><TMPL_VAR magicType></dl></TMPL_IF>
           <TMPL_IF magicPremiseOn  ><dl class="premise  "><dt>前提         <dd><TMPL_VAR magicPremise></dl></TMPL_IF>
           <TMPL_IF magicPartOn     ><dl class="part     "><dt>適用部位     <dd><TMPL_VAR magicApplyPart></dl></TMPL_IF>
+          <TMPL_IF magicHumanFormOn><dl class="human-form"><dt>人間形態時   <dd><TMPL_VAR magicApplyHumanForm></dl></TMPL_IF>
           <TMPL_IF magicRankOn     ><dl class="rank     "><dt>ランク       <dd><TMPL_VAR magicRank></dl></TMPL_IF>
           <TMPL_IF magicCommandCostOn  ><dl class="ccost  "><dt>陣気コスト<dd><TMPL_VAR magicCommandCost></dl></TMPL_IF>
           <TMPL_IF magicCommandChargeOn><dl class="ccharge"><dt>陣気蓄積  <dd><TMPL_VAR magicCommandCharge></dl></TMPL_IF>

--- a/_core/skin/sw2/sheet-arts.html
+++ b/_core/skin/sw2/sheet-arts.html
@@ -117,7 +117,7 @@
           <TMPL_IF magicTypeOn     ><dl class="type     "><dt><TMPL_VAR magicTypeDt DEFAULT="対応"><dd><TMPL_VAR magicType></dl></TMPL_IF>
           <TMPL_IF magicPremiseOn  ><dl class="premise  "><dt>前提         <dd><TMPL_VAR magicPremise></dl></TMPL_IF>
           <TMPL_IF magicPartOn     ><dl class="part     "><dt>適用部位     <dd><TMPL_VAR magicApplyPart></dl></TMPL_IF>
-          <TMPL_IF magicHumanFormOn><dl class="human-form"><dt>人間形態時   <dd><TMPL_VAR magicApplyHumanForm></dl></TMPL_IF>
+          <TMPL_IF magicHumanFormOn><dl class="human-form"><dt>人間形態時  <dd><TMPL_VAR magicApplyHumanForm></dl></TMPL_IF>
           <TMPL_IF magicRankOn     ><dl class="rank     "><dt>ランク       <dd><TMPL_VAR magicRank></dl></TMPL_IF>
           <TMPL_IF magicCommandCostOn  ><dl class="ccost  "><dt>陣気コスト<dd><TMPL_VAR magicCommandCost></dl></TMPL_IF>
           <TMPL_IF magicCommandChargeOn><dl class="ccharge"><dt>陣気蓄積  <dd><TMPL_VAR magicCommandCharge></dl></TMPL_IF>


### PR DESCRIPTION
# 変更内容

技芸シートの魔装データに「人間形態時」の項目を設ける

# 理由

『バルバロスレイジ』掲載の魔装データの様式（⇒同書53頁）に合わせる。

# 仕様

入力側はラジオボタンによる選択制とした。
項目の性質上、「有効」か「無効」か「変身しない種族用の魔装ゆえに関与しない」かの三値以外をとるとは考えづらいため。

## 後方互換性

「変身しない種族用の魔装ゆえに関与しない」用の選択肢に対応する値を空としているので、既存データは「変身しない種族用の魔装ゆえに関与しない」相当となる。
これは、閲覧画面での表示では `―` となるため、既存の（変身する種族用の）データに表示されても、大きな問題はないと思われる。

……というか、2024/11/03現時点で、ゆと工公式のゆとシートで魔装データを検索して２件しかヒットしないので、そもそも魔装データが世に気にするほど存在していないような気がします。

# 表示例

実例として、既存の魔装【巨大な身体】（⇒『バルバロスレイジ』56頁）と同様の内容を入力してみる：

## 編集画面

![image](https://github.com/user-attachments/assets/bce288a5-5f71-4dd0-b388-1ea49c58f22b)

## 閲覧画面

![image](https://github.com/user-attachments/assets/bce6dec1-9050-4e61-844a-79e7bba8ba49)
