### PR TITLE
[SW2] 魔法／神格／流派シートの編集画面の目次の項目名を修正

### DIFF
--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -223,7 +223,7 @@ HTML
         </dl>
       </div>
 
-      <div class="box in-toc" id="name-form" data-content-title="カテゴリ・プレイヤー名">
+      <div class="box in-toc" id="name-form" data-content-title="カテゴリ・製作者名">
         <div>
           <dl id="category">
             <dt>カテゴリ


### PR DESCRIPTION
before: `カテゴリ・プレイヤー名`
after: `カテゴリ・製作者名`

（魔法／神格／流派シートにおいて、「プレイヤー」名を入力する項目はなく、あるのは「製作者」名を入力する項目である）