### PR TITLE
Fix: 存在しない id を指定して JSON にアクセスしようとしたときに内部エラーが発生しないように

### DIFF
--- a/_core/lib/json.pl
+++ b/_core/lib/json.pl
@@ -26,7 +26,7 @@ if($id){
 
   my $datatype = ($::in{log}) ? 'logs' : 'data';
   my $hit = 0;
-  open my $IN, '<', "${dir}${file}/${datatype}.cgi" or viewNotFound($dir);
+  open my $IN, '<', "${dir}${file}/${datatype}.cgi" or error('データがありません');
   while (<$IN>){
     if($datatype eq 'logs'){
       if (index($_, "=") == 0){


### PR DESCRIPTION
`viewNotFound` は _view.pl_ 内に定義されているサブルーチンなので、 _json.pl_ から呼び出そうとしてエラーになっていた。

`viewNotFound` の内容を見たところ、 JSON へのアクセス時に必要そうなものではなかったので、単純な `error` サブルーチンで代用することにした。