### PR TITLE
Fix: 存在しない id を指定してチャットパレットにアクセスしようとしたときに内部エラーが発生しないように

### DIFF
--- a/_core/lib/palette.pl
+++ b/_core/lib/palette.pl
@@ -25,7 +25,7 @@ sub outputChatPalette {
   my $datatype = ($::in{log}) ? 'logs' : 'data';
 
   my @lines;
-  open my $IN, '<', "${set::char_dir}${file}/${datatype}.cgi" or &login_error;
+  open my $IN, '<', "${set::char_dir}${file}/${datatype}.cgi" or error('データがありません');
   if($datatype eq 'logs'){
     my $hit = 0;
     while (<$IN>){


### PR DESCRIPTION
`login_error` は存在しないサブルーチンっぽい。
（同名の変数であれば _edit.pl_ で定義されている）

いずれにせよ、チャットパレットへのアクセス時にログイン（編集権限）を考慮する必要はないと思われるので、単純な `error` サブルーチンに置き換えた。