### PR TITLE
ルビの代替表示用括弧要素の内容をルビ記法に合わせる

### DIFF
--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -498,7 +498,7 @@ sub unescapeTags {
   $text =~ s/%%(.+?)%%/<span class="strike">$1<\/span>/gi;  # 打ち消し線
   $text =~ s/__(.+?)__/<span class="underline">$1<\/span>/gi;  # 下線
   $text =~ s/\{\{(.+?)\}\}/<span style="color:transparent">$1<\/span>/gi;  # 透明
-  $text =~ s/[|｜]([^|｜\n]+?)《(.+?)》/<ruby>$1<rp>(<\/rp><rt>$2<\/rt><rp>)<\/rp><\/ruby>/gi; # なろう式ルビ
+  $text =~ s/[|｜]([^|｜\n]+?)《(.+?)》/<ruby><rp>｜<\/rp>$1<rp>《<\/rp><rt>$2<\/rt><rp>》<\/rp><\/ruby>/gi; # なろう式ルビ
   $text =~ s/《《(.+?)》》/<span class="text-em">$1<\/span>/gi; # カクヨム式傍点
 
   $text =~ s/\x{FFFC}(\d+)\x{FFFC}/$linkPlaceholders[$1-1]/g; # リンク後処理


### PR DESCRIPTION
ゆとシートの利用者には、そのほうが馴染み深いと思われる。

また、単なる括弧 `()` よりは他の環境でもルビ記法と解釈されるケースが多いので、いくらか有意義だと考えられる。
（たとえば Udonarium Lily でも、ルビの記法は `｜《》` である）