### PR TITLE
[SW2] 奈落魔法の属性抽選用のコマンドをチャットパレットに含める

### DIFF
--- a/_core/lib/palette.pl
+++ b/_core/lib/palette.pl
@@ -101,6 +101,51 @@ sub swapWordAndCommand {
   return join("\n", @palette);
 }
 
+# 抽選コマンドをつくる
+sub makeChoiceCommand {
+  my $count = shift;
+  my @sourceItems = @{shift;};
+  my %bot = %{shift;};
+
+  sub validateItems {
+    my @sources = @{shift;};
+    my %_bot = %{shift;};
+
+    my @validated = ();
+
+    foreach my $item (@sources) {
+      next if $item =~ /^[\s　]*$/;
+
+      if ($_bot{YTC}) {
+        $item =~ s/,/_/g;
+      }
+      elsif ($_bot{BCD}) {
+        $item =~ s/ /_/g;
+      }
+      else {
+        next;
+      }
+
+      push(@validated, $item);
+    }
+
+    return @validated;
+  }
+
+  my @validatedItems = validateItems(\@sourceItems, \%bot);
+  return '' unless @validatedItems;
+
+  if ($bot{YTC}) {
+    return "${count}\$" . join(',', @validatedItems) . "\n";
+  }
+
+  if ($bot{BCD}) {
+    return ($count > 1 ? "x${count} " : '') . 'choice ' . join(' ', @validatedItems) . "\n";
+  }
+
+  return '';
+}
+
 sub outputChatPaletteTemplate {
   use JSON::PP;
   my $type = $::in{type};

--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -312,7 +312,13 @@ sub palettePreset {
             $text .= "Dru[24,27,30]+$druidBase／【ダブルストンプ】\n"     if($::pc{lvDru} >= 15);
           }
         }
-      
+
+        if ($id eq 'Aby' && $::pc{'lv'.$id} >= 7) {
+          foreach my $count (1 .. 2) {
+            $text .= makeChoiceCommand($count, ['雷', '純エネルギー', '衝撃', '断空', '毒', '呪い'], \%bot);
+          }
+        }
+
         foreach my $pow (sort {$a <=> $b} keys %{$heals{$id}}) {
           if($heals{$id}{$pow} =~ /^[0-9]+$/){
             next if($::pc{'lv'.$id} < $heals{$id}{$pow});


### PR DESCRIPTION
# 変更内容

一部の奈落魔法のための、属性抽選用のコマンドをチャットパレットに含める。

該当する奈落魔法は次のとおり：
- ７レベル【アビス・ヴォーテックス】（⇒『アビスブレイカー』13頁）
- 13レベル【アビス・ストーム】（⇒『アビスブレイカー』16頁）

# 背景と目的

当該魔法は、奈落魔法のラインナップ内において比較的有力な攻撃手段であり、奈落魔法を習得しているキャラクターにおいては、使用頻度がそれなりに高い傾向にあると思われる。
そのため、これら魔法における属性の抽選処理を、より円滑に実行できるようにしたい。

# 仕様

## 内容
属性を抽選するための抽選コマンド。
各魔法の「拡張効果」を考慮し、２つをいっぺんに抽選するコマンドも提供する。

## 条件
アビスゲイザー技能が７レベル以上の場合。

## 位置
攻撃用の威力コマンドの後。

## 形式

- 「使用ツール」が「ゆとチャadv.」であれば、ゆとチャadv.用の形式で出力する
- 「使用ツール」が「Tekey」または「その他（BCDice使用）」であれば、BCDice用の形式で出力する

### 例：ゆとチャadv.用
```
1$雷,純エネルギー,衝撃,断空,毒,呪い
2$雷,純エネルギー,衝撃,断空,毒,呪い
```

### 例：BCDice用
```
choice 雷 純エネルギー 衝撃 断空 毒 呪い
x2 choice 雷 純エネルギー 衝撃 断空 毒 呪い
```