### PR TITLE
追加:[AR2E]デフォルト変数及びプリセット（変数使用）において全て変数対応

### DIFF
--- a/_core/lib/ar2e/palette-sub.pl
+++ b/_core/lib/ar2e/palette-sub.pl
@@ -16,24 +16,24 @@ sub palettePreset {
   if(!$type){
     # 基本判定
     $text .= "### ■判定\n";
-    $text .= "{筋力判定}+$::pc{rollStrDice}D 【筋力】判定\n";
-    $text .= "{器用判定}+$::pc{rollDexDice}D 【器用】判定\n";
-    $text .= "{敏捷判定}+$::pc{rollAgiDice}D 【敏捷】判定\n";
-    $text .= "{知力判定}+$::pc{rollIntDice}D 【知力】判定\n";
-    $text .= "{感知判定}+$::pc{rollSenDice}D 【感知】判定\n";
-    $text .= "{精神判定}+$::pc{rollMndDice}D 【精神】判定\n";
-    $text .= "{幸運判定}+$::pc{rollLukDice}D 【幸運】判定\n";
+    $text .= "{筋力判定}+{筋力判定ダイス}D 【筋力】判定\n";
+    $text .= "{器用判定}+{器用判定ダイス}D 【器用】判定\n";
+    $text .= "{敏捷判定}+{敏捷判定ダイス}D 【敏捷】判定\n";
+    $text .= "{知力判定}+{知力判定ダイス}D 【知力】判定\n";
+    $text .= "{感知判定}+{感知判定ダイス}D 【感知】判定\n";
+    $text .= "{精神判定}+{精神判定ダイス}D 【精神】判定\n";
+    $text .= "{幸運判定}+{幸運判定ダイス}D 【幸運】判定\n";
     $text .= "{命中}+{命中ダイス}D 命中判定\n";
     $text .= "{攻撃力}+{攻撃ダイス}D 攻撃力\n";
     $text .= "{回避}+{回避ダイス}D 回避判定\n";
-    $text .= "{トラップ探知}+$::pc{rollTrapDetectDice}D トラップ探知判定\n";
-    $text .= "{トラップ解除}+$::pc{rollTrapReleaseDice}D トラップ解除判定\n";
-    $text .= "{危険感知}+$::pc{rollDangerDetectDice}D 危険感知判定\n";
-    $text .= "{エネミー識別}+$::pc{rollEnemyLoreDice}D エネミー識別判定\n";
-    $text .= "{アイテム鑑定}+$::pc{rollAppraisalDice}D アイテム鑑定判定\n";
-    $text .= "{魔術判定}+$::pc{rollMagicDice}D 魔術判定\n";
-    $text .= "{呪歌判定}+$::pc{rollSongDice}D 呪歌判定\n";
-    $text .= "{錬金術判定}+$::pc{rollAlchemyDice}D 錬金術判定\n";
+    $text .= "{トラップ探知}+{トラップ探知ダイス}D トラップ探知判定\n";
+    $text .= "{トラップ解除}+{トラップ解除ダイス}D トラップ解除判定\n";
+    $text .= "{危険感知}+{危険感知ダイス}D 危険感知判定\n";
+    $text .= "{エネミー識別}+{エネミー識別ダイス}D エネミー識別判定\n";
+    $text .= "{アイテム鑑定}+{アイテム鑑定ダイス}D アイテム鑑定判定\n";
+    $text .= "{魔術判定}+{魔術判定ダイス}D 魔術判定\n";
+    $text .= "{呪歌判定}+{呪歌判定ダイス}D 呪歌判定\n";
+    $text .= "{錬金術判定}+{錬金術判定ダイス}D 錬金術判定\n";
     
     $text .= "###\n" if $bot{YTC} || $bot{TKY};
   }
@@ -82,12 +82,19 @@ sub paletteProperties {
     push @propaties, "//精神=$::pc{sttMndTotal}";
     push @propaties, "//幸運=$::pc{sttLukTotal}";
     push @propaties, "//筋力判定={筋力}".addNum($::pc{rollStrAdd});
+    push @propaties, "//筋力判定ダイス=".$::pc{rollStrDice};
     push @propaties, "//器用判定={器用}".addNum($::pc{rollDexAdd});
+    push @propaties, "//器用判定ダイス=".$::pc{rollDexDice};
     push @propaties, "//敏捷判定={敏捷}".addNum($::pc{rollAgiAdd});
+    push @propaties, "//敏捷判定ダイス=".$::pc{rollAgiDice};
     push @propaties, "//知力判定={知力}".addNum($::pc{rollIntAdd});
+    push @propaties, "//知力判定ダイス=".$::pc{rollIntDice};
     push @propaties, "//感知判定={感知}".addNum($::pc{rollSenAdd});
+    push @propaties, "//感知判定ダイス=".$::pc{rollSenDice};
     push @propaties, "//精神判定={精神}".addNum($::pc{rollMndAdd});
+    push @propaties, "//精神判定ダイス=".$::pc{rollMndDice};
     push @propaties, "//幸運判定={幸運}".addNum($::pc{rollLukAdd});
+    push @propaties, "//幸運判定ダイス=".$::pc{rollLukDice};
     push @propaties, "### ■代入パラメータ";
     push @propaties, "//命中={器用判定}".addNum($::pc{battleAddAcc});
     push @propaties, "//命中ダイス=".$::pc{battleDiceAcc};
@@ -100,13 +107,21 @@ sub paletteProperties {
     push @propaties, "//行動値=".$::pc{battleTotalIni};
     push @propaties, "//移動力=".$::pc{battleTotalMove};
     push @propaties, "//トラップ探知={感知判定}".addNum($::pc{rollTrapDetectAdd});
+    push @propaties, "//トラップ探知ダイス="    .$::pc{rollTrapDetectDice};
     push @propaties, "//トラップ解除={器用判定}".addNum($::pc{rollTrapReleaseAdd});
+    push @propaties, "//トラップ解除ダイス="    .$::pc{rollTrapReleaseDice};
     push @propaties, "//危険感知={感知判定}"    .addNum($::pc{rollDangerDetectAdd});
+    push @propaties, "//危険感知ダイス="        .$::pc{rollDangerDetectDice};
     push @propaties, "//エネミー識別={知力判定}".addNum($::pc{rollEnemyLoreAdd});
+    push @propaties, "//エネミー識別ダイス="    .$::pc{rollEnemyLoreDice};
     push @propaties, "//アイテム鑑定={知力判定}".addNum($::pc{rollAppraisalAdd});
+    push @propaties, "//アイテム鑑定ダイス="    .addNum($::pc{rollAppraisalDice});
     push @propaties, "//魔術判定={知力判定}"    .addNum($::pc{rollMagicAdd});
+    push @propaties, "//魔術判定ダイス="        .$::pc{rollMagicDice};
     push @propaties, "//呪歌判定={精神判定}"    .addNum($::pc{rollSongAdd});
+    push @propaties, "//呪歌判定ダイス="        .$::pc{rollSongDice};
     push @propaties, "//錬金術判定={器用判定}"  .addNum($::pc{rollAlchemyAdd});
+    push @propaties, "//錬金術判定ダイス="      .$::pc{rollAlchemyDice};
   }
   
   return @propaties;


### PR DESCRIPTION
# 変更内容
アリアンロッド2Eのデフォルト変数及びプリセット（変数使用）においてすべての判定で変数を使用するように変更。
# 背景と目的
キャンペーンシナリオ等の理由でキャラクターシート及びチャットパレットの更新を頻繁に行うケースにおいて、チャットパレットの更新漏れを予防する。
また、変数対応によって複数キャラクター間でユーザーオリジナルのチャットパレットのテンプレートを使用しやすくなる。
# 仕様
## 内容
各種基礎ステータス判定及びトラップ探知以下8種の判定においてデフォルト変数に判定ダイスを追加。
従来キャラクターシートを参照して数値を出力していた部分に対して新規に追加したデフォルト変数を使用する。
## 形式
### デフォルト変数
キャラクターシートの各種ダイス数の設定に応じて変動する。
```
//トラップ探知ダイス=2
```

### **例：ゆとちゃadv.用**
```
旧：トラップ探知判定 {トラップ探知}+2D
新：トラップ探知判定 {トラップ探知}+{トラップ探知ダイス}D
```
### **例：BCDice用**
```
旧：{トラップ探知}+2D トラップ探知判定
新：{トラップ探知}+{トラップ探知ダイス}D トラップ探知判定
```