### PR TITLE
[SW2] 閲覧画面において、武器・防具・装飾品の専用化の列をもうけない （効果や備考の列に混ぜ込む）

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -694,6 +694,7 @@ else {
       $pc{'weapon'.$_.'Acc'} = 0;
       $pc{'weapon'.$_.'Dmg'} = 0;
     }
+    $pc{'weapon'.$_.'Note'} = '<i class="own">専用</i>' . $pc{'weapon'.$_.'Note'} if $pc{'weapon'.$_.'Own'};
     push(@weapons, {
       NAME     => $pc{'weapon'.$_.'Name'},
       PART     => $pc{'part'.$pc{'weapon'.$_.'Part'}.'Name'},
@@ -707,7 +708,6 @@ else {
       CRIT     => $pc{'weapon'.$_.'Crit'},
       DMG      => addNum($pc{'weapon'.$_.'Dmg'}),
       DMGTOTAL => $pc{'weapon'.$_.'DmgTotal'},
-      OWN      => $pc{'weapon'.$_.'Own'},
       NOTE     => replaceModificationNotation($pc{'weapon'.$_.'Note'}),
       NOTESPAN => $pc{'weapon'.$_.'NoteSpan'},
       NOTEOFF  => $pc{'weapon'.$_.'NoteOff'},
@@ -844,13 +844,14 @@ else {
 
     if($pc{'armour'.$_.'Type'} =~ /^(鎧|盾|他)[0-9]+/ && $count{$1} <= 1){ $pc{'armour'.$_.'Type'} = $1 }
 
+    $pc{'armour'.$_.'Note'} = '<i class="own">専用</i>' . $pc{'armour'.$_.'Note'} if $pc{'armour'.$_.'Own'};
+
     push(@armours, {
       TYPE => $pc{'armour'.$_.'Type'},
       NAME => $pc{'armour'.$_.'Name'},
       REQD => $pc{'armour'.$_.'Reqd'},
       EVA  => $pc{'armour'.$_.'Eva'} ? addNum($pc{'armour'.$_.'Eva'}) : ($pc{'armour'.$_.'Category'} =~ /[鎧盾]/ ? '―' : ''),
       DEF  => $pc{'armour'.$_.'Def'} // ($pc{'armour'.$_.'Category'} =~ /[鎧盾]/ ? '0' : ''),
-      OWN  => $pc{'armour'.$_.'Own'},
       NOTE => $pc{'armour'.$_.'Note'},
     } );
   }
@@ -922,10 +923,12 @@ else {
     if (@$_[1] =~ /_$/) {
       next unless $pc{'accessory'.substr(@$_[1],0,-1).'Add'};
     }
+
+    my $own = $pc{'accessory'.@$_[1].'Own'};
+    $pc{'accessory'.@$_[1].'Note'} = "<i class=\"own\" data-kind=\"$own\">専用</i>" . $pc{'accessory'.@$_[1].'Note'} if $own;
     push(@accessories, {
       TYPE => @$_[0],
       NAME => $pc{'accessory'.@$_[1].'Name'},
-      OWN  => $pc{'accessory'.@$_[1].'Own'},
       NOTE => replaceModificationNotation($pc{'accessory'.@$_[1].'Note'}),
     } );
   }

--- a/_core/skin/sw2.0/sheet-chara.html
+++ b/_core/skin/sw2.0/sheet-chara.html
@@ -395,30 +395,28 @@
           <table class="data-table line-tbody">
             <thead>
               <tr>
-                <th>武器
-                <th>用法
-                <th>必筋
-                <th>命中力
-                <th>威力
-                <th>Ｃ値
-                <th>追加Ｄ
-                <th>専用
-                <th>備考
+                <th class="name">武器
+                <th class="usage">用法
+                <th class="reqd">必筋
+                <th class="acc">命中力
+                <th class="rate">威力
+                <th class="crit">Ｃ値
+                <th class="dmg">追加Ｄ
+                <th class="note">備考
               
             </thead>
             <tbody><TMPL_LOOP Weapons><TMPL_IF CLOSE></tbody><tbody></TMPL_IF>
               <tr>
-                <TMPL_UNLESS NAMEOFF><td rowspan="<TMPL_VAR ROWSPAN>">
+                <TMPL_UNLESS NAMEOFF><td class="name" rowspan="<TMPL_VAR ROWSPAN>">
                   <span class="item-name"><TMPL_VAR NAME><TMPL_IF PART><span class="part-name">（<TMPL_VAR PART>）</span></TMPL_IF></span>
                 </TMPL_UNLESS>
-                <td><TMPL_VAR USAGE>
-                <td><TMPL_VAR REQD>
-                <td><TMPL_IF ACC><TMPL_VAR ACC>=</TMPL_IF><b><TMPL_VAR ACCTOTAL></b>
-                <td><TMPL_VAR RATE>
-                <td><TMPL_VAR CRIT>
-                <td><TMPL_IF DMG><TMPL_VAR DMG>=</TMPL_IF><b><TMPL_VAR DMGTOTAL></b>
-                <td><TMPL_IF OWN>✔</TMPL_IF>
-                <TMPL_UNLESS NOTEOFF><td class="left" rowspan="<TMPL_VAR NOTESPAN>">
+                <td class="usage"><TMPL_VAR USAGE>
+                <td class="reqd"><TMPL_VAR REQD>
+                <td class="acc"><TMPL_IF ACC><TMPL_VAR ACC>=</TMPL_IF><b><TMPL_VAR ACCTOTAL></b>
+                <td class="rate"><TMPL_VAR RATE>
+                <td class="crit"><TMPL_VAR CRIT>
+                <td class="dmg"><TMPL_IF DMG><TMPL_VAR DMG>=</TMPL_IF><b><TMPL_VAR DMGTOTAL></b>
+                <TMPL_UNLESS NOTEOFF><td class="note left" rowspan="<TMPL_VAR NOTESPAN>">
                   <span class="item-name"><TMPL_VAR NOTE></span>
                 </TMPL_UNLESS>
             </TMPL_LOOP></tbody>
@@ -454,7 +452,6 @@
                 <th class="reqd">必筋
                 <th class="eva ">回避力
                 <th class="def ">防護点
-                <th class="own ">専用
                 <th class="note">備考
             </thead>
             <tbody>
@@ -464,7 +461,6 @@
                 <td class="reqd"><TMPL_VAR REQD>
                 <td class="eva "><TMPL_VAR EVA>
                 <td class="def "><TMPL_VAR DEF>
-                <td class="own "><TMPL_IF OWN>✔</TMPL_IF>
                 <td class="note"><TMPL_VAR NOTE>
               </TMPL_LOOP>
             </tbody>
@@ -473,7 +469,7 @@
                 <th colspan="3">合計: <TMPL_VAR TH>
                 <td><TMPL_VAR EVA>
                 <td><TMPL_VAR DEF>
-                <td colspan="2"><TMPL_VAR NOTE>
+                <td><TMPL_VAR NOTE>
               </TMPL_LOOP>
             </tfoot>
           </table>
@@ -482,17 +478,15 @@
           <table class="data-table">
             <thead>
               <tr>
-                <th>
-                <th>装飾品
-                <th>専用
-                <th>効果
+                <th class="type">
+                <th class="name">装飾品
+                <th class="note">効果
             </thead>
             <tbody>
               <TMPL_LOOP Accessories><tr>
-                <th><TMPL_VAR TYPE>
-                <td><span class="item-name"><TMPL_VAR NAME></span>
-                <td><TMPL_IF OWN>✔<TMPL_VAR OWN></TMPL_IF>
-                <td><TMPL_VAR NOTE>
+                <th class="type"><TMPL_VAR TYPE>
+                <td class="name"><span class="item-name"><TMPL_VAR NAME></span>
+                <td class="note"><TMPL_VAR NOTE>
               </TMPL_LOOP>
             </tbody>
           </table>

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -808,6 +808,30 @@ dl#level {
       font-weight: normal;
       font-size: 1.15em;
     }
+
+    td i.own {
+      background-color: grey;
+      color: var(--bg-color);
+      font-size: 90%;
+      line-height: 100%;
+      padding: 0.11em 0.25em;
+      border-radius: 0.3em;
+      font-style: normal;
+      font-weight: normal;
+      position: relative;
+      top: -1px;
+      margin-right: 0.25em;
+
+      &::before {
+        content: "✔";
+      }
+
+      &[data-kind] {
+        &::after {
+          content: "(" attr(data-kind) ")";
+        }
+      }
+    }
   }
   
   & .item-name {
@@ -851,15 +875,15 @@ dl#level {
 }
 
 #weapons thead th {
-  &:nth-child(1) { width:   25%; } /* 名前 */
-  &:nth-child(2) { width: 3.5em; } /* 用法 */
-  &:nth-child(3) { width: 3.5em; } /* 必筋 */
-  &:nth-child(4) { width:   5em; } /* 命中 */
-  &:nth-child(5) { width: 3.5em; } /* 威力 */
-  &:nth-child(6) { width: 3.5em; } /* Ｃ値 */
-  &:nth-child(7) { width:   5em; } /* 追加Ｄ */
-  &:nth-child(8) { width:   1em; } /* 専用 */
-  &:nth-child(9) { width: auto; } /* 備考 */
+  &:nth-child(1), &.name  { width:   25%; } /* 名前 */
+  &:nth-child(2), &.usage { width: 3.5em; } /* 用法 */
+  &:nth-child(3), &.reqd  { width: 3.5em; } /* 必筋 */
+  &:nth-child(4), &.acc   { width:   5em; } /* 命中 */
+  &:nth-child(5), &.rate  { width: 3.5em; } /* 威力 */
+  &:nth-child(6), &.crit  { width: 3.5em; } /* Ｃ値 */
+  &:nth-child(7), &.dmg   { width:   5em; } /* 追加Ｄ */
+  &:nth-child(8)          { width:   1em; } /* 専用 */
+  &:nth-child(9), &.note  { width: auto; } /* 備考 */
   
   @media screen and (width <= 735px){
     &:nth-child(1) { width:   25%; } /* 名前 */
@@ -933,12 +957,12 @@ dl#level {
 
 /* Accessories */
 #accessories thead th {
-  &:nth-child(1) { width: 2.5em; } /* 種別 */
-  &:nth-child(2) { width:   25%; } /* 名前 */
-  &:nth-child(3) { width: 3.5em; } /* 専用 */
-  &:nth-child(4) { width:  auto; } /* 備考 */
+  &:nth-child(1), &.type { width: 2.5em; } /* 種別 */
+  &:nth-child(2), &.name { width:   25%; } /* 名前 */
+  &:nth-child(3)         { width: 3.5em; } /* 専用 */
+  &:nth-child(4), &.note { width:  auto; } /* 備考 */
 }
-#accessories tbody td:nth-child(4) { /* 備考 */
+#accessories tbody td:is(:nth-child(4), .note) { /* 備考 */
   padding-left: .3em;
   text-align: left;
   font-size: 90%;

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -372,15 +372,14 @@
           <table class="data-table line-tbody">
             <thead>
               <tr>
-                <th>武器
-                <th>用法
-                <th>必筋
-                <th>命中力
-                <th>威力
-                <th>Ｃ値
-                <th>追加Ｄ
-                <th>専用
-                <th>備考
+                <th class="name">武器
+                <th class="usage">用法
+                <th class="reqd">必筋
+                <th class="acc">命中力
+                <th class="rate">威力
+                <th class="crit">Ｃ値
+                <th class="dmg">追加Ｄ
+                <th class="note">備考
               </tr>
             </thead>
             <tbody><TMPL_LOOP Weapons><TMPL_IF CLOSE></tbody><tbody></TMPL_IF>
@@ -388,14 +387,13 @@
                 <TMPL_UNLESS NAMEOFF><td rowspan="<TMPL_VAR ROWSPAN>">
                   <span class="item-name"><TMPL_VAR NAME><TMPL_IF PART><span class="part-name">（<TMPL_VAR PART>）</span></TMPL_IF></span>
                 </TMPL_UNLESS>
-                <td><TMPL_VAR USAGE>
-                <td><TMPL_VAR REQD>
-                <td><TMPL_IF ACC><TMPL_VAR ACC>=</TMPL_IF><b><TMPL_VAR ACCTOTAL></b>
-                <td><TMPL_VAR RATE>
-                <td><TMPL_VAR CRIT>
-                <td><TMPL_IF DMG><TMPL_VAR DMG>=</TMPL_IF><b><TMPL_VAR DMGTOTAL></b>
-                <td><TMPL_IF OWN>✔</TMPL_IF>
-                <TMPL_UNLESS NOTEOFF><td class="left" rowspan="<TMPL_VAR NOTESPAN>">
+                <td class="usage"><TMPL_VAR USAGE>
+                <td class="reqd"><TMPL_VAR REQD>
+                <td class="acc"><TMPL_IF ACC><TMPL_VAR ACC>=</TMPL_IF><b><TMPL_VAR ACCTOTAL></b>
+                <td class="rate"><TMPL_VAR RATE>
+                <td class="crit"><TMPL_VAR CRIT>
+                <td class="dmg"><TMPL_IF DMG><TMPL_VAR DMG>=</TMPL_IF><b><TMPL_VAR DMGTOTAL></b>
+                <TMPL_UNLESS NOTEOFF><td class="note left" rowspan="<TMPL_VAR NOTESPAN>">
                   <span class="item-name"><TMPL_VAR NOTE></span>
                 </TMPL_UNLESS>
             </TMPL_LOOP></tbody>
@@ -431,7 +429,6 @@
                 <th class="reqd">必筋
                 <th class="eva ">回避力
                 <th class="def ">防護点
-                <th class="own ">専用
                 <th class="note">備考
               </tr>
             <tbody>
@@ -441,7 +438,6 @@
                 <td class="reqd"><TMPL_VAR REQD>
                 <td class="eva "><TMPL_VAR EVA>
                 <td class="def "><TMPL_VAR DEF>
-                <td class="own "><TMPL_IF OWN>✔</TMPL_IF>
                 <td class="note"><TMPL_VAR NOTE>
               </TMPL_LOOP>
             </tbody>
@@ -450,7 +446,7 @@
                 <th colspan="3">合計:<span class="small"><TMPL_VAR TH></span>
                 <td class="eva "><TMPL_VAR EVA>
                 <td class="def "><TMPL_VAR DEF>
-                <td class="note" colspan="2"><TMPL_VAR NOTE>
+                <td class="note"><TMPL_VAR NOTE>
               </TMPL_LOOP>
             </tfoot>
           </table>
@@ -480,17 +476,15 @@
           <table class="data-table">
             <thead>
               <tr>
-                <th>
-                <th>装飾品
-                <th>専用
-                <th>効果
+                <th class="type">
+                <th class="name">装飾品
+                <th class="note">効果
               </tr>
             <tbody>
               <TMPL_LOOP Accessories><tr>
-                <th><TMPL_VAR TYPE>
-                <td><span class="item-name"><TMPL_VAR NAME></span>
-                <td><TMPL_IF OWN>✔<TMPL_VAR OWN></TMPL_IF>
-                <td><TMPL_VAR NOTE>
+                <th class="type"><TMPL_VAR TYPE>
+                <td class="name"><span class="item-name"><TMPL_VAR NAME></span>
+                <td class="note"><TMPL_VAR NOTE>
               </TMPL_LOOP>
             </tbody>
           </table>


### PR DESCRIPTION
# 変更内容

閲覧画面上にかぎり、武器・防具・装飾品のリストから「専用化」の列を除外し、代わりに「備考」列内に専用化されている旨を混ぜ込む。

# 目的

「備考」列の幅を（それが可能な場合だけでも）拡げたい。

上記の目的のもと、

- 「専用化」する装備品はあるていどかぎられる
  - 武器の専用化は、器用度の値によってはとくに意味がない
  - 防具の専用化は、移動力に困っているキャラクターでなければわざわざしないことも多い（例：通常移動をする気がさらさらないソーサラーなど）
  - 装飾品の専用化は、ＨＰとＭＰそれぞれについて１つずつのみおこなえばよく、その２つ以外の装飾品には施さないことが多い
- 武器・防具・装飾品において、「専用化」によるルール上の影響は、専用の列を設けるほどのものではない

の二点から、「専用化」の列を排除して幅を稼ぐことにする。

# 表示例

![image](https://github.com/user-attachments/assets/f29b2c19-76a9-4dc2-a5da-4c049a877f71)
