### PR TITLE
[SW2] 閲覧画面の魔法／賦術／呪歌の基準値について、ひとつも専用化の影響が介在していなければ専用化の列を非表示にする

### DIFF
--- a/_core/skin/sw2.0/sheet-chara.html
+++ b/_core/skin/sw2.0/sheet-chara.html
@@ -369,7 +369,7 @@
           <h2><TMPL_VAR MagicPowerHeader></h2>
           <table class="data-table">
             <thead>
-              <tr><th><th><th><TMPL_VAR MagicPowerThPow><th class="small"><TMPL_VAR MagicPowerThAct><br>基準値<th class="small">ダメージ<br>上昇効果<th>専用
+              <tr><th><th><th><TMPL_VAR MagicPowerThPow><th class="small"><TMPL_VAR MagicPowerThAct><br>基準値<th class="small">ダメージ<br>上昇効果<th class="own">専用
             </thead>
             <TMPL_LOOP MagicPowers><tr>
               <td><TMPL_VAR NAME>
@@ -377,7 +377,7 @@
               <td class="num"><TMPL_VAR POWER>
               <td class="num"><TMPL_VAR CAST>
               <td class="num"><TMPL_VAR DAMAGE>
-              <td><TMPL_VAR OWN>
+              <td class="own"><TMPL_VAR OWN></td>
             </TMPL_LOOP>
           </table>
         </section>

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -778,6 +778,12 @@ dl#level {
     line-height: 1.6;
     white-space: nowrap;
   }
+
+  &:not(:has(td.own:not(:empty))) {
+    :is(th, td).own {
+      display: none;
+    }
+  }
 }
 #magic-power #fairycontact {
   margin: -.2em 0 -.1em;

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -348,7 +348,7 @@
           <h2><TMPL_VAR MagicPowerHeader></h2>
           <table class="data-table">
             <thead>
-              <tr><th><th><th><TMPL_VAR MagicPowerThPow><th class="small"><TMPL_VAR MagicPowerThAct><br>基準値<th class="small">ダメージ<br>上昇効果<th>専用
+              <tr><th><th><th><TMPL_VAR MagicPowerThPow><th class="small"><TMPL_VAR MagicPowerThAct><br>基準値<th class="small">ダメージ<br>上昇効果<th class="own">専用
             <tbody>
             <TMPL_LOOP MagicPowers><tr>
               <td><TMPL_VAR NAME>
@@ -356,7 +356,7 @@
               <td class="num"><TMPL_VAR POWER>
               <td class="num"><TMPL_VAR CAST>
               <td class="num"><TMPL_VAR DAMAGE>
-              <td><TMPL_VAR OWN>
+              <td class="own"><TMPL_VAR OWN></td>
             </TMPL_LOOP>
           </table>
         </section>


### PR DESCRIPTION
# 変更内容

魔法／賦術／呪歌のいずれにも専用化の影響が介在していなければ、閲覧画面において、「専用」の列を非表示にする。

# 意図

必要のないものは省略して、より見通しをよくする。

術具の専用化は、
- 「専用化するだけの名誉点ないしは冒険者ランクがない」（一般的な低レベル期）
- 「専用化したところでボーナスに影響しない」（たまたまそのような能力値である場合）
- 「達成値を高める必要がない」（もっぱら補助動作で運用する想定で習得された魔動機術や森羅魔法、賦術などが該当）
などのケースにおいて実施されないこともそれなりにある。

そのような、とくに専用化を実施していないキャラクターにおいては、当該部分における「専用」列は無意味であるため、省略したい。

# 表示例

![image](https://github.com/user-attachments/assets/04603210-69b2-44d4-a15f-aa513e1e45d9)
