### PR TITLE
[SW2] 武器の「用法」の選択肢に「2H投」を追加

### DIFF
--- a/_core/lib/sw2/edit-chara-datalist.pl
+++ b/_core/lib/sw2/edit-chara-datalist.pl
@@ -35,6 +35,7 @@ sub printCharaDataList {
     <option value="1H騎">
     <option value="2H">
     <option value="2H#">
+    <option value="2H投">
     <option value="振2H">
     <option value="突2H">
   </datalist>

--- a/_core/lib/sw2/edit-item.pl
+++ b/_core/lib/sw2/edit-item.pl
@@ -282,6 +282,7 @@ print <<"HTML";
     <option value="1H騎">
     <option value="2H">
     <option value="2H#">
+    <option value="2H投">
     <option value="振2H">
     <option value="突2H">
   </datalist>


### PR DESCRIPTION
# 変更内容

武器の「用法」の選択肢に「2H投」を追加

## 適用対象

- キャラクターの武器欄
- アイテムシートの武器データ

# 背景

『Ⅰ』～『Ⅲ』の範疇では、「2H投」は存在しない。

『エピックトレジャリー』の時点で、ごく少数ながらも「2H投」が登場した。
（〈テムスガルドの～〉シリーズの４種のみ）

『アビスブレイカー』では、〈リムチョッパー〉〈トランクディバイダー〉〈ジャッジメントアックス〉の３種が追加された。
また、『アビスブレイカー』で追加されたダークハンター技能は、かなり積極的に〈投擲〉をあつかう技能であることから、これらの「2H投」の武器を実際にキャラクターシートで採用する頻度や、「2H投」の用法をもつ武器を自作するケースは、従来より格段に増えるものと思われる。

以上をかんがみ、入力の選択肢に追加しておきたい。