### PR TITLE
[DX3] 侵蝕率を固定にする機能を追加

### DIFF
--- a/_core/lib/dx3/edit-chara.js
+++ b/_core/lib/dx3/edit-chara.js
@@ -14,6 +14,7 @@ window.onload = function() {
   checkStage();
   checkWorks();
   checkSyndrome();
+  encroachModeChanged();
   calcStt();
   calcEffect();
   calcMagic();
@@ -443,6 +444,33 @@ function encroachBonusSet(enc){
       break;
     }
   }
+}
+
+function encroachModeChanged() {
+  const checkbox = document.querySelector('input[name="encroachFixed"]');
+  const fixed = checkbox != null && checkbox.checked;
+
+  const lifePathNode = document.getElementById('lifepath');
+  lifePathNode.classList.toggle('encroach-fixed', fixed);
+
+  const awakenInputCell = lifePathNode.querySelector('tbody.awaken tr > td:nth-child(2)');
+  const awakenNoteCell = lifePathNode.querySelector('tbody.awaken tr > td:last-child');
+  const impulseInputCell = lifePathNode.querySelector('tbody.impulse tr:first-child > td:nth-child(2)');
+  const impulseNoteCell = lifePathNode.querySelector('tbody.impulse tr:first-child > td:last-child');
+
+  if (fixed) {
+    awakenInputCell.setAttribute('colspan', '2');
+    awakenNoteCell.setAttribute('colspan', '2');
+    impulseInputCell.setAttribute('colspan', '2');
+    impulseNoteCell.setAttribute('colspan', '2');
+  } else {
+    awakenInputCell.removeAttribute('colspan');
+    awakenNoteCell.removeAttribute('colspan');
+    impulseInputCell.removeAttribute('colspan');
+    impulseNoteCell.removeAttribute('colspan');
+  }
+
+  calcEncroach();
 }
 
 // ロイス ----------------------------------------

--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -506,33 +506,36 @@ print <<"HTML";
               <th id="encounter-or-desire">邂逅/欲望
               <td colspan="2">@{[input "lifepathEncounter"]}
               <td colspan="2" class="left">@{[input "lifepathEncounterNote",'','','placeholder="備考"']}
-          <tbody>
+          <tbody class="awaken">
             <tr>
               <th>覚醒
               <td><select name="lifepathAwaken" oninput="calcEncroach()">@{[option "lifepathAwaken",@awakens]}</select>
-              <th class="small">侵蝕値
-              <td class="center" id="awaken-encroach">
+              <th class="small encroach">侵蝕値
+              <td class="center encroach" id="awaken-encroach">
               <td class="left">@{[input "lifepathAwakenNote",'','','placeholder="備考"']}
-          <tbody>
+          <tbody class="impulse">
             <tr>
               <th rowspan="2">衝動
               <td><select name="lifepathImpulse" oninput="refreshByImpulse()">@{[option "lifepathImpulse",@impulses]}</select>
-              <th class="small">侵蝕値
-              <td class="center" id="impulse-encroach">
+              <th class="small encroach">侵蝕値
+              <td class="center encroach" id="impulse-encroach">
               <td class="left">@{[input "lifepathImpulseNote",'','','placeholder="備考"']}
             <tr>
-              <th class="small">@{[input "lifepathUrgeCheck",'checkbox']}変異暴走
+              <th><span class="small">@{[input "lifepathUrgeCheck",'checkbox']}変異暴走</span>
               <th class="small">効果
               <td class="left" colspan="2">@{[input "lifepathUrgeNote",'','','placeholder="効果"']}
-          <tbody>
+          <tbody class="encroach-offset">
             <tr>
               <th colspan="3" class="right small">その他の修正
               <td class="center">@{[input "lifepathOtherEncroach",'number','calcEncroach']}
               <td class="left">@{[input "lifepathOtherNote",'','','placeholder="備考"']}
-          <tbody>
+          <tbody class="neutral-encroach">
             <tr>
-              <th colspan="3" class="right">侵蝕率基本値
-              <td class="center bold" id="base-encroach">
+              <th colspan="3" class="right">侵蝕率<span class="suffix">基本値</span>
+              <td class="center bold">
+                <span class="calculated-value" id="base-encroach"></span>
+                @{[input "encroachFixedValue", 'number', 'calcEncroach']}
+              <td>@{[ checkbox 'encroachFixed', '侵蝕率を固定にする（ＮＰＣ向け）', 'encroachModeChanged' ]}
           </tbody>
         </table>
       </details>

--- a/_core/lib/dx3/view-chara.pl
+++ b/_core/lib/dx3/view-chara.pl
@@ -269,6 +269,10 @@ my $breedPrefix = ($pc{breed} ? $pc{breed} : $pc{syndrome3} ? 'トライ' : $pc{
 $SHEET->param(breed => isNoiseText(removeTags $breedPrefix) ? $breedPrefix : $breedPrefix ? "$breedPrefix<span class=\"shorten\">ブリード</span>" : '');
 
 ### 侵蝕率基本値 --------------------------------------------------
+if ($pc{encroachFixed}) {
+  $pc{'lifepathOtherEncroach'} = undef;
+  $pc{'lifepathOtherNote'} = undef;
+}
 $SHEET->param(hasEncroachOffset => $pc{'lifepathOtherEncroach'} || $pc{'lifepathOtherNote'} ? 1 : 0);
 
 ### 能力値 --------------------------------------------------

--- a/_core/skin/dx3/css/chara.css
+++ b/_core/skin/dx3/css/chara.css
@@ -357,6 +357,18 @@ body {
     font-size: 87%;
   }
 }
+#lifepath.encroach-fixed table {
+  tbody.awaken .encroach,
+  tbody.impulse .encroach,
+  table tbody.encroach-offset,
+  tbody.neutral-encroach .suffix {
+    display: none;
+  }
+
+  tbody.neutral-encroach {
+    background-color: var(--box-even-rows-bg-color);
+  }
+}
 
 
 /* // Status / Skills
@@ -1212,6 +1224,9 @@ body {
   &[type="checkbox"] + label:hover {
     opacity: 0.8;
   }
+}
+#enc-bonus.encroach-fixed p .encroach-prefix {
+  display: none;
 }
 #enc-bonus table {
   border-top: 1px;

--- a/_core/skin/dx3/css/edit.css
+++ b/_core/skin/dx3/css/edit.css
@@ -140,8 +140,10 @@ body:not(.mode-crc) .crc-only {
 #lifepath table {
   table-layout: auto;
   & th:nth-child(1) { width: 5em; }
-  & td:nth-child(2) { width: 6em; }
-  & th:nth-child(3) { width: 4em; }
+  & td:nth-child(2),
+  & tbody.impulse tr:nth-child(2) th:nth-child(1) { width: 6em; }
+  & th:nth-child(3),
+  & tbody.impulse tr:nth-child(2) th:nth-child(2) { width: 4em; }
   & td.center { width: 4em; }
   & td:last-child   { width: auto; }
 }
@@ -157,6 +159,39 @@ body:not(.mode-crc) .crc-only {
 #lifepath table input[type=checkbox] {
   transform: scale(1.4) translateY(.1em);
   margin-right: .2em;
+}
+#lifepath table th.small {
+  border-bottom-style: solid;
+}
+#lifepath.encroach-fixed {
+  table {
+    tbody.awaken .encroach,
+    tbody.impulse .encroach,
+    tbody.encroach-offset,
+    tbody.neutral-encroach th .suffix,
+    tbody.neutral-encroach td .calculated-value {
+      display: none;
+    }
+
+    tbody.neutral-encroach {
+      background-color: var(--box-even-rows-bg-color);
+    }
+  }
+}
+#lifepath:not(.encroach-fixed) {
+  table tbody.neutral-encroach {
+    td input[name="encroachFixedValue"] {
+      display: none;
+    }
+  }
+}
+#lifepath table tbody.neutral-encroach td:last-child {
+  text-align: left;
+
+  .check-button {
+    border: none;
+    font-size: 80%;
+  }
 }
 @media screen and (width <= 735px){
   #lifepath table,
@@ -202,6 +237,13 @@ body:not(.mode-crc) .crc-only {
   }
   #lifepath tbody:nth-child(5) tr:nth-child(2) th:nth-child(2) {
     display: none;
+  }
+  #lifepath tbody.neutral-encroach:nth-child(n+7) tr {
+    grid-template-columns: 6em 1fr auto;
+  }
+  #lifepath tbody.neutral-encroach:nth-child(n+7) tr td:last-child {
+    font-size: 80%;
+    vertical-align: middle;
   }
 }
 

--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -176,7 +176,7 @@
         <div class="create-type"><TMPL_UNLESS forbiddenMode><TMPL_VAR createTypeName><span class="nowrap shorten">作成</span></TMPL_UNLESS></div>
         </section>
         
-        <section class="box" id="lifepath">
+        <section class="box <TMPL_IF encroachFixed>encroach-fixed</TMPL_IF>" id="lifepath">
           <h2>ライフパス</h2>
           <table class="data-table line-tbody">
             <colgroup><col><col><col></colgroup>
@@ -198,32 +198,34 @@
                 <td rowspan="2" class="comment"><TMPL_VAR lifepathEncounterNote>
               <tr>
                 <td colspan="2"><TMPL_VAR lifepathEncounter></td>
-            <tbody>
+            <tbody class="awaken">
               <tr>
-                <th class="left">覚醒
-                <th class="small">侵蝕値
+                <th class="left" <TMPL_IF encroachFixed>colspan="2"</TMPL_IF>>覚醒
+                <th class="small encroach">侵蝕値
                 <td rowspan="2" class="comment"><TMPL_VAR lifepathAwakenNote>
               <tr>
-                <td><TMPL_VAR lifepathAwaken>
-                <td class="center"><TMPL_VAR lifepathAwakenEncroach></td>
-            <tbody>
+                <td <TMPL_IF encroachFixed>colspan="2"</TMPL_IF>><TMPL_VAR lifepathAwaken>
+                <td class="center encroach"><TMPL_VAR lifepathAwakenEncroach>
+            <tbody class="impulse">
               <tr>
-                <th class="left">衝動
-                <th class="small">侵蝕値
+                <th class="left" <TMPL_IF encroachFixed>colspan="2"</TMPL_IF>>衝動
+                <th class="small encroach">侵蝕値
                 <td rowspan="2" class="comment"><TMPL_VAR lifepathImpulseNote>
               <tr>
-                <td <TMPL_IF lifepathUrgeCheck>style="border-bottom:hidden"</TMPL_IF>><TMPL_VAR lifepathImpulse></td>
-                <td class="center"><TMPL_VAR lifepathImpulseEncroach>
+                <td <TMPL_IF encroachFixed>colspan="2"</TMPL_IF> <TMPL_IF lifepathUrgeCheck>style="border-bottom:hidden"</TMPL_IF>><TMPL_VAR lifepathImpulse>
+                <td class="center encroach"><TMPL_VAR lifepathImpulseEncroach>
               <TMPL_IF lifepathUrgeCheck><tr class="urge">
                 <th colspan="2" class="right">／変異暴走
                 <td class="comment"><TMPL_VAR lifepathUrgeNote></td>
               </TMPL_IF>
             <TMPL_IF hasEncroachOffset>
-            <tbody>
+            <tbody class="encroach-offset">
               <tr><th class="right small">その他の修正<td class="center"><TMPL_VAR lifepathOtherEncroach><td class="comment"><TMPL_VAR lifepathOtherNote>
             </TMPL_IF>
-            <tbody>
-              <tr><th class="right">侵蝕率基本値<td class="center bold"><TMPL_VAR baseEncroach><td>
+            <tbody class="neutral-encroach">
+              <tr><th class="right">侵蝕率<span class="suffix">基本値</span>
+                <td class="center bold"><TMPL_IF encroachFixed><TMPL_VAR encroachFixedValue><TMPL_ELSE><TMPL_VAR baseEncroach></TMPL_IF>
+                <td>
             </tbody>
           </table>
         </section>
@@ -587,11 +589,11 @@
           </table>
         </section>
       </div>
-      <div id="enc-bonus">
+      <div id="enc-bonus" <TMPL_IF encroachFixed>class="encroach-fixed"</TMPL_IF>>
         <details class="box">
           <summary>侵蝕率効果表</summary>
           <p>
-            現在侵蝕率:<input type="number" id="current-encroach" value="<TMPL_VAR currentEncroach>" oninput="encroachBonusSet(this.value);">
+            <span class="encroach-prefix">現在</span>侵蝕率:<TMPL_IF encroachFixed><span class="encroach-fixed-value"><TMPL_VAR encroachFixedValue></span><TMPL_ELSE><input type="number" id="current-encroach" value="<TMPL_VAR currentEncroach>" oninput="encroachBonusSet(this.value);"></TMPL_IF>
             <input type="checkbox" id="encroach-ea-on" oninput="encroachBonusType();" <TMPL_IF encroachEaOn>checked</TMPL_IF>><label for="encroach-ea-on">エフェクトアーカイブ</label>
             <input type="checkbox" id="encroach-or-on" oninput="encroachBonusType();" <TMPL_IF encroachOrOn>checked</TMPL_IF>><label for="encroach-or-on">起源種</label>
           </p>
@@ -631,7 +633,16 @@
         let thBonus = document.createElement("th"); thBonus.textContent = 'ダイス' ; document.getElementById('enc-table-dices').prepend(thBonus);
         let thLevel = document.createElement("th"); thLevel.textContent = 'Efct.Lv'; document.getElementById('enc-table-level').prepend(thLevel);
         
-        encroachBonusSet(document.getElementById('current-encroach').value);
+        let encroachValue;
+        
+        if (document.getElementById('enc-bonus').classList.contains('encroach-fixed')) {
+          const valueText = document.querySelector('#enc-bonus .encroach-fixed-value').textContent;
+          encroachValue = /^\d+$/.test(valueText) ? parseInt(valueText) : -1;
+        } else {
+          encroachValue = document.getElementById('current-encroach').value;
+        }
+        
+        encroachBonusSet(encroachValue);
       }
       function encroachBonusSet(enc){
         for (let v of array){ document.getElementById('enc-col'+v).classList.remove('current'); }


### PR DESCRIPTION
# 変更内容

侵蝕率を固定にする機能を追加

# 背景

『ＤＸ３』においては、ゲストの侵蝕率を固定とする運用法がある。（『ルールブック１』P315）

ルールブック上では方法の一種のように書かれているが、実際のところ、ほとんどのシナリオのゲストはこの運用をされている。
たとえば、付属シナリオのゲストはすべてこの運用か、これに準ずる運用（※）である。

（※：「標準状態では160％だが、シナリオ中で所定の条件を満たした場合には＋30％される」というようなもの）

# 目的

前述のような侵蝕率を固定とするゲストのデータを、ゆとシート上で取り扱えるようにしたい。

（従来は、侵蝕率基本値に対する「その他の修正」を極端に大きな値にするなどで強引に再現していたが、これは機能の用途に対して不自然な運用である。また、目当ての侵蝕率にするために必要な補正値を計算する必要があり、直感的でもない）

# 仕様

## 侵蝕率を固定にする方法

既存の「侵蝕率基本値」の側に、「侵蝕率を固定にする（ＮＰＣ向け）」というチェックボックスを設け、これをチェックした場合には侵蝕率が固定される。

![image](https://github.com/user-attachments/assets/ea8df49d-ac19-4561-9060-2a052ab997e9)

## 侵蝕率が固定されている状態

- 「覚醒」「衝動」に対応する侵蝕率（基本値）が表示されなくなる
- 侵蝕率基本値に対する「その他の修正」が表示されなくなる
- 「侵蝕率」を直接入力する _input_ が表示される（編集画面）
- 「基本値」の文言がなくなり、「侵蝕率」とだけ表示される

![image](https://github.com/user-attachments/assets/1d35f79c-8117-4990-91fe-5b7c0febbc5f)

![image](https://github.com/user-attachments/assets/29d888e0-ffee-4811-b1d5-412266661811)
