### PR TITLE
修正:[AR2E]デフォルト変数のアイテム鑑定ダイスに不要な+記号が含まれている。

### DIFF
--- a/_core/lib/ar2e/palette-sub.pl
+++ b/_core/lib/ar2e/palette-sub.pl
@@ -115,7 +115,7 @@ sub paletteProperties {
     push @propaties, "//エネミー識別={知力判定}".addNum($::pc{rollEnemyLoreAdd});
     push @propaties, "//エネミー識別ダイス="    .$::pc{rollEnemyLoreDice};
     push @propaties, "//アイテム鑑定={知力判定}".addNum($::pc{rollAppraisalAdd});
-    push @propaties, "//アイテム鑑定ダイス="    .addNum($::pc{rollAppraisalDice});
+    push @propaties, "//アイテム鑑定ダイス="    .$::pc{rollAppraisalDice};
     push @propaties, "//魔術判定={知力判定}"    .addNum($::pc{rollMagicAdd});
     push @propaties, "//魔術判定ダイス="        .$::pc{rollMagicDice};
     push @propaties, "//呪歌判定={精神判定}"    .addNum($::pc{rollSongAdd});


### PR DESCRIPTION
https://github.com/yutorize/ytsheet2/pull/306 の変更の際の記入ミスで
//アイテム鑑定ダイス=+2
等の表記になってる症状の修正。