### PR TITLE
[SW2] 編集画面において、キャラクター作成時点の経験点・ガメル・名誉点をカンマ区切りにする

### DIFF
--- a/_core/lib/sw2.0/edit-chara.pl
+++ b/_core/lib/sw2.0/edit-chara.pl
@@ -1462,9 +1462,9 @@ print <<"HTML";
               <td>-
               <td>
               <td>キャラクター作成
-              <td id="history0-exp">$pc{history0Exp}
-              <td id="history0-money">$pc{history0Money}
-              <td id="history0-honor">$pc{history0Honor}
+              <td id="history0-exp">@{[commify $pc{history0Exp}]}
+              <td id="history0-money">@{[commify $pc{history0Money}]}
+              <td id="history0-honor">@{[commify $pc{history0Honor}]}
               <td id="history0-grow">$pc{history0Grow}
             </tr>
 HTML

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -113,9 +113,9 @@ function formCheck(){
 
 // レギュレーション ----------------------------------------
 function changeRegu(){
-  document.getElementById("history0-exp").textContent = form.history0Exp.value;
-  document.getElementById("history0-honor").textContent = form.history0Honor.value;
-  document.getElementById("history0-money").textContent = form.history0Money.value;
+  document.getElementById("history0-exp").textContent = commify(form.history0Exp.value);
+  document.getElementById("history0-honor").textContent = commify(form.history0Honor.value);
+  document.getElementById("history0-money").textContent = commify(form.history0Money.value);
   
   calcExp();
   calcLv();

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -1485,9 +1485,9 @@ print <<"HTML";
               <td>-
               <td>
               <td>キャラクター作成
-              <td id="history0-exp">$pc{history0Exp}
-              <td id="history0-money">$pc{history0Money}
-              <td id="history0-honor">$pc{history0Honor}
+              <td id="history0-exp">@{[commify $pc{history0Exp}]}
+              <td id="history0-money">@{[commify $pc{history0Money}]}
+              <td id="history0-honor">@{[commify $pc{history0Honor}]}
               <td id="history0-grow">$pc{history0Grow}
             </tr>
 HTML


### PR DESCRIPTION
これらは四桁以上になる数値であり、そうした巨大な数はカンマ区切りのほうが読み取りやすいため。
また、閲覧画面においてはカンマ区切りで表記されることを踏まえ、それに合わせる意図もある。

![image](https://github.com/user-attachments/assets/c0aff6a5-c781-4b3f-b664-eb502dd5387d)
