### PR TITLE
Fix: [SW2] 魔力欄の `―` 表記が視認しづらい問題に対処

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -564,9 +564,9 @@ foreach my $class (@data::class_names){
     NAME => $class."<wbr><span class=\"small\">技能レベル</span>".$pc{'lv'.$id},
     OWN  => ($pc{'magicPowerOwn'.$id} ? '✔<span class="small">'.$stt.'+2</span>' : ''),
     MAGIC  => $name,
-    POWER  => ($pname) ? ($power ? '<span class="small">'.addNum($power).'=</span>' : '').$pc{'magicPower'.$id} : '―',
+    POWER  => ($pname) ? ($power ? '<span class="small">'.addNum($power).'=</span>' : '').$pc{'magicPower'.$id} : '<span class="nan">―</span>',
     CAST   => ($cast ? '<span class="small">'.addNum($cast).'=</span>' : '').($pc{'magicPower'.$id}+$cast),
-    DAMAGE => ($pname) ? addNum($damage)||'+0' : '―',
+    DAMAGE => ($pname) ? addNum($damage)||'+0' : '<span class="nan">―</span>',
   } );
 }
 $SHEET->param(MagicPowers => \@magic);

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -777,6 +777,10 @@ dl#level {
     font-size: 1.15em;
     line-height: 1.6;
     white-space: nowrap;
+
+    > .nan {
+      font-size: 1.5rem;
+    }
   }
 }
 #magic-power #fairycontact {


### PR DESCRIPTION
# 現象

環境によっては、魔力欄の `―` 表記が視認しづらいことがある。

![image](https://github.com/user-attachments/assets/81240d5e-85a5-43d6-810a-3ce5224a2e66)
（画像下側の武器攻撃欄の `―` とくらべて、かなり視認しづらい）

# 原因

フォントサイズが半端に大きいことによるっぽい

# 対処

`―` のフォントサイズを（外側のスタイルにかかわらず）一定にする。

![image](https://github.com/user-attachments/assets/3bfaebc7-a3ef-4c93-a613-28c7ff01bb8a)
