### PR TITLE
[SW2] Fix: バトルダンサーの追加の宣言特技枠に由来する特技がチャットパレットに含まれない不具合を修正

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -229,7 +229,7 @@ sub palettePreset {
     # 宣言特技
     require $set::data_feats;
     my @declarationFeats = ();
-    foreach ('1+', @set::feats_lv) {
+    foreach ('1bat', @set::feats_lv) {
       my $level = $_;
       last if $level ne '1+' && $level > $::pc{level};
       my $featName = $::pc{"combatFeatsLv${level}"};


### PR DESCRIPTION
26940e7b2fa0e1f6b33395addc985716accf8e06 の不備

永続化データにおいては、 `combatFeatsLv1+` ではなく `combatFeatsLv1bat` としてアクセスするのが正しかった。