### PR TITLE
[SW2] 防御の定義が複数ある場合、チャットパレットの回避力コマンドに技能名を付加する

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -554,7 +554,9 @@ sub palettePreset {
 
       $text .= "2d+";
       $text .= $::pc{paletteUseVar} ? "{回避${i}}" : $::pc{"defenseTotal${i}Eva"};
-      $text .= "+{回避修正} 回避力".($::pc{"defenseTotal${i}Note"}?"／$::pc{'defenseTotal'.$i.'Note'}":'')."\n";
+      $text .= "+{回避修正} 回避力";
+      $text .= '（' . $::pc{"evasionClass${i}"} . '）' if (grep { $::pc{"evasionClass${_}"} } (1 .. $::pc{defenseNum})) > 1;
+      $text .= ($::pc{"defenseTotal${i}Note"}?"／$::pc{'defenseTotal'.$i.'Note'}":'')."\n";
     }
     $text .= appendPaletteInsert('defense');
     


### PR DESCRIPTION
# 背景

図のように、複数の防御の定義をもつキャラクターがあるとき、
![image](https://github.com/user-attachments/assets/0e7bfa66-94b6-4a7d-b897-f7e8926a4f5e)

そのチャットパレットは、
```
回避力 2d+9+{回避修正}
回避力 2d+10+{回避修正}
```
のように出力されていた。

# 問題

チャットパレットだけを見たとき、それぞれの回避力のコマンドがいずれの防御の定義を参照しているのかが明確でない。
（どっちがどっちだかわからない）

# 改善

上記を改善すべく、防御の定義が複数ある場合にかぎり、回避力コマンドに技能名を付記するように。

```
回避力（ファイター） 2d+9+{回避修正}
回避力（デーモンルーラー） 2d+10+{回避修正}
```