### PR TITLE
[SW2] 魔晶石の在庫を管理する機能を追加

### DIFF
--- a/_core/lib/sw2.0/edit-chara.pl
+++ b/_core/lib/sw2.0/edit-chara.pl
@@ -1347,6 +1347,33 @@ print <<"HTML";
           </div>
         </div>
         <div id="area-items-R">
+          <details class="box" id="mana-gems" @{[ (grep { my $key = $_ < 10 ? ('0' . $_) : $_; $pc{"manaGem${key}Quantity"} || $pc{"manaGem${key}Offset"} } (1 .. 20)) ? 'open' : '' ]}>
+            <summary class="in-toc">魔晶石</summary>
+            <table class="edit-table no-border-cells">
+              <thead>
+                <th class="point">点数
+                <th class="quantity">所持数
+                <th class="offset">一時的増減
+                <th class="total">
+              </thead>
+              <tbody>
+HTML
+foreach my $point (1 .. 20) {
+  my $key = $point < 10 ? ('0' . $point) : $point;
+  print <<"HTML";
+                <tr data-point="${point}">
+                  <th class="point">${point}点
+                  <td class="quantity">@{[input "manaGem${key}Quantity",'number',"calcManaGem(${point})",'min="0"']}
+                  <td class="offset">@{[input "manaGem${key}Offset",'number',"calcManaGem(${point})"]}
+                  <td class="total">=<span class="value"></span><i class="unit">個</i>
+                </tr>
+HTML
+}
+print <<"HTML";
+              </tbody>
+            </table>
+            <button type="button" id="clearing-off-mana-gems-offset" onclick="clearOffManaGemsOffset();" disabled>一時的増減を清算する</button>
+          </details>
           <div class="box" id="material-cards"@{[ display $pc{lvAlc} ]}>
             <h2 class="in-toc">マテリアルカード</h2>
             <table class="edit-table no-border-cells" >

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -89,6 +89,7 @@ window.onload = function() {
   calcHonor();
   calcDishonor();
   calcCommonClass();
+  calcManaGems();
   checkEffectAll();
   setupBracketInputCompletion();
   
@@ -2502,6 +2503,85 @@ function addPart(){
 function delPart(){
   delRow('partNum', '#parts tbody tr:last-of-type');
   calcParts();
+}
+// 魔晶石 ----------------------------------------
+function calcManaGems() {
+  for (let point = 1; point <= 20; point++) {
+    calcManaGem(point);
+  }
+}
+/**
+ * @param {int} point
+ */
+function calcManaGem(point) {
+  const tr = document.querySelector(`#mana-gems table tr[data-point="${point}"]`);
+
+  const quantity = parseInt(tr.querySelector('.quantity input').value);
+  const offset = parseInt(tr.querySelector('.offset input').value);
+
+  const total = (isNaN(quantity) ? 0 : quantity) + (isNaN(offset) ? 0 : offset);
+
+  const valueElement = tr.querySelector('.total .value');
+  valueElement.textContent = commify(total);
+  valueElement.classList.toggle('zero', total === 0);
+  valueElement.classList.toggle('minus', total < 0);
+
+  switchManaGemClearingOffButton();
+}
+function switchManaGemClearingOffButton() {
+  let hasOffset = false;
+
+  for (let point = 1; point <= 20; point++) {
+    const offset = parseInt(document.querySelector(`#mana-gems table tr[data-point="${point}"] .offset input`).value);
+
+    if (!isNaN(offset) && offset !== 0) {
+      hasOffset = true;
+      break;
+    }
+  }
+
+  document.getElementById('clearing-off-mana-gems-offset').disabled = !hasOffset;
+}
+function clearOffManaGemsOffset() {
+  /** @var {Array<Function>} */
+  const clearingFunctions = [];
+
+  for (let point = 1; point <= 20; point++) {
+    const tr = document.querySelector(`#mana-gems table tr[data-point="${point}"]`);
+
+    const quantityInput = tr.querySelector('.quantity input');
+    const offsetInput = tr.querySelector('.offset input');
+
+    const offset = parseInt(offsetInput.value);
+
+    if (isNaN(offset) || offset === 0) {
+      continue;
+    }
+
+    const quantity = quantityInput.value !== '' ? parseInt(quantityInput.value) : 0;
+    const clearedQuantity = quantity + offset;
+
+    if (clearedQuantity < 0) {
+      alert(`魔晶石（${point}点）の減少量が元の所持数より大きいため清算できません。`);
+      return;
+    }
+
+    clearingFunctions.push(((quantityInput, offsetInput, clearedQuantity) => {
+      return () => {
+        quantityInput.value = clearedQuantity.toString();
+        offsetInput.value = '';
+
+        for (const input of [quantityInput, quantityInput]) {
+          input.dispatchEvent(new Event('input'));
+          input.dispatchEvent(new Event('change'));
+        }
+      };
+    })(quantityInput, offsetInput, clearedQuantity));
+  }
+
+  clearingFunctions.forEach(x => x.call());
+
+  switchManaGemClearingOffButton();
 }
 // 名誉アイテム欄 ----------------------------------------
 // 追加

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -1348,6 +1348,33 @@ print <<"HTML";
           </div>
         </div>
         <div id="area-items-R">
+          <details class="box" id="mana-gems" @{[ (grep { my $key = $_ < 10 ? ('0' . $_) : $_; $pc{"manaGem${key}Quantity"} || $pc{"manaGem${key}Offset"} } (1 .. 20)) ? 'open' : '' ]}>
+            <summary class="in-toc">魔晶石</summary>
+            <table class="edit-table no-border-cells">
+              <thead>
+                <th class="point">点数
+                <th class="quantity">所持数
+                <th class="offset">一時的増減
+                <th class="total">
+              </thead>
+              <tbody>
+HTML
+foreach my $point (1 .. 20) {
+  my $key = $point < 10 ? ('0' . $point) : $point;
+  print <<"HTML";
+                <tr data-point="${point}">
+                  <th class="point">${point}点
+                  <td class="quantity">@{[input "manaGem${key}Quantity",'number',"calcManaGem(${point})",'min="0"']}
+                  <td class="offset">@{[input "manaGem${key}Offset",'number',"calcManaGem(${point})"]}
+                  <td class="total">=<span class="value"></span><i class="unit">個</i>
+                </tr>
+HTML
+}
+print <<"HTML";
+              </tbody>
+            </table>
+            <button type="button" id="clearing-off-mana-gems-offset" onclick="clearOffManaGemsOffset();" disabled>一時的増減を清算する</button>
+          </details>
           <div class="box" id="material-cards"@{[ display $pc{lvAlc} ]}>
             <h2 class="in-toc">マテリアルカード</h2>
             <table class="edit-table no-border-cells" >

--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -87,6 +87,19 @@ sub createUnitStatus {
       }
       push(@unitStatus, { '陣気' => '0' }) if $pc{lvWar};
     }
+
+    foreach my $point (1 .. 20) {
+      my $key = $point < 10 ? ('0' . $point) : $point;
+      my $quantity = $pc{"manaGem${key}Quantity"} // 0;
+      next if $quantity == 0;
+
+      sub encloseNumeric {
+        my $num = shift;
+        return ('①', '②', '③', '④', '⑤', '⑥', '⑦', '⑧', '⑨', '⑩', '⑪', '⑫', '⑬', '⑭', '⑮', '⑯', '⑰', '⑱', '⑲', '⑳')[$num - 1];
+      }
+
+      push(@unitStatus, { '魔晶石' . encloseNumeric($point) => $quantity });
+    }
   }
 
   foreach my $key (split ',', $pc{unitStatusNotOutput}){

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -979,6 +979,45 @@ if(exists $data::races{$pc{race}}{parts}){
   $SHEET->param(Parts => \@row);
 }
 
+### 魔晶石 --------------------------------------------------
+my @manaGems = ();
+{
+  my $lastColumn = 0;
+  my $row;
+
+  foreach my $point (1 .. 20) {
+    my $key = $point < 10 ? ('0' . $point) : $point;
+
+    my $quantity = $pc{"manaGem${key}Quantity"} // 0;
+    my $offset = $pc{"manaGem${key}Offset"} // 0;
+
+    my $total = $quantity + $offset;
+    next if $total == 0;
+
+    my $startColumn = $point < 10 ? 1 : 4;
+
+    if ($startColumn > $lastColumn) {
+      $row = 1;
+      $lastColumn = $startColumn;
+    }
+    else {
+      $row++;
+    }
+
+    push(
+        @manaGems,
+        {
+            POINT        => $point,
+            TOTAL        => commify($total),
+            ROW          => $row,
+            POINT_COLUMN => $startColumn,
+            TOTAL_COLUMN => $startColumn + 1,
+        }
+    );
+  }
+}
+$SHEET->param(ManaGems => \@manaGems);
+
 ### 履歴 --------------------------------------------------
 
 $pc{history0Grow} .= '器用'.$pc{sttPreGrowA} if $pc{sttPreGrowA};

--- a/_core/skin/sw2.0/sheet-chara.html
+++ b/_core/skin/sw2.0/sheet-chara.html
@@ -523,6 +523,17 @@
           </section>
         </div>
         <div id="area-items-R">
+          <section class="box" id="mana-gems">
+            <h2>魔晶石</h2>
+            <dl>
+              <TMPL_LOOP ManaGems>
+                <dt class="point" style="grid-column-start: <TMPL_VAR POINT_COLUMN>; grid-row-start: <TMPL_VAR ROW>;">
+                  <TMPL_VAR POINT>点
+                <dd class="total" style="grid-column-start: <TMPL_VAR TOTAL_COLUMN>; grid-row-start: <TMPL_VAR ROW>;">
+                  <i class="mark">×</i><span class="value"><TMPL_VAR TOTAL></span><i class="unit">個</i>
+              </TMPL_LOOP>
+            </dl>
+          </section>
           <TMPL_IF lvAlc><section class="box" id="material-cards">
             <h2>マテリアルカード</h2>
             <table class="data-table">

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1023,6 +1023,90 @@ dl#level {
   }
 }
 
+/* 魔晶石 */
+#mana-gems {
+  table {
+    .point {
+      width: 3em;
+    }
+
+    td.total {
+      display: grid;
+      grid-template-columns: max-content 1fr max-content;
+      padding: 0 0.25em;
+      text-wrap: nowrap;
+      word-break: keep-all;
+      white-space: nowrap;
+
+      &:has(.value.zero) {
+        color: gray;
+        opacity: 0.8;
+      }
+
+      &:has(.value.minus) {
+        color: #e70;
+      }
+
+      .value {
+        display: inline-block;
+        text-wrap: nowrap;
+        word-break: keep-all;
+        white-space: nowrap;
+        text-align: right;
+      }
+
+      .unit {
+        display: flex;
+        flex-flow: row;
+        align-items: flex-end;
+        font-size: smaller;
+        font-style: normal;
+      }
+    }
+  }
+
+  #clearing-off-mana-gems-offset {
+    margin: 0.25em;
+
+    &[disabled] {
+      pointer-events: none;
+      opacity: 0.5;
+    }
+  }
+
+  dl {
+    display: grid;
+    grid-template-columns: repeat(2, max-content max-content 1fr);
+    padding: 0 0.5em;
+
+    .point {
+      text-align: right;
+    }
+
+    .total {
+      i {
+        font-style: normal;
+      }
+
+      text-align: right;
+      padding-left: 0.5em;
+
+      .mark {
+        float: left;
+      }
+
+      .value {
+        display: inline-block;
+        text-align: right;
+      }
+
+      .unit {
+        font-size: smaller;
+      }
+    }
+  }
+}
+
 /* MaterialCard */
 #material-cards table {
   & tr > * {

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -522,6 +522,19 @@
           </section>
         </div>
         <div id="area-items-R">
+          <TMPL_IF ManaGems>
+          <section class="box" id="mana-gems">
+            <h2>魔晶石</h2>
+            <dl>
+              <TMPL_LOOP ManaGems>
+                <dt class="point" style="grid-column-start: <TMPL_VAR POINT_COLUMN>; grid-row-start: <TMPL_VAR ROW>;">
+                  <TMPL_VAR POINT>点
+                <dd class="total" style="grid-column-start: <TMPL_VAR TOTAL_COLUMN>; grid-row-start: <TMPL_VAR ROW>;">
+                  <i class="mark">×</i><span class="value"><TMPL_VAR TOTAL></span><i class="unit">個</i>
+              </TMPL_LOOP>
+            </dl>
+          </section>
+          </TMPL_IF>
           <TMPL_IF lvAlc><section class="box" id="material-cards">
             <h2>マテリアルカード</h2>
             <table class="data-table">


### PR DESCRIPTION
# 変更内容

魔晶石の在庫を管理する機能を追加。

- 点数ごとの所持数の入力
- 点数ごとの一時的増減量の記録
- 一時的増減量の機械的な清算
- ユニット出力において、魔晶石の所持数を含める

機能の詳細は後述。

# 背景と目的

〈魔晶石〉は、“新規に作成されたばかりの（＝２レベルの）キャラクターによるセッション”でもないかぎり、ほとんどのセッションにおいて、かなり多くのキャラクターが使用するアイテムである。

具体的な採用の度合いについては環境やセッションごとにおいて差があると思われるものの、５レベル以上ともなればほぼすべてのセッションにおいてほぼすべてのキャラクターが使用するものだと考えられる。

また、ゲームプレイ中の増減も非常に激しい。戦闘においては１手番中に複数個（場合によっては二桁個）が消費されることはごくありふれており、また、きわめて汎用性の高い消耗品であることから、セッション中の購入（買い足し）や、前払い報酬、あるいは冒険中の獲得なども比較的頻繁である。

以上のように、採用の頻度・消費の頻度の両面において、〈マテリアルカード〉より上だと思われる。
入手の頻度については、〈粗製のマテリアルカード〉にはおそらく劣るものの、それでもかなり高いと考えられる。

この数量管理をあるていどツールでサポートすることで、ゲームプレイの便宜を改善したい。

# 機能の詳細

## 所持数と一時的増減量の記録

点数ごとに、「所持数」と「一時的増減」を入力できる。

![image](https://github.com/user-attachments/assets/a9c7e3c9-ec4e-4dfe-b601-5d5a14bea9fa)

想定する利用法は、

- 所持数：キャラクター作成ないし成長時に用意した数
- 一時的増減：セッション本編中に増減した数

を、それぞれ入力することである。

「一時的増減」の欄をことさらに設けてあるのは、〈魔晶石〉は増減が非常に激しいことと、そうした増減の状況は別途記録しておきたいケース（プレイヤー）があるため。
むろん、「一時的増減」を意識する必要がないと考えるケース（ユーザー）においては、「一時的増減」欄を無視して「所持数」欄のみで管理してもよい。

「所持数」と「一時的増減」の和は常に自動的に計算され、右側に表示される。

もし減少量の絶対値が所持数を上回った場合には、和の色を変更して強調する。
![image](https://github.com/user-attachments/assets/75a16954-471c-49b0-b9dc-607f844800ce)

なお、この欄（ box ）はそこそこ巨大になったため、折り畳めるようにしたうえで、入力がない状態では自動的に畳まれている。

## 一時的増減量の機械的な清算

「一時的増減を清算する」ボタンをクリックすると、「一時的増減」の結果を「所持数」に反映し、「一時的増減」欄をクリアする。
![ytsheet-mana_gems_clear_off](https://github.com/user-attachments/assets/d2d899bd-93b4-41ea-bbac-6c657ec826dc)

このとき、減少量の絶対値が所持数を上回る行（点数）がある場合には、エラーメッセージを alert で表示し、清算しない。
![image](https://github.com/user-attachments/assets/2aafd63d-3529-421a-9b2d-298633212590)

## ユニット出力に魔晶石の所持数を含める

ユニット出力に対し、「所持数」が入力されている〈魔晶石〉の数を含める。
（ユニットを出力するのは作成ないし成長を終えた直後の状態であると考えられるため、ここでは「一時的増減」は加味しない）

![image](https://github.com/user-attachments/assets/0191262b-8211-4ba7-9e04-3507301ca4cd)

不要な場合には、他の項目と同様に、「出力しない」のチェックボックスによって除外が可能である。

## 閲覧画面での表示

閲覧画面では、端的に、点数ごとの数を表示する。
この数は、「所持数」と「一時的増減」の和である。
![image](https://github.com/user-attachments/assets/2cf07aba-db2b-489d-9963-987630ce6e94)

２列に区切って表示するようにし、左側が一桁点数、右側が二桁点数となるようにレイアウトしてある。
（１～５点を中心とする一桁点数の〈魔晶石〉と、10・15・20点を中心とする二桁点数の〈魔晶石〉は、価格やゲーム中の運用にそれなりの差があるため、このようなレイアウトが最もプレイヤーの直感に合致すると考えた）