### PR TITLE
[SW2] 戦利品の出目範囲を上下中央揃えにする

### DIFF
--- a/_core/skin/sw2/css/monster.css
+++ b/_core/skin/sw2/css/monster.css
@@ -354,7 +354,9 @@ table.status {
       background-color: var(--monster-head-bg-color);
       border-width: 0px 1px 1px 0px;
       border-style: solid;
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      align-items: center;
       min-width: 6em;
     }
     > dd {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d08094f7-58b2-407a-97f9-7e63d4493686)
