### PR TITLE
[SW2] 戦利品の具体的内容の表示を `word-break: auto-phrase;` にする

### DIFF
--- a/_core/skin/sw2/css/monster.css
+++ b/_core/skin/sw2/css/monster.css
@@ -362,6 +362,7 @@ table.status {
       padding: .2rem .5rem;
       border-width: 0px 0px 1px;
       border-style: solid;
+      word-break: auto-phrase;
     }
     > dt:last-of-type,
     > dd:last-of-type {


### PR DESCRIPTION
当該箇所は、ほとんどの場合、端的な名詞や名詞句から成るはずなので、おそらく `auto-phrase` のほうが適している