### PR TITLE
[SW2] 秘伝・秘伝魔法をひとつでも習得しているなら、消費名誉点が 0 であっても名誉アイテム欄の秘伝の行を表示する

### DIFF
--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1826,24 +1826,32 @@ function calcHonor(){
     form['honorItem'+i+'Pt'].classList.toggle('mark', (point && point <= free));
   }
   // 流派
-  let mysticArtsPt = 0;
+  let mysticArtsPt = null;
   for (let i = 1; i <= form.mysticArtsNum.value; i++){
+    if ((form[`mysticArts${i}`].value ?? '') === '') {
+      continue;
+    }
     let point = safeEval(form['mysticArts'+i+'Pt'].value) || 0;
+    mysticArtsPt ??= 0;
     mysticArtsPt += point;
     form['mysticArts'+i+'Pt'].classList.toggle('mark', (point && point <= free));
   }
   for (let i = 1; i <= form.mysticMagicNum.value; i++){
+    if ((form[`mysticMagic${i}`].value ?? '') === '') {
+      continue;
+    }
     let point = safeEval(form['mysticMagic'+i+'Pt'].value) || 0;
+    mysticArtsPt ??= 0;
     mysticArtsPt += point;
     form['mysticMagic'+i+'Pt'].classList.toggle('mark', (point && point <= free));
   }
-  pointTotal -= mysticArtsPt;
+  pointTotal -= mysticArtsPt ?? 0;
   //
   pointTotal -= Number(form.honorOffset.value) + Number(form.honorOffsetBarbaros.value);
   document.getElementById("honor-value"   ).textContent = pointTotal;
   document.getElementById("honor-value-MA").textContent = pointTotal;
   document.getElementById("mystic-arts-honor-value").textContent = mysticArtsPt;
-  document.getElementById('honor-items-mystic-arts').style.display = mysticArtsPt ? '' : 'none';
+  document.getElementById('honor-items-mystic-arts').style.display = mysticArtsPt != null ? '' : 'none';
 }
 // 不名誉点計算
 function calcDishonor(){

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -343,6 +343,7 @@ my $mysticarts_honor = $mysticarts_honor{human}
                      .($mysticarts_honor{dragon}  ?"<br><small>竜</small>$mysticarts_honor{dragon}"  :'');
 $SHEET->param(MysticArts => \@mystic_arts);
 $SHEET->param(MysticArtsHonor => $mysticarts_honor);
+$SHEET->param(DisplayArtsHonor => @mystic_arts ? 1 : 0);
 
 ### 秘奥魔法 --------------------------------------------------
 my %gramarye_ruby;

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -560,7 +560,7 @@
               <tbody>
                 <TMPL_IF rankHonorValue><tr><td>冒険者ランク<td><TMPL_VAR rankHonorValue></TMPL_IF>
                 <TMPL_IF rankBarbarosValue><tr><td>バルバロス栄光ランク<td><TMPL_VAR rankBarbarosValue></TMPL_IF>
-                <TMPL_IF MysticArtsHonor><tr><td>秘伝<td><TMPL_VAR MysticArtsHonor></TMPL_IF>
+                <TMPL_IF DisplayArtsHonor><tr><td>秘伝<td><TMPL_VAR MysticArtsHonor></TMPL_IF>
                 <TMPL_LOOP HonorItems><tr><td class="left"><TMPL_VAR NAME><td><TMPL_VAR PT></TMPL_LOOP>
                 <TMPL_IF honorOffset><tr><td>不名誉点相殺<td><TMPL_VAR honorOffset></TMPL_IF>
                 <TMPL_IF honorOffsetBarbaros><tr><td>不名誉点相殺（蛮族）<td><TMPL_VAR honorOffsetBarbaros></TMPL_IF>


### PR DESCRIPTION
# 変更内容

秘伝・秘伝魔法をひとつでも習得しているなら、消費名誉点が 0 であっても名誉アイテム欄の秘伝の行を表示する。

※これまでは、秘伝・秘伝魔法の消費名誉点の総和が 0 のときは、名誉アイテム欄において、秘伝の行が表示されていなかった

# 背景

「フリー」のルールにより、“秘伝や秘伝魔法への実質的な名誉点の消費がすべて 0 ”というケースはそれなりにある。

ここで、消費が 0 であるならば表示しなくてもよいという考えもありうるが、直接入力の通常の名誉アイテム（例：〈頑丈なランタン〉）の場合、アイテム名を記入したうえで消費を 0 とする運用が一般的だと思われる。
こうしたアイテムは、消費が 0 であっても名誉アイテム欄に記入し、表示されるのであるから、秘伝についてもそれに合わせたほうが一貫性が高まると考える。