### PR TITLE
〈情報:学問〉の括弧閉じ漏れの修正

### DIFF
--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -1325,7 +1325,7 @@ print <<"HTML";
     <option value="〈情報:裏社会〉">
     <option value="〈情報:警察〉">
     <option value="〈情報:軍事〉">
-    <option value="〈情報:学問">
+    <option value="〈情報:学問〉">
     <option value="〈情報:ウェブ〉">
     <option value="〈情報:メディア〉">
     <option value="〈情報:ビジネス〉">


### PR DESCRIPTION
一般アイテムで技能を指定する際、プルダウン内の〈情報:学問〉の閉じカッコが抜けていた脱字を修正