### PR TITLE
[SW2] チャットパレットの「非戦闘系」の見出しに、必要に応じ「魔物知識」「先制」の文言を追加する

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -193,7 +193,10 @@ sub palettePreset {
   if(!$type){
     $text .= appendPaletteInsert('');
     # 基本判定
-    $text .= "### ■非戦闘系\n";
+    $text .= "### ■非戦闘系";
+    $text .= "・魔物知識" if $::pc{monsterLore};
+    $text .= "・先制" if $::pc{initiative};
+    $text .= "\n";
     foreach my $statusName ('器用', '敏捷', '筋力', '生命', '知力','精神') {
       $text .= "2d+{冒険者}+{${statusName}B} 冒険者＋${statusName}\n";
     }


### PR DESCRIPTION
# 変更内容

チャットパレットの「非戦闘系」の見出しに、必要に応じ「魔物知識」「先制」の文言を追加する

# 背景

- 戦闘開始処理における「魔物知識判定」と「先制判定」は、「戦闘」の一部である。（『Ⅰ』128頁）
- 「魔物知識判定」をおこなうのは戦闘中のみとはかぎらないが、すくなくとも戦闘に際しておこなう蓋然性はかなり高い。
- 「先制判定」をおこなうのは常に戦闘中である。

上記をかんがみたとき、魔物知識判定・先制判定のためのコマンドが「非戦闘系」と（のみ）明記されている箇所に存在するのは、すくなからず不適切である。

- ルールに照らして妥当さに欠ける（とくに先制判定）
- コマンドがどこに存在するのかを把握していないような経験の浅いユーザーに対しては、誤導的でもある
  - 戦闘に際した魔物知識判定や先制判定のコマンドを探すときに、「非戦闘中」と銘打ってある箇所は探さない可能性がかんがえられる
    - とくにゆとチャadv.やTekeyにおいては折り畳みが適用されるため、物理的に視界に入らないことすらありうる

# 仕様

- 魔物知識が 0 でなければ、見出しに `・魔物知識` の文言を追加する
- 先制力が 0 でなければ、見出しに `・先制` の文言を追加する
