### PR TITLE
[SW2.5] 『2.5』にかぎり、呪歌・終律の判定コマンドに付記する文言を「演奏判定」にする

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -381,7 +381,7 @@ sub palettePreset {
 
         $text .= "2d+{$power}";
         if   ($name =~ /魔/){ $text .= "$activePower+{行使修正}$activeCast ${name}行使$activeName\n"; }
-        elsif($name =~ /歌/){ $text .= " 呪歌演奏\n"; }
+        elsif($name =~ /歌/){ $text .= " @{[$::SW2_0 ? '呪歌演奏' : '演奏判定']}\n"; }
         else                { $text .= " ${name}\n"; }
         
         if($dmgTexts{$paNum + 1} && $dmgTexts{$paNum} eq $dmgTexts{$paNum + 1}){


### PR DESCRIPTION
従来は「呪歌演奏」という文言だった。

しかし、「呪歌」にかぎらず「終律」でも同じ判定をもちいるため、「呪歌」に限定しない表現のほうが望ましい。
『2.5』においてはこの判定には「演奏判定」という名称があるので、これをもちいる。
（『Ⅱ』123頁および125頁）

『2.0』には「演奏判定」という用語がなく、また「終律」も存在しないため、従来のまま「呪歌演奏」としておく。