### PR TITLE
Fix: [SW2.5] 終律のダメージコマンドに付記する文言を「呪歌」から「終律」に変更

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -390,7 +390,9 @@ sub palettePreset {
         if($dmgTexts{$paNum} eq $dmgTexts{$paNum - 1}){
           $activeName = $::pc{'paletteMagic'.($paNum - 1).'Name'} ? "＋$::pc{'paletteMagic'.($paNum - 1).'Name'}" : '';
         }
-        $text .= $bot{BCD} ? ($dmgTexts{$paNum} =~ s/(ダメージ|半減)(\n|／)/$1／$name$activeName$2/gr) : $dmgTexts{$paNum};
+        my $actionName = $name;
+        $actionName = '終律' if !$::SW2_0 && $actionName eq '呪歌';
+        $text .= $bot{BCD} ? ($dmgTexts{$paNum} =~ s/(ダメージ|半減)(\n|／)/$1／$actionName$activeName$2/gr) : $dmgTexts{$paNum};
         $text .= "\n";
       }
     }


### PR DESCRIPTION
ダメージを与えるのは「呪歌」ではなく「終律」なので