### PR TITLE
Fix: [SW2] 流派データに流派装備を追加した時点では、当該アイテムが複数のカテゴリをもつ可能性が考慮されていない不具合を修正

### DIFF
--- a/_core/lib/sw2/edit-arts.js
+++ b/_core/lib/sw2/edit-arts.js
@@ -187,7 +187,7 @@ async function addSchoolItem(){
       tr.setAttribute('class','item-data');
       tr.innerHTML = `
         <td><a href="${url}">${ruby(data.itemName||'')}</a></td>
-        <td>${data.category||''}</td>
+        <td>${data?.category.replace(/\s+/, '<hr>') ?? ''}</td>
         <td>${data.summary ||''}</td>
         <td class="button" onclick="delSchoolItem(this,'${url}')">×</td>
       `;


### PR DESCRIPTION
# 現象
複数のカテゴリをもつアイテムを流派装備として流派データに追加したとき、その時点では、次の画像のように、カテゴリが区切られていなかった。（ここで〈クロスボウ〉と〈盾〉が別々の行にあるのは、表示幅の不足による折り返しにすぎない）

![image](https://github.com/user-attachments/assets/1e07d07f-167c-4682-badb-5228e3685cde)

# 正常な動作

保存してリロードすると、次のように水平線で明示的に区切られる。

![image](https://github.com/user-attachments/assets/32f5e381-e141-4692-9bc3-997b1ccd6116)

# 原因

JS側では複数のカテゴリをもつ可能性が考慮されていなかった。