### PR TITLE
[SW2] 秘伝データの「前提」が複数あるケースのレイアウトを改善

### DIFF
--- a/_core/lib/sw2/view-arts.pl
+++ b/_core/lib/sw2/view-arts.pl
@@ -322,6 +322,8 @@ foreach my $num (1..$pc{schoolArtsNum}){
   next if !($pc{'schoolArts'.$num.'Name'});
   my $icon;
   if($pc{'schoolArts'.$num.'ActionTypeSetup'}){ $icon .= '<i class="s-icon setup">△</i>' }
+  $pc{'schoolArts'.$num.'Premise'} =~ s#(《.+?》)、?#<span>$1</span>#g;
+  $pc{'schoolArts'.$num.'Premise'} =~ s#(</span>)(<span>)#$1<wbr>$2#g;
   $pc{'schoolArts'.$num.'Effect'} =~ s#<h2>(.+?)</h2>#</dd><dt><span class="center">$1</span></dt><dd class="box">#gi;
   push(@arts, {
     "NAME"     => stylizeCharacterName($pc{'schoolArts'.$num.'Name'}),

--- a/_core/skin/sw2/css/arts.css
+++ b/_core/skin/sw2/css/arts.css
@@ -352,6 +352,16 @@ article {
     grid-template-columns: 4.2em 1fr;
   }
 }
+.data-magic.data-arts dl.premise dd {
+  > .content {
+    width: 100%;
+    height: max-content;
+
+    > span {
+      word-break: keep-all;
+    }
+  }
+}
 #mystic-arts dl.cost dt > span,
 #mystic-arts dl.a-cost dt > span {
   display: inline-block;

--- a/_core/skin/sw2/sheet-arts.html
+++ b/_core/skin/sw2/sheet-arts.html
@@ -241,7 +241,7 @@
             <h3 class="name    "><div><TMPL_VAR ICON>《<TMPL_VAR NAME>》</div></h3>
             <dl class="cost    "><dt><span>必要名誉点</span><dd><TMPL_VAR COST></dl>
             <dl class="type    "><dt>タイプ    <dd><TMPL_VAR TYPE></dl>
-            <dl class="premise "><dt>前提      <dd><TMPL_VAR PREMISE></dl>
+            <dl class="premise "><dt>前提      <dd><span class="content"><TMPL_VAR PREMISE></span></dl>
             <dl class="equip   "><dt>限定条件  <dd><TMPL_VAR EQUIP></dl>
             <dl class="use     "><dt>使用      <dd><TMPL_VAR USE></dl>
             <dl class="apply   "><dt>適用      <dd><TMPL_VAR APPLY></dl>


### PR DESCRIPTION
従来は、秘伝の「前提」欄の折り返しが無造作だった。
![image](https://github.com/user-attachments/assets/c510c283-f9ba-40e8-a381-83126fe0964d)

これをいい感じにレイアウトされるように変更。
![image](https://github.com/user-attachments/assets/84491d24-1a23-4090-881c-8e6408ca73c3)

動作テスト用のデータ： https://yutorize.2-d.jp/ytsheet/sw2.5/?id=u7tsLq