### PR TITLE
Fix: [SW2] 編集画面において、複数部位のＰＣデータのコア部位のＨＰ／ＭＰが NaN になる場合がある不具合を修正

### DIFF
--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1382,8 +1382,8 @@ function calcParts(){
     }
     // コア
     if(form.partCore.value == num){
-      hp += subStt.hpBase + subStt.hpAutoAdd - stt.addD - equipMod.D + Number(form.sttPartD.value||0);
-      mp += subStt.mpBase + subStt.mpAutoAdd - stt.addF - equipMod.F + Number(form.sttPartF.value||0);
+      hp += subStt.hpBase + subStt.hpAutoAdd - stt.addD - (equipMod.D ?? 0) + Number(form.sttPartD.value||0);
+      mp += subStt.mpBase + subStt.mpAutoAdd - stt.addF - (equipMod.F ?? 0) + Number(form.sttPartF.value||0);
       if(raceAbilities.includes('蠍人の身体')){
         def = 0;
         hp += subStt.hpAccessory;


### PR DESCRIPTION
# 現象

編集画面において、複数部位をもつ種族のコア部位のＨＰまたはＭＰが、 _NaN_ と表示される場合がある。

## 再現サンプル
https://yutorize.2-d.jp/ytsheet/sw2.5/?id=6Ak5SF
![image](https://github.com/user-attachments/assets/0dbbaa66-95a0-42a9-b69b-8f7155a44ac1)

# 条件

直接修正記法によって生命力／精神力が増減していないとき、それぞれＨＰ／ＭＰが NaN となる。

# 原因

計算過程で、直接修正記法による増減量が参照されていたが、増減がない場合は _undefined_ であるため、数値と _undefined_ とを演算した結果として _NaN_ になっていた。

# 修正方針

Null合体演算子をもちいて、 _undefined_ のときは 0 とみなす。