### PR TITLE
[SW2] ゆとチャadv.用の武器攻撃の威力解決コマンドに、武器名と用法を明記する

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -498,7 +498,7 @@ sub palettePreset {
             $text .= $bot{YTC} ? '首切' : $bot{BCD} ? 'r5' : '';
           }
           $text .= " ダメージ";
-          $text .= "／$::pc{'weapon'.$_.'Name'}$::pc{'weapon'.$_.'Usage'}";
+          $text .= "／$::pc{'weapon'.$_.'Name'}@{[extractWeaponMarks($::pc{'weapon'.$_.'Note'})]}$::pc{'weapon'.$_.'Usage'}";
           $text .= "（${partName}）" if $partName && $bot{BCD};
           $text .= "\n";
         }

--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -498,8 +498,7 @@ sub palettePreset {
             $text .= $bot{YTC} ? '首切' : $bot{BCD} ? 'r5' : '';
           }
           $text .= " ダメージ";
-          $text .= extractWeaponMarks($::pc{'weapon'.$_.'Name'}.$::pc{'weapon'.$_.'Note'}) unless $bot{BCD};
-          $text .= "／$::pc{'weapon'.$_.'Name'}$::pc{'weapon'.$_.'Usage'}" if $bot{BCD};
+          $text .= "／$::pc{'weapon'.$_.'Name'}$::pc{'weapon'.$_.'Usage'}";
           $text .= "（${partName}）" if $partName && $bot{BCD};
           $text .= "\n";
         }


### PR DESCRIPTION
#89 で刃武器・打撃武器・魔法の武器の特性部分をコマンド行に含めるようにしていたが、（ BCDice 用のコマンドと同様に、）そもそも武器名と用法をまるごと含めてしまったほうがより明示的であると思い直した。

具体的には、

- 複数の武器を使い分けるキャラクター（「スレイヤー」や「属性武器」、または特殊な効果をもつ武器などを、相手や状況に応じて使い分けるということはふつうに考えられる）
- 同一武器の複数の用法を使い分けるキャラクター（「１Ｈ両」と「２Ｈ」の使い分けや、「振ｎＨ」と「突ｎＨ」の使い分けなどが典型的）

などにおいて、コマンド行に武器名と用法が明記されているほうが、何を実行しているのかが明瞭になるため。
（とくに他の参加者から見たときに明瞭である。また、実行する本人にとっても、命中力判定の行を見ずに威力の行を見るだけで何を実行するのかが明らかになる）