### PR TITLE
Fix: [SW2] 閲覧画面において、所持金が空のときに単位「G」のみが表示されてしまう現象を修正

### DIFF
--- a/_core/skin/sw2.0/sheet-chara.html
+++ b/_core/skin/sw2.0/sheet-chara.html
@@ -515,7 +515,7 @@
         <div id="area-items-L">
           <dl class="box" id="money">
             <dt>所持金<dd><span class="value"><TMPL_VAR money></span> <span class="unit">G</span>
-            <dt>預金／借金<dd><TMPL_IF deposit><TMPL_VAR deposit> G<TMPL_ELSE>―</TMPL_IF>
+            <dt>預金／借金<dd><span class="value"><TMPL_VAR deposit></span> <span class="unit">G</span>
           </dl>
           <section class="box" id="items">
             <h2><TMPL_IF head_items><TMPL_VAR head_items><TMPL_ELSE>所持品</TMPL_IF></h2>

--- a/_core/skin/sw2.0/sheet-chara.html
+++ b/_core/skin/sw2.0/sheet-chara.html
@@ -514,7 +514,7 @@
       <TMPL_UNLESS forbiddenMode><div id="area-items">
         <div id="area-items-L">
           <dl class="box" id="money">
-            <dt>所持金<dd><TMPL_VAR money> G
+            <dt>所持金<dd><span class="value"><TMPL_VAR money></span> <span class="unit">G</span>
             <dt>預金／借金<dd><TMPL_IF deposit><TMPL_VAR deposit> G<TMPL_ELSE>―</TMPL_IF>
           </dl>
           <section class="box" id="items">

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -1015,6 +1015,16 @@ dl#level {
   }
   > dd {
     grid-row: 2;
+
+    &:has(.value:empty) {
+      .unit {
+        display: none;
+      }
+
+      &::after {
+        content: "―";
+      }
+    }
   }
   > *:last-of-type {
     border-left-width: 1px;

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -514,7 +514,7 @@
         <div id="area-items-L">
           <dl class="box" id="money">
             <dt>所持金<dd><span class="value"><TMPL_VAR money></span> <span class="unit">G</span>
-            <dt>預金／借金<dd><TMPL_IF deposit><TMPL_VAR deposit> G<TMPL_ELSE>―</TMPL_IF>
+            <dt>預金／借金<dd><span class="value"><TMPL_VAR deposit></span> <span class="unit">G</span>
           </dl>
           <section class="box" id="items">
             <h2><TMPL_IF head_items><TMPL_VAR head_items><TMPL_ELSE>所持品</TMPL_IF></h2>

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -513,7 +513,7 @@
       <TMPL_UNLESS forbiddenMode><div id="area-items">
         <div id="area-items-L">
           <dl class="box" id="money">
-            <dt>所持金<dd><TMPL_VAR money> G
+            <dt>所持金<dd><span class="value"><TMPL_VAR money></span> <span class="unit">G</span>
             <dt>預金／借金<dd><TMPL_IF deposit><TMPL_VAR deposit> G<TMPL_ELSE>―</TMPL_IF>
           </dl>
           <section class="box" id="items">


### PR DESCRIPTION
# 現象

所持金が空のとき、単位「G」のみが表示されてしまう。

![image](https://github.com/user-attachments/assets/2de46a7e-a5b7-46d9-a583-cc8aa21badfc)

所持金が空になるケースとは、自動計算を無効化したうえで直接入力の値を空文字列としている状態が該当する。
（所持金を管理するつもりのないＮＰＣなどにおいては、このような用法がありうる）

再現サンプル： https://yutorize.2-d.jp/ytsheet/sw2.5/?id=2yAo8Y

# 修正後

![image](https://github.com/user-attachments/assets/457ea3c9-7ab8-4ed3-a85f-9b549025d0d1)
