### PR TITLE
[SW2] 武器攻撃の追加オプション設定欄での武器名の行の高さを改善

### DIFF
--- a/_core/skin/sw2/css/edit.css
+++ b/_core/skin/sw2/css/edit.css
@@ -1382,6 +1382,10 @@ article > form > hr {
       &.crit { width: 6em; }
       &.roll { width: 6em; }
     }
+
+    tbody td label:is(.radio-button, .check-button) {
+      line-height: 1.4;
+    }
   }
 }
 #palette-magic {


### PR DESCRIPTION
行の高さがごく小さかった（ 1.0 ）ため、折り返しがあると、ひどく読みづらい見た目で表示されていた。

なお、変更後の行の高さ（ 1.4 ）は、閲覧画面における武器名の表示箇所に合わせたもの。

**before**
![image](https://github.com/user-attachments/assets/b55601f2-0bde-44cb-964e-235d0086a90f)

**after**
![image](https://github.com/user-attachments/assets/cada4785-61b5-483a-93a8-733ee97fe946)

