### PR TITLE
[SW2] ゆとチャadv.用の威力表コマンド行に、武器攻撃の追加オプションの名称を含める

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -530,7 +530,7 @@ sub palettePreset {
         if($dmgTexts{$paNum} eq $dmgTexts{$paNum - 1}){
           $activeName = $::pc{'paletteAttack'.($paNum - 1).'Name'} ? "＋$::pc{'paletteAttack'.($paNum - 1).'Name'}" : '';
         }
-        $text .= $bot{BCD} ? ($dmgTexts{$paNum} =~ s/(\n)/$activeName$1/gr) : $dmgTexts{$paNum};
+        $text .= ($dmgTexts{$paNum} =~ s/(\n)/$activeName$1/gr);
         $text .= "\n";
       }
     }


### PR DESCRIPTION
# 変更内容
（ BCDice 用のコマンドと同様に、）武器攻撃の追加オプションの設定名を、コマンド行に付加する。

## 例

### before
```
命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋全力攻撃Ⅱ 2d+24+{命中修正}
ダメージ[魔][刃] k30[10]+{C修正}]+20+12+{追加D修正}{出目修正}
```
### after
```
命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋全力攻撃Ⅱ 2d+24+{命中修正}
ダメージ[魔][刃]＋全力攻撃Ⅱ k30[10]+{C修正}]+20+12+{追加D修正}{出目修正}
```

# 目的

当該行のみで（＝直前の命中力判定の行によらず）、コマンドの主旨が明らかになるように。