### PR TITLE
[SW2] 武器攻撃の追加オプションについて、命中力判定あるいはダメージに影響がなければ、そのコマンドは出力しない

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -530,7 +530,7 @@ sub palettePreset {
         if($dmgTexts{$paNum} eq $dmgTexts{$paNum - 1}){
           $activeName = $::pc{'paletteAttack'.($paNum - 1).'Name'} ? "＋$::pc{'paletteAttack'.($paNum - 1).'Name'}" : '';
         }
-        $text .= $bot{BCD} ? ($dmgTexts{$paNum} =~ s/(\n)/$activeName$1/gr) : $dmgTexts{$paNum};
+        $text .= ($dmgTexts{$paNum} =~ s/(\n)/$activeName$1/gr);
         $text .= "\n";
       }
     }

--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -498,7 +498,7 @@ sub palettePreset {
             $text .= $bot{YTC} ? '首切' : $bot{BCD} ? 'r5' : '';
           }
           $text .= " ダメージ";
-          $text .= "／$::pc{'weapon'.$_.'Name'}$::pc{'weapon'.$_.'Usage'}";
+          $text .= "／$::pc{'weapon'.$_.'Name'}@{[extractWeaponMarks($::pc{'weapon'.$_.'Note'})]}$::pc{'weapon'.$_.'Usage'}";
           $text .= "（${partName}）" if $partName && $bot{BCD};
           $text .= "\n";
         }

--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -510,26 +510,30 @@ sub palettePreset {
         
         my $activeName = $::pc{'paletteAttack'.$paNum.'Name'} ? "＋$::pc{'paletteAttack'.$paNum.'Name'}" : '';
 
-        $text .= "2d+";
-        $text .= $::pc{paletteUseVar} ? "{命中$_}" : $::pc{"weapon${_}AccTotal"};
-        $text .= "+{命中修正}";
-        if($::pc{'paletteAttack'.$paNum.'Acc'}){
-          $text .= optimizeOperatorFirst "+$::pc{'paletteAttack'.$paNum.'Acc'}";
+        if ($paNum == 0 || $::pc{'paletteAttack'.$paNum.'Acc'}) {
+          $text .= "2d+";
+          $text .= $::pc{paletteUseVar} ? "{命中$_}" : $::pc{"weapon${_}AccTotal"};
+          $text .= "+{命中修正}";
+          if($::pc{'paletteAttack'.$paNum.'Acc'}){
+            $text .= optimizeOperatorFirst "+$::pc{'paletteAttack'.$paNum.'Acc'}";
+          }
+          $text .= " 命中力／$::pc{'weapon'.$_.'Name'}$::pc{'weapon'.$_.'Usage'}";
+          $text .= "（${partName}）" if $partName;
+          if($::pc{'paletteAttack'.$paNum.'Name'}){
+            $text .= "＋$::pc{'paletteAttack'.$paNum.'Name'}";
+          }
+          $text .= "\n";
         }
-        $text .= " 命中力／$::pc{'weapon'.$_.'Name'}$::pc{'weapon'.$_.'Usage'}";
-        $text .= "（${partName}）" if $partName;
-        if($::pc{'paletteAttack'.$paNum.'Name'}){
-          $text .= "＋$::pc{'paletteAttack'.$paNum.'Name'}";
-        }
-        $text .= "\n";
         
         if($dmgTexts{$paNum + 1} && $dmgTexts{$paNum} eq $dmgTexts{$paNum + 1}){
           next;
         }
-        if($dmgTexts{$paNum} eq $dmgTexts{$paNum - 1}){
-          $activeName = $::pc{'paletteAttack'.($paNum - 1).'Name'} ? "＋$::pc{'paletteAttack'.($paNum - 1).'Name'}" : '';
+        elsif ($paNum == 0 || $::pc{'paletteAttack'.$paNum.'Crit'} || $::pc{'paletteAttack'.$paNum.'Dmg'} || $::pc{'paletteAttack'.$paNum.'Roll'}) {
+          if($dmgTexts{$paNum} eq $dmgTexts{$paNum - 1}){
+            $activeName = $::pc{'paletteAttack'.($paNum - 1).'Name'} ? "＋$::pc{'paletteAttack'.($paNum - 1).'Name'}" : '';
+          }
+          $text .= ($dmgTexts{$paNum} =~ s/(\n)/$activeName$1/gr);
         }
-        $text .= ($dmgTexts{$paNum} =~ s/(\n)/$activeName$1/gr);
         $text .= "\n";
       }
     }

--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -498,8 +498,7 @@ sub palettePreset {
             $text .= $bot{YTC} ? '首切' : $bot{BCD} ? 'r5' : '';
           }
           $text .= " ダメージ";
-          $text .= extractWeaponMarks($::pc{'weapon'.$_.'Name'}.$::pc{'weapon'.$_.'Note'}) unless $bot{BCD};
-          $text .= "／$::pc{'weapon'.$_.'Name'}$::pc{'weapon'.$_.'Usage'}" if $bot{BCD};
+          $text .= "／$::pc{'weapon'.$_.'Name'}$::pc{'weapon'.$_.'Usage'}";
           $text .= "（${partName}）" if $partName && $bot{BCD};
           $text .= "\n";
         }


### PR DESCRIPTION
# 前提ＰＲ
#338, #341

# 変更内容

武器攻撃の追加オプションについて、命中力判定あるいはダメージに影響がなければ、そのコマンドは出力しない

## 考え方
- 《全力攻撃Ⅰ》（⇒『Ⅰ』286頁）を表現する追加オプションであれば、命中力判定のコマンドは出力しない
- 《牽制攻撃Ⅰ》（⇒『Ⅰ』286頁）を表現する追加オプションであれば、威力のコマンドは出力しない

## 具体例

### before
https://yutorize.2-d.jp/ytsheet/sw2.5/?id=1Q2eq3
```
命中力／[魔]〈ツーハンドソード＋１〉[刃]2H 2d+24+{命中修正}
ダメージ[魔][刃] k30[10+{C修正}]+20+{追加D修正}{出目修正}

命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋全力攻撃Ⅱ 2d+24+{命中修正}
ダメージ[魔][刃] k30[10+{C修正}]+20+12+{追加D修正}{出目修正}

命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋魔力撃 2d+24+{命中修正}
ダメージ[魔][刃] k30[10+{C修正}]+20+(20+2+{魔力修正})+{追加D修正}{出目修正}

命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋法剣魔測眼 2d+24+{命中修正}+7
ダメージ[魔][刃] k30[10+{C修正}]+20+{追加D修正}{出目修正}

命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋捨て身攻撃Ⅲ 2d+24+{命中修正}
ダメージ[魔][刃] k30[10+{C修正}]+20+30+{追加D修正}{出目修正}

命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋囮攻撃Ⅱ 2d+24+{命中修正}-2
ダメージ[魔][刃] k30[10+{C修正}]+20+8+{追加D修正}{出目修正}

命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋牽制攻撃Ⅲ 2d+24+{命中修正}+3
ダメージ[魔][刃] k30[10+{C修正}]+20+{追加D修正}{出目修正}

命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋必殺攻撃Ⅲ 2d+24+{命中修正}
ダメージ[魔][刃] k30[10+{C修正}]+20+{追加D修正}#1

命中力／[魔]〈ウィークネスリピーラー〉[刃]1H 2d+23+{命中修正}
ダメージ[魔][刃] k5[10+{C修正}]+19+{追加D修正}{出目修正}

命中力／[魔]〈ウィークネスリピーラー〉[刃]1H＋法剣魔測眼 2d+23+{命中修正}+7
ダメージ[魔][刃] k5[10+{C修正}]+19+{追加D修正}{出目修正}

命中力／[魔]〈ウィークネスリピーラー〉[刃]1H＋牽制攻撃Ⅲ 2d+23+{命中修正}+3
ダメージ[魔][刃] k5[10+{C修正}]+19+{追加D修正}{出目修正}

命中力／〈ストーン〉[打]1H投 2d+23+{命中修正}
ダメージ[打] k1[12+{C修正}]+19+{追加D修正}{出目修正}
```

### after
```
命中力／[魔]〈ツーハンドソード＋１〉[刃]2H 2d+24+{命中修正}
ダメージ／[魔]〈ツーハンドソード＋１〉[刃]2H k30[10]+{C修正}]+20+{追加D修正}{出目修正}

ダメージ／[魔]〈ツーハンドソード＋１〉[刃]2H＋全力攻撃Ⅱ k30[10]+{C修正}]+20+12+{追加D修正}{出目修正}

ダメージ／[魔]〈ツーハンドソード＋１〉[刃]2H＋魔力撃 k30[10]+{C修正}]+20+(20+2+{魔力修正})+{追加D修正}{出目修正}

命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋法剣魔測眼 2d+24+{命中修正}+7

ダメージ／[魔]〈ツーハンドソード＋１〉[刃]2H＋捨て身攻撃Ⅲ k30[10]+{C修正}]+20+30+{追加D修正}{出目修正}

命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋囮攻撃Ⅱ 2d+24+{命中修正}-2
ダメージ／[魔]〈ツーハンドソード＋１〉[刃]2H＋囮攻撃Ⅱ k30[10]+{C修正}]+20+8+{追加D修正}{出目修正}

命中力／[魔]〈ツーハンドソード＋１〉[刃]2H＋牽制攻撃Ⅲ 2d+24+{命中修正}+3

ダメージ／[魔]〈ツーハンドソード＋１〉[刃]2H＋必殺攻撃Ⅲ k30[10]+{C修正}]+20+{追加D修正}#1

命中力／[魔]〈ウィークネスリピーラー〉[刃]1H 2d+23+{命中修正}
ダメージ／[魔]〈ウィークネスリピーラー〉[刃]1H k5[10]+{C修正}]+19+{追加D修正}{出目修正}

命中力／[魔]〈ウィークネスリピーラー〉[刃]1H＋法剣魔測眼 2d+23+{命中修正}+7

命中力／[魔]〈ウィークネスリピーラー〉[刃]1H＋牽制攻撃Ⅲ 2d+23+{命中修正}+3

命中力／〈ストーン〉[打]1H投〈投擲〉 2d+23+{命中修正}
ダメージ／〈ストーン〉[打]1H投 k1[12]+{C修正}]+19+{追加D修正}{出目修正}
```

# 目的
重複となるコマンドを省略し、より簡潔かつ必要なもののみがある状態に近づける。

# 備考

魔法の追加オプションについては別途作業する予定です