### PR TITLE
[SW2] 穢れ度が 1 以上のキャラクターは、チャットパレットのデフォルト変数として「穢れ」を出力する

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -781,6 +781,7 @@ sub paletteProperties {
     push @propaties, '';
     push @propaties, "//冒険者={冒険者レベル}";
     push @propaties, "//LV={冒険者}";
+    push @propaties, "//穢れ=$::pc{sin}" if $::pc{sin} > 0;
     push @propaties, '';
     #push @propaties, "//魔物知識=$::pc{monsterLore}" if $::pc{monsterLore};
     #push @propaties, "//先制力=$::pc{initiative}" if $::pc{initiative};


### PR DESCRIPTION
# 変更内容

穢れ度が 1 以上のキャラクターは、チャットパレットのデフォルト変数として「穢れ」を出力する

# 背景

〈穢れの一撃加工〉（⇒『ＢＲ』64頁）や〈テインテッドポーション〉（⇒同65頁）など、“穢れ”を数値として参照してダメージや回復量をもとめるデータがあるため。
