### PR TITLE
Fix: [SW2] 《クリティカルキャストⅠ》の場合は半減時にクリティカルさせない

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -320,7 +320,7 @@ sub palettePreset {
           if ($id eq 'Fai' && $::pc{fairyContractEarth} && ($pow == 10 || $pow == 50)) {
             $text .= "k${pow}[12$activeCrit]+$magicPower".addNum($::pc{'magicDamageAdd'.$id})."+{物理魔法D修正}$activeDmg 物理ダメージ\n";
           }
-          my $halfCrit = $activeName =~ /クリティカルキャスト/ ? "{魔法C}$activeCrit" : "13";
+          my $halfCrit = $activeName =~ /クリティカルキャスト(?!(?:1|I(?:[^I]|$)|Ⅰ))/i ? "{魔法C}$activeCrit" : "13";
           if ($bot{YTC}) { $half .= "k${pow}[$halfCrit]+$magicPower" . "//" . addNum($::pc{'magicDamageAdd'.$id}) . "+{魔法D修正}$activeDmg 半減\n"; }
           if ($bot{BCD}) { $half .= "k${pow}[$halfCrit]+$magicPower" . "h+("  . ($::pc{'magicDamageAdd'.$id} || '') . "+{魔法D修正}$activeDmg) 半減\n"; }
         }


### PR DESCRIPTION
# ゲームルール
半減時にクリティカルさせる効果をもつのは《クリティカルキャスト**Ⅱ**》（⇒『Ⅲ』215頁、『ＢＭ』28頁）のみであり、《クリティカルキャスト**Ⅰ**》（⇒『Ⅱ』233頁、『ＢＭ』28頁）には当該効果がない。

# 仕様

オプション名が `クリティカルキャストⅠ` `クリティカルキャストII` `クリティカルキャスト1` にマッチする場合は、半減時クリティカル効果がないものとして処理する。

## 備考
ローマ数字の記述されていない無印クリティカルキャストについては、後方互換性の観点から従来どおり、半減時のクリティカル効果があるものとした。


# サンプル

## 入力

https://yutorize.2-d.jp/ytsheet/sw2.5/?id=rLoMwE

![image](https://github.com/user-attachments/assets/caa65ac9-5a2e-41de-9690-f59ca52624b2)

## 出力
```
真語魔法行使 2d+22+{魔力修正}+{行使修正}
ダメージ k10[{魔法C}]+22+{魔力修正}+{魔法D修正}
ダメージ k20[{魔法C}]+22+{魔力修正}+{魔法D修正}
ダメージ k30[{魔法C}]+22+{魔力修正}+{魔法D修正}
物理ダメージ k30[10]+22+{魔力修正}+{物理魔法D修正}
ダメージ k40[{魔法C}]+22+{魔力修正}+{魔法D修正}
ダメージ k50[{魔法C}]+22+{魔力修正}+{魔法D修正}
ダメージ k60[{魔法C}]+22+{魔力修正}+{魔法D修正}
ダメージ k100[{魔法C}]+22+{魔力修正}+{魔法D修正}
半減 k10[13]+22+{魔力修正}//+{魔法D修正}
半減 k20[13]+22+{魔力修正}//+{魔法D修正}
半減 k30[13]+22+{魔力修正}//+{魔法D修正}
半減 k40[13]+22+{魔力修正}//+{魔法D修正}
半減 k50[13]+22+{魔力修正}//+{魔法D修正}
半減 k60[13]+22+{魔力修正}//+{魔法D修正}
半減 k100[13]+22+{魔力修正}//+{魔法D修正}

真語魔法行使＋クリティカルキャスト 2d+22+{魔力修正}+{行使修正}
ダメージ k10[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k20[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k30[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
物理ダメージ k30[10-1]+22+{魔力修正}+{物理魔法D修正}
ダメージ k40[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k50[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k60[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k100[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
半減 k10[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k20[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k30[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k40[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k50[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k60[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k100[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}

真語魔法行使＋クリティカルキャストⅠ 2d+22+{魔力修正}+{行使修正}
ダメージ k10[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k20[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k30[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
物理ダメージ k30[10-1]+22+{魔力修正}+{物理魔法D修正}
ダメージ k40[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k50[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k60[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k100[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
半減 k10[13]+22+{魔力修正}//+{魔法D修正}
半減 k20[13]+22+{魔力修正}//+{魔法D修正}
半減 k30[13]+22+{魔力修正}//+{魔法D修正}
半減 k40[13]+22+{魔力修正}//+{魔法D修正}
半減 k50[13]+22+{魔力修正}//+{魔法D修正}
半減 k60[13]+22+{魔力修正}//+{魔法D修正}
半減 k100[13]+22+{魔力修正}//+{魔法D修正}

真語魔法行使＋クリティカルキャストⅡ 2d+22+{魔力修正}+{行使修正}
ダメージ k10[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k20[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k30[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
物理ダメージ k30[10-1]+22+{魔力修正}+{物理魔法D修正}
ダメージ k40[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k50[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k60[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
ダメージ k100[{魔法C}-1]+22+{魔力修正}+{魔法D修正}
半減 k10[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k20[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k30[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k40[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k50[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k60[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
半減 k100[{魔法C}-1]+22+{魔力修正}//+{魔法D修正}
```