### PR TITLE
[SW2] 秘伝の「前提」欄に入力候補を提供

### DIFF
--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -379,7 +379,7 @@ print <<"HTML";
             <dl class="name    "><dt>名称      <dd>《@{[ input "schoolArts${num}Name",'' ]}》<br>@{[ checkbox "schoolArts${num}ActionTypeSetup",'戦闘準備' ]}</dl>
             <dl class="cost    "><dt>必要名誉点<dd>@{[ input "schoolArts${num}Cost" ]}</dl>
             <dl class="type    "><dt>タイプ    <dd>@{[ input "schoolArts${num}Type",'','','list="list-arts-type"' ]}</dl>
-            <dl class="premise "><dt>前提      <dd>@{[ input "schoolArts${num}Premise",'','','list="list-arts-base"' ]}</dl>
+            <dl class="premise "><dt>前提      <dd>@{[ input "schoolArts${num}Premise",'','','list="list-arts-premise"' ]}</dl>
             <dl class="equip   "><dt>限定条件  <dd>@{[ input "schoolArts${num}Equip" ]}</dl>
             <dl class="use     "><dt>使用      <dd>@{[ input "schoolArts${num}Use",'','','list="list-arts-use"' ]}</dl>
             <dl class="apply   "><dt>適用      <dd>@{[ input "schoolArts${num}Apply",'','','list="list-arts-apply"' ]}</dl>
@@ -615,6 +615,15 @@ print <<"HTML";
     <option value="主動作型">
     <option value="《》変化型">
     <option value="独自宣言型">
+  </datalist>
+  <datalist id="list-arts-premise">
+    <option value="なし">
+    <option value="《》">
+    <option value="《》《》">
+    <option value="《》《》《》">
+    <option value="《》《》《》《》">
+    <option value="【】">
+    <option value="【】【】">
   </datalist>
   <datalist id="list-arts-use">
     <option value="ファイター技能">


### PR DESCRIPTION
# 変更内容

流派シートの、秘伝の「前提」欄に、入力候補を提供

# 具体的な入力候補

```
    <option value="なし">
    <option value="《》">
    <option value="《》《》">
    <option value="《》《》《》">
    <option value="《》《》《》《》">
    <option value="【】">
    <option value="【】【】">
```

`なし` は前提をもたない秘伝用のもの。（例：《ディスパース》⇒『バトルマスタリー』45頁）

二重山括弧《》は、戦闘特技または秘伝を前提とする秘伝用のもの。（例：《ディスエンゲージ》⇒『バトルマスタリー』45頁）
複数の二重山括弧が並んでいるものは、複数の前提をもつ秘伝用のもの。（例：《大転がしテイルスイング》⇒『バトルマスタリー』64頁）

隅付き括弧【】は、技芸を前提とする秘伝用のもの。
このようなケースについて、秘伝の総則（⇒『バトルマスタリー』38頁）には**規定が存在しない**が、地方の流派などには**実例がある**。（例：【ソムバートル制圧弓騎兵団】⇒『ウルシラ博物誌』19頁。同書内の秘伝総則（⇒14頁）にもやはり規定は存在しない……）