### PR TITLE
[SW2] 武器の「必要精神力」の概念をサポート

### DIFF
--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -449,7 +449,7 @@ function setLanguageDefault(){
 }
 // ステータス計算 ----------------------------------------
 let reqdStr = 0;
-let reqdWil = 0;
+let reqdMnd = 0;
 let reqdStrHalf = 0;
 let stt = {};
 let bonus = {}
@@ -541,7 +541,7 @@ function calcStt() {
   }
   
   reqdStr = stt.totalStr;
-  reqdWil = stt.totalMnd;
+  reqdMnd = stt.totalMnd;
   reqdStrHalf = Math.ceil(reqdStr / 2);
   
   checkFeats();
@@ -1523,7 +1523,7 @@ function calcWeapon() {
     // 必筋チェック
     const maxReqd
       = (className === "フェンサー") ? reqdStrHalf
-      : /^\d+w$/i.test(weaponReqdRaw) ? reqdWil
+      : /^\d+w$/i.test(weaponReqdRaw) ? reqdMnd
       : SET.class[className]?.accUnlock?.reqd ? stt['total'+SET.class[className]?.accUnlock?.reqd]
       : reqdStr;
     form["weapon"+i+"Reqd"].classList.toggle('error', weaponReqd > maxReqd + (equipMod.WeaponReqd||0));

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -449,6 +449,7 @@ function setLanguageDefault(){
 }
 // ステータス計算 ----------------------------------------
 let reqdStr = 0;
+let reqdWil = 0;
 let reqdStrHalf = 0;
 let stt = {};
 let bonus = {}
@@ -540,6 +541,7 @@ function calcStt() {
   }
   
   reqdStr = stt.totalStr;
+  reqdWil = stt.totalMnd;
   reqdStrHalf = Math.ceil(reqdStr / 2);
   
   checkFeats();
@@ -1509,7 +1511,8 @@ function calcWeapon() {
     const category = form["weapon"+i+"Category"].value;
     const ownDex = form["weapon"+i+"Own"].checked ? 2 : 0;
     const note = form["weapon"+i+"Note"].value;
-    const weaponReqd = safeEval(form["weapon"+i+"Reqd"].value) || 0;
+    const weaponReqdRaw = form["weapon"+i+"Reqd"]?.value?.toString();
+    const weaponReqd = (weaponReqdRaw.match(/^(\d+)w$/i) ? safeEval(RegExp.$1) : safeEval(weaponReqdRaw)) || 0;
     const classLv = lv[ SET.class[className]?.id ] || 0;
     let dex = (partNum ? stt.Dex+Number(form.sttPartA.value || 0) : stt.totalDex);
     let str = (partNum ? stt.Str+Number(form.sttPartC.value || 0) : stt.totalStr);
@@ -1520,6 +1523,7 @@ function calcWeapon() {
     // 必筋チェック
     const maxReqd
       = (className === "フェンサー") ? reqdStrHalf
+      : /^\d+w$/i.test(weaponReqdRaw) ? reqdWil
       : SET.class[className]?.accUnlock?.reqd ? stt['total'+SET.class[className]?.accUnlock?.reqd]
       : reqdStr;
     form["weapon"+i+"Reqd"].classList.toggle('error', weaponReqd > maxReqd + (equipMod.WeaponReqd||0));


### PR DESCRIPTION
# 変更内容

武器欄において、「必要精神力」の概念をサポート

# 背景

『ウルシラ博物誌』掲載の流派【オークファルト念闘術】において、「必要精神力」の概念が規定された。

- 「必要精神力」のルールは、同書27頁の、流派アイテム概説、ならびに、秘伝《念武肢》の効果を参照。
- この概念をもちいる具体的なアイテムデータについては、同書31頁を参照。

# 仕様

武器の「必要筋力」欄で、数値の末尾に `w` が記述されていれば、「必要精神力」を意味するものとみなす。
なお、この書式は、『ウルシラ博物誌』31頁に倣ったもの。

「必要精神力」とみなしたならば、筋力の代わりに精神力を参照し、不足の是非を検証する。
このとき、従来の「必要筋力」に干渉する要素のいっさいを無視する。これは、【オークファルト念闘術】の記述において、そのような要素を考慮する素振りがまったく見られず、また、「必要精神力」は「必要筋力」とは異なるルールであることにもとづく。

# 備考

JS 内では、「必要精神力」の文脈における“精神力”の表現を _wil_ とした。
これは、『ウルシラ博物誌』31頁の書式において“精神力”の表現が _w_ であることにもとづく。 _w_ が何の略であるのかは定かでないが、 will （意志・意志力・自制心）か wisdom （賢明さ・判断力）のいずれかと思われ、『SW2』における“精神力”の位置づけからは前者であると推測した。

まあ従来どおり _mnd_ でも（のほうが）いいかもしれない。

# 例

https://yutorize.2-d.jp/ytsheet/sw2.5/?id=4z1Rw4

![image](https://github.com/user-attachments/assets/c57328d0-d212-4692-a8f6-1b096e3ee254)
