### PR TITLE
Fix: [SW2] 魔法の追加オプションにあらたな行を追加したとき、追加された行では習得状況にかかわらずすべての魔法系統が表示されてしまう不具合を修正

### DIFF
--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -2611,6 +2611,7 @@ setSortable('paletteAttack','#palette-attack > table tbody','tr');
 // 魔法
 function addPaletteMagic(){
   document.querySelector("#palette-magic > table tbody").append(createRow('palette-magic','paletteMagicNum'));
+  calcMagic();
 }
 function delPaletteMagic(){
   if(delRow('paletteMagicNum', '#palette-magic > table tbody tr:last-of-type')){


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7949a4e2-d2ef-467b-bd9b-fb8d87f0ac2e)
