### PR TITLE
Fix: [SW2] 編集画面で《魔力強化》による増分が正しく表示されない不具合を修正

### DIFF
--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1289,6 +1289,8 @@ function calcMagic() {
   document.getElementById("magic-power-common"      ).style.display = openMagic              ? '' : 'none';
   document.getElementById("magic-power-hr"          ).style.display = openMagic && openCraft ? '' : 'none';
 
+  document.getElementById('magic-power-magicenhance-value').textContent = feats['魔力強化']?.toString();
+
   stylizeVisibleRows(document.querySelectorAll('#magic-power > .edit-table > tbody > tr'))
 }
 


### PR DESCRIPTION
《魔力強化Ⅰ～Ⅱ》を習得すると、魔法の各種数値の表で「《魔力強化》」の行が表示されるが、具体的な魔力の増分は常に `+0` として表示されていた。

![image](https://github.com/user-attachments/assets/2d147947-3a77-44e1-94fd-80eac594b441)

これを実際の魔力の増分（《魔力強化Ⅰ》であれば +1 、《魔力強化Ⅱ》であれば +2 ）に修正する。