### PR TITLE
[SW2] 武器をもちいない操気の判定には道具の専用化をさせない

### DIFF
--- a/_core/lib/sw2.0/edit-chara.pl
+++ b/_core/lib/sw2.0/edit-chara.pl
@@ -913,7 +913,12 @@ foreach my $name (@data::class_list){
             <tr@{[ display $pc{'lv'.$id} ]} id="magic-power-${ename}">
               <td>${name}
               <td>$data::class{$name}{craft}{jName}
-              <td><label>@{[ input 'magicPowerOwn'.$id, 'checkbox','calcMagic' ]}$data::class{$name}{craft}{stt}+2</label>
+              <td>
+HTML
+  if ($data::class{$name}{craft}{personalization} // 1) {
+    print "<label>@{[ input 'magicPowerOwn'.$id, 'checkbox','calcMagic' ]}$data::class{$name}{craft}{stt}+2</label>";
+  }
+  print <<"HTML";
               <td>
 HTML
   if($data::class{$name}{craft}{power}){

--- a/_core/lib/sw2/calc-chara.pl
+++ b/_core/lib/sw2/calc-chara.pl
@@ -536,7 +536,7 @@ sub data_calc {
       + int(($pc{sttInt}
       + $pc{sttAddE}
       + $pc{sttEquipE}
-      + ($pc{'magicPowerOwn'.$id} ? 2 : 0)) / 6)
+      + (($data::class{$name}{magic}{personalization} // 1) && $pc{'magicPowerOwn'.$id} ? 2 : 0)) / 6)
       + $pc{'magicPowerAdd'.$id}
       + $pc{magicPowerAdd}
       + $pc{magicPowerEnhance}
@@ -553,7 +553,7 @@ sub data_calc {
     next if (!$data::class{$name}{craft}{stt});
     my $id = $data::class{$name}{id};
     my $st = $data::class{$name}{craft}{stt};
-    $pc{'magicPower'.$id} = $pc{'lv'.$id} ? ( $pc{'lv'.$id} + int(($pc{'stt'.$stt{$st}[0]} + $pc{'sttAdd'.$stt{$st}[1]} + $pc{'sttEquip'.$stt{$st}[1]} + ($pc{'magicPowerOwn'.$id} ? 2 : 0)) / 6) + $pc{'magicPowerAdd'.$id} ) : 0;
+    $pc{'magicPower'.$id} = $pc{'lv'.$id} ? ( $pc{'lv'.$id} + int(($pc{'stt'.$stt{$st}[0]} + $pc{'sttAdd'.$stt{$st}[1]} + $pc{'sttEquip'.$stt{$st}[1]} + (($data::class{$name}{craft}{personalization} // 1) && $pc{'magicPowerOwn'.$id} ? 2 : 0)) / 6) + $pc{'magicPowerAdd'.$id} ) : 0;
   }
   $pc{magicPowerAlc} += $pc{alchemyEnhance};
   

--- a/_core/lib/sw2/data-class.pl
+++ b/_core/lib/sw2/data-class.pl
@@ -612,6 +612,7 @@ our %class = (
       jName => '操気',
       eName => 'psychokinesis',
       stt => '精神力',
+      personalization => 0,
       power => '理力',
       data => [
         [1,'気集中','[補]'],

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1237,7 +1237,7 @@ function calcMagic() {
       if(cLv){ openMagic++; }
       
       const seekerMagicAdd = (lvSeeker && checkSeekerAbility('魔力上昇') && cLv >= 15) ? 3 : 0;
-      let power = cLv + parseInt((stt.totalInt + (form["magicPowerOwn"+id].checked ? 2 : 0)) / 6) + Number(form["magicPowerAdd"+id].value) + addPower + seekerMagicAdd + raceAbilityMagicPower;
+      let power = cLv + parseInt((stt.totalInt + ((form["magicPowerOwn"+id]?.checked ?? false) ? 2 : 0)) / 6) + Number(form["magicPowerAdd"+id].value) + addPower + seekerMagicAdd + raceAbilityMagicPower;
       if(id === 'Pri' && (
            raceAbilities.includes('神の御名と共に')
         || raceAbilities.includes('神への礼賛')
@@ -1257,10 +1257,10 @@ function calcMagic() {
       
       let power = cLv;
       if     (SET.class[key].craft.stt === '知力')  {
-        power += parseInt((stt.totalInt + (form["magicPowerOwn"+id].checked ? 2 : 0)) / 6);
+        power += parseInt((stt.totalInt + ((form["magicPowerOwn"+id]?.checked ?? false) ? 2 : 0)) / 6);
       }
       else if(SET.class[key].craft.stt === '精神力'){
-        power += parseInt((stt.totalMnd + (form["magicPowerOwn"+id].checked ? 2 : 0)) / 6);
+        power += parseInt((stt.totalMnd + ((form["magicPowerOwn"+id]?.checked ?? false) ? 2 : 0)) / 6);
       }
       if(SET.class[key].craft.power){
         power += Number(form["magicPowerAdd"+id].value);

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -913,7 +913,12 @@ foreach my $name (@data::class_names){
             <tr@{[ display $pc{'lv'.$id} ]} id="magic-power-${ename}">
               <td>${name}
               <td>$data::class{$name}{craft}{jName}
-              <td><label>@{[ input 'magicPowerOwn'.$id, 'checkbox','calcMagic' ]}$data::class{$name}{craft}{stt}+2</label>
+              <td>
+HTML
+  if ($data::class{$name}{craft}{personalization} // 1) {
+    print "<label>@{[ input 'magicPowerOwn'.$id, 'checkbox', 'calcMagic' ]}$data::class{$name}{craft}{stt}+2</label>";
+  }
+  print <<"HTML";
               <td>
 HTML
   if($data::class{$name}{craft}{power}){


### PR DESCRIPTION
# 変更内容

武器をもちいない操気の判定には道具の専用化をさせないように

# 背景

操気には、呪歌・終律における〈楽器〉や賦術における〈アルケミーキット〉のような、“操気全体でもちいる道具”が存在しない。（⇒『アビスブレイカー』18頁、「操気を使用するとき、装備などの制限は存在しません」）

【気操法】などの、投擲攻撃をおこなう主旨の操気では、武器が専用化しうる道具にあたる（※註）と考えられるが、その専用化の解決は武器欄側で管理されているため、そのような操気においても、操気全体にかかる専用化の概念は不要である。

（※註：余談となるが、操気によって精神力を参照しておこなう投擲攻撃に、〈専用武器〉の効果があるかどうかも定かではない。『Ⅱ』136頁の「器用度＋２（命中力判定）」という記述にもとづくならば、操気による命中力判定は器用度をもちいないのであるから、適用されない疑いがある。しかし一方で、同135頁の「対応する能力値ひとつ」という専用道具の主旨をふまえると、器用度とは別に「精神力＋２（操気による命中力判定）」のような専用化を施す余地はあると考えられる（その場合、器用度のための専用化と精神力のための専用化は別の専用化となり、プレイヤーは併行的に管理しなければならない）。……が、いずれにせよ、この点は本ＰＲの主旨とは直交しており、本件においては考慮の必要がない）

# 仕様

## 内部仕様

技能定義の `magic` および `craft` に、 `personalization` というキーがあり、その値が偽であるならば、その魔法あるいは技芸では、道具の専用化をあつかわない。
（ `personalization` キーがない場合は、従来どおり、専用化をあつかう）

## 外部仕様

専用化をあつかわない魔法および技芸では、専用化のチェックボックスを表示しない。

![image](https://github.com/user-attachments/assets/7b7aac36-629c-4ece-b138-0ea8faf6a4df)

## 既存データへの影響

再保存によって、専用化を無視した数値で再計算される。

