### PR TITLE
Refactor: integrate `urlDataGet` from each games

### DIFF
--- a/_core/lib/ar2e/convert.pl
+++ b/_core/lib/ar2e/convert.pl
@@ -3,23 +3,10 @@ use strict;
 #use warnings;
 use utf8;
 use open ":utf8";
-use LWP::UserAgent;
 use JSON::PP;
 
 require $set::data_class;
 require $set::data_races;
-
-sub urlDataGet {
-  my $url = shift;
-  my $ua  = LWP::UserAgent->new;
-  my $res = $ua->get($url);
-  if ($res->is_success) {
-    return $res->decoded_content;
-  }
-  else {
-    return undef;
-  }
-}
 
 sub dataConvert {
   my $set_url = shift;

--- a/_core/lib/blp/convert.pl
+++ b/_core/lib/blp/convert.pl
@@ -3,20 +3,7 @@ use strict;
 #use warnings;
 use utf8;
 use open ":utf8";
-use LWP::UserAgent;
 use JSON::PP;
-
-sub urlDataGet {
-  my $url = shift;
-  my $ua  = LWP::UserAgent->new;
-  my $res = $ua->get($url);
-  if ($res->is_success) {
-    return $res->decoded_content;
-  }
-  else {
-    return undef;
-  }
-}
 
 sub dataConvert {
   my $set_url = shift;

--- a/_core/lib/dx3/convert.pl
+++ b/_core/lib/dx3/convert.pl
@@ -3,20 +3,7 @@ use strict;
 #use warnings;
 use utf8;
 use open ":utf8";
-use LWP::UserAgent;
 use JSON::PP;
-
-sub urlDataGet {
-  my $url = shift;
-  my $ua  = LWP::UserAgent->new;
-  my $res = $ua->get($url);
-  if ($res->is_success) {
-    return $res->decoded_content;
-  }
-  else {
-    return undef;
-  }
-}
 
 sub dataConvert {
   my $set_url = shift;

--- a/_core/lib/gc/convert.pl
+++ b/_core/lib/gc/convert.pl
@@ -3,22 +3,9 @@ use strict;
 #use warnings;
 use utf8;
 use open ":utf8";
-use LWP::UserAgent;
 use JSON::PP;
 
 require $set::data_class;
-
-sub urlDataGet {
-  my $url = shift;
-  my $ua  = LWP::UserAgent->new;
-  my $res = $ua->get($url);
-  if ($res->is_success) {
-    return $res->decoded_content;
-  }
-  else {
-    return undef;
-  }
-}
 
 sub dataConvert {
   my $set_url = shift;

--- a/_core/lib/gs/convert.pl
+++ b/_core/lib/gs/convert.pl
@@ -3,22 +3,9 @@ use strict;
 #use warnings;
 use utf8;
 use open ":utf8";
-use LWP::UserAgent;
 use JSON::PP;
 
 require $set::data_class;
-
-sub urlDataGet {
-  my $url = shift;
-  my $ua  = LWP::UserAgent->new;
-  my $res = $ua->get($url);
-  if ($res->is_success) {
-    return $res->decoded_content;
-  }
-  else {
-    return undef;
-  }
-}
 
 sub dataConvert {
   my $set_url = shift;

--- a/_core/lib/kiz/convert.pl
+++ b/_core/lib/kiz/convert.pl
@@ -3,20 +3,7 @@ use strict;
 #use warnings;
 use utf8;
 use open ":utf8";
-use LWP::UserAgent;
 use JSON::PP;
-
-sub urlDataGet {
-  my $url = shift;
-  my $ua  = LWP::UserAgent->new;
-  my $res = $ua->get($url);
-  if ($res->is_success) {
-    return $res->decoded_content;
-  }
-  else {
-    return undef;
-  }
-}
 
 sub dataConvert {
   my $set_url = shift;

--- a/_core/lib/ms/convert.pl
+++ b/_core/lib/ms/convert.pl
@@ -3,20 +3,7 @@ use strict;
 #use warnings;
 use utf8;
 use open ":utf8";
-use LWP::UserAgent;
 use JSON::PP;
-
-sub urlDataGet {
-  my $url = shift;
-  my $ua  = LWP::UserAgent->new;
-  my $res = $ua->get($url);
-  if ($res->is_success) {
-    return $res->decoded_content;
-  }
-  else {
-    return undef;
-  }
-}
 
 sub dataConvert {
   my $set_url = shift;

--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -5,6 +5,7 @@ use open ":utf8";
 use CGI::Cookie;
 use List::Util qw/max min/;
 use Fcntl;
+use LWP::UserAgent;
 
 ### サブルーチン #####################################################################################
 
@@ -903,6 +904,19 @@ sub logFileUpdate {
   rmdir("${dir}/backup");
   unlink("${dir}/buname.cgi");
   if($mode eq 'view'){ print "Location:./?id=$::in{id}\n\n"; }
+}
+
+### 外部データ取得 --------------------------------------------------
+sub urlDataGet {
+  my $url = shift;
+  my $ua  = LWP::UserAgent->new;
+  my $res = $ua->get($url);
+  if ($res->is_success) {
+    return $res->decoded_content;
+  }
+  else {
+    return undef;
+  }
 }
 
 

--- a/_core/lib/sw2/convert.pl
+++ b/_core/lib/sw2/convert.pl
@@ -3,22 +3,9 @@ use strict;
 #use warnings;
 use utf8;
 use open ":utf8";
-use LWP::UserAgent;
 use JSON::PP;
 
 require $set::data_class;
-
-sub urlDataGet {
-  my $url = shift;
-  my $ua  = LWP::UserAgent->new;
-  my $res = $ua->get($url);
-  if ($res->is_success) {
-    return $res->decoded_content;
-  }
-  else {
-    return undef;
-  }
-}
 
 sub dataConvert {
   my $set_url = shift;

--- a/_core/lib/vc/convert.pl
+++ b/_core/lib/vc/convert.pl
@@ -3,23 +3,10 @@ use strict;
 #use warnings;
 use utf8;
 use open ":utf8";
-use LWP::UserAgent;
 use JSON::PP;
 
 require $set::data_class;
 require $set::data_races;
-
-sub urlDataGet {
-  my $url = shift;
-  my $ua  = LWP::UserAgent->new;
-  my $res = $ua->get($url);
-  if ($res->is_success) {
-    return $res->decoded_content;
-  }
-  else {
-    return undef;
-  }
-}
 
 sub dataConvert {
   my $set_url = shift;


### PR DESCRIPTION
ゲームごとの convert.pl に存在していた `urlDataGet` を統合。

まったく同じ実装にもかかわらずゲームごとに記述されており、メンテナビリティを損なっていたため。
