### PR TITLE
メールアドレスの設定を奨励する

### DIFF
--- a/_core/lib/ar2e/list-chara.pl
+++ b/_core/lib/ar2e/list-chara.pl
@@ -27,6 +27,7 @@ $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 $INDEX->param(typeName => 'キャラ');
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/blp/list-chara.pl
+++ b/_core/lib/blp/list-chara.pl
@@ -22,6 +22,7 @@ $INDEX->param(modeList => 1);
 $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/dx3/list-chara.pl
+++ b/_core/lib/dx3/list-chara.pl
@@ -22,6 +22,7 @@ $INDEX->param(modeList => 1);
 $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/gc/list-chara.pl
+++ b/_core/lib/gc/list-chara.pl
@@ -27,6 +27,7 @@ $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 $INDEX->param(typeName => 'キャラ');
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/gc/list-country.pl
+++ b/_core/lib/gc/list-country.pl
@@ -27,6 +27,7 @@ $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 $INDEX->param(typeName => '国管理');
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/gs/list-chara.pl
+++ b/_core/lib/gs/list-chara.pl
@@ -28,6 +28,7 @@ $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 $INDEX->param(typeName => 'キャラ');
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/info.pl
+++ b/_core/lib/info.pl
@@ -15,6 +15,7 @@ my $INDEX = HTML::Template->new( filename => $set::skin_tmpl, utf8 => 1,
 $INDEX->param(modeInfo => 1);
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/kiz/list-chara.pl
+++ b/_core/lib/kiz/list-chara.pl
@@ -22,6 +22,7 @@ $INDEX->param(modeList => 1);
 $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/ms/list-chara.pl
+++ b/_core/lib/ms/list-chara.pl
@@ -23,6 +23,7 @@ $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 $INDEX->param(typeName => '都民');
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/ms/list-clan.pl
+++ b/_core/lib/ms/list-clan.pl
@@ -23,6 +23,7 @@ $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 $INDEX->param(typeName => 'クラン');
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -117,6 +117,14 @@ sub getplayername {
 }
 
 
+### メールアドレス設定の有無を判定 --------------------------------------------------
+sub emailRegistered {
+  my $login_id = shift;
+  my $email = (getplayername($login_id))[1];
+  return $email ne '' ? 1 : 0;
+}
+
+
 ### 編集保護設定取得 --------------------------------------------------
 sub getProtectType {
   my $file = shift;

--- a/_core/lib/sw2/list-arts.pl
+++ b/_core/lib/sw2/list-arts.pl
@@ -24,6 +24,7 @@ $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 $INDEX->param(typeName => '魔法');
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/sw2/list-chara.pl
+++ b/_core/lib/sw2/list-chara.pl
@@ -29,6 +29,7 @@ $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 $INDEX->param(typeName => 'キャラ');
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/sw2/list-item.pl
+++ b/_core/lib/sw2/list-item.pl
@@ -24,6 +24,7 @@ $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 $INDEX->param(typeName => 'アイテム');
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/sw2/list-making.pl
+++ b/_core/lib/sw2/list-making.pl
@@ -25,6 +25,7 @@ $INDEX->param(typeName => 'キャラ');
 $INDEX->param(name => (getplayername($LOGIN_ID))[0]);
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/sw2/list-mons.pl
+++ b/_core/lib/sw2/list-mons.pl
@@ -24,6 +24,7 @@ $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 $INDEX->param(typeName => '魔物');
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/lib/vc/list-chara.pl
+++ b/_core/lib/vc/list-chara.pl
@@ -27,6 +27,7 @@ $INDEX->param(modeMylist => 1) if $mode eq 'mylist';
 $INDEX->param(typeName => 'キャラ');
 
 $INDEX->param(LOGIN_ID => $LOGIN_ID);
+$INDEX->param(EMAIL_NOT_REGISTERED => !emailRegistered($LOGIN_ID));
 $INDEX->param(OAUTH_MODE => $set::oauth_service);
 $INDEX->param(OAUTH_LOGIN_URL => $set::oauth_login_url);
 

--- a/_core/skin/_common/css/base.css
+++ b/_core/skin/_common/css/base.css
@@ -323,6 +323,16 @@ header {
       > b {
         font-size: 110%;
       }
+
+      &.email-registered {
+        &::before {
+          content: '\e86c';
+          font-family: "Material Symbols Outlined", sans-serif;
+          font-variation-settings: 'FILL' 0;
+          position: relative;
+          top: 0.1em;
+        }
+      }
     }
   }
 }

--- a/_core/skin/_common/css/base.css
+++ b/_core/skin/_common/css/base.css
@@ -393,6 +393,66 @@ main {
   @media print {
     border-width: 0;
   }
+
+  .notice-list {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    margin: 5rem 0 0 0;
+    padding: 0 3em;
+
+    @media screen and (width <= 735px) {
+      margin-top: 10rem;
+    }
+
+    @media print {
+      display: none;
+    }
+
+    &:not(:has(li)) {
+      display: none;
+    }
+
+    > li {
+      margin: 2em auto;
+      padding: 1em;
+      border: 3px dashed #e70;
+      border-radius: 0.75em;
+      background-color: #f504;
+      width: max-content;
+
+      > p {
+        margin: 0;
+        padding: 0;
+      }
+
+      &[data-mode] {
+        display: grid;
+        grid-template-columns: max-content 1fr;
+
+        &::before {
+          font-family: "Material Symbols Outlined", sans-serif;
+          font-variation-settings: 'FILL' 0;
+          grid-column: 1 / 2;
+          grid-row: 1 / -1;
+          font-size: 200%;
+          margin-right: 0.25em;
+          color: #e70;
+        }
+
+        > p {
+          grid-column: 2 / -1;
+          grid-row: auto;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+        }
+
+        &[data-mode="important"]::before {
+          content: "\e000";
+        }
+      }
+    }
+  }
 }
 
 article{

--- a/_core/skin/_common/form.html
+++ b/_core/skin/_common/form.html
@@ -128,6 +128,7 @@
         </dl>
       </section>
       <section class="form">
+        <a id="account"></a>
         <h2>アカウント情報</h2>
         <form method="post" action="./">
           <input type="hidden" name="mode" value="option">

--- a/_core/skin/_common/login-state.html
+++ b/_core/skin/_common/login-state.html
@@ -1,0 +1,1 @@
+<TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>

--- a/_core/skin/_common/login-state.html
+++ b/_core/skin/_common/login-state.html
@@ -1,1 +1,1 @@
-<TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>
+<TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span><TMPL_UNLESS EMAIL_NOT_REGISTERED><span class="email-registered">メールアドレス設定済み</span></TMPL_UNLESS></div></TMPL_IF>

--- a/_core/skin/_common/notice.html
+++ b/_core/skin/_common/notice.html
@@ -1,0 +1,11 @@
+<ul class="notice-list">
+    <TMPL_IF LOGIN_ID>
+    <TMPL_IF EMAIL_NOT_REGISTERED>
+    <li data-mode="important">
+        <p>
+            メールアドレスが設定されていません。（<a href="./?mode=option#account" target="_blank">設定する</a>）
+        </p>
+    </li>
+    </TMPL_IF>
+    </TMPL_IF>
+</ul>

--- a/_core/skin/ar2e/index.html
+++ b/_core/skin/ar2e/index.html
@@ -25,7 +25,7 @@
   <header>
     <h1><a href="./"><TMPL_VAR title></a></h1>
     <nav><TMPL_INCLUDE NAME="../_common/index-menu.html"></nav>
-    <TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>
+    <TMPL_INCLUDE NAME="../_common/login-state.html">
   </header>
   
   <main>

--- a/_core/skin/blp/index.html
+++ b/_core/skin/blp/index.html
@@ -25,7 +25,7 @@
   <header>
     <h1><a href="./"><TMPL_VAR title></a></h1>
     <nav><TMPL_INCLUDE NAME="../_common/index-menu.html"></nav>
-    <TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>
+    <TMPL_INCLUDE NAME="../_common/login-state.html">
   </header>
   
   <main>

--- a/_core/skin/dx3/index.html
+++ b/_core/skin/dx3/index.html
@@ -25,7 +25,7 @@
   <header>
     <h1><a href="./"><TMPL_VAR title></a></h1>
     <nav><TMPL_INCLUDE NAME="../_common/index-menu.html"></nav>
-    <TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>
+    <TMPL_INCLUDE NAME="../_common/login-state.html">
   </header>
   
   <main>

--- a/_core/skin/gc/index.html
+++ b/_core/skin/gc/index.html
@@ -25,7 +25,7 @@
   <header>
     <h1><a href="./"><TMPL_VAR title></a></h1>
     <nav><TMPL_INCLUDE NAME="../_common/index-menu.html"></nav>
-    <TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>
+    <TMPL_INCLUDE NAME="../_common/login-state.html">
   </header>
   
   <main>

--- a/_core/skin/gs/index.html
+++ b/_core/skin/gs/index.html
@@ -25,7 +25,7 @@
   <header>
     <h1><a href="./"><TMPL_VAR title></a></h1>
     <nav><TMPL_INCLUDE NAME="../_common/index-menu.html"></nav>
-    <TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>
+    <TMPL_INCLUDE NAME="../_common/login-state.html">
   </header>
   
   <main>

--- a/_core/skin/kiz/index.html
+++ b/_core/skin/kiz/index.html
@@ -25,7 +25,7 @@
   <header>
     <h1><a href="./"><TMPL_VAR title></a></h1>
     <nav><TMPL_INCLUDE NAME="../_common/index-menu.html"></nav>
-    <TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>
+    <TMPL_INCLUDE NAME="../_common/login-state.html">
   </header>
   
   <main>

--- a/_core/skin/ms/index.html
+++ b/_core/skin/ms/index.html
@@ -25,7 +25,7 @@
   <header>
     <h1><a href="./"><TMPL_VAR title></a></h1>
     <nav><TMPL_INCLUDE NAME="../_common/index-menu.html"></nav>
-    <TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>
+    <TMPL_INCLUDE NAME="../_common/login-state.html">
   </header>
   
   <main>

--- a/_core/skin/sw2/index.html
+++ b/_core/skin/sw2/index.html
@@ -30,6 +30,7 @@
   
   <main>
     <TMPL_INCLUDE NAME="skin-add/main-header.html">
+    <TMPL_INCLUDE NAME="../_common/notice.html">
     <nav>
       <ul>
         <li class="<TMPL_IF modeMaking>current</TMPL_IF>"><a href="./?mode=making<TMPL_IF modeMylist>&mylist=1</TMPL_IF><TMPL_IF tag>&tag=<TMPL_VAR tag></TMPL_IF>">能力値作成</a></li>

--- a/_core/skin/sw2/index.html
+++ b/_core/skin/sw2/index.html
@@ -25,7 +25,7 @@
   <header>
     <h1><a href="./<TMPL_IF isMakingResult>?mode=making</TMPL_IF>"><TMPL_VAR title></a></h1>
     <nav><TMPL_INCLUDE NAME="../_common/index-menu.html"></nav>
-    <TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>
+    <TMPL_INCLUDE NAME="../_common/login-state.html">
   </header>
   
   <main>

--- a/_core/skin/vc/index.html
+++ b/_core/skin/vc/index.html
@@ -25,7 +25,7 @@
   <header>
     <h1><a href="./"><TMPL_VAR title></a></h1>
     <nav><TMPL_INCLUDE NAME="../_common/index-menu.html"></nav>
-    <TMPL_IF LOGIN_ID><div class="login-user"><span>ログイン中: <b><TMPL_VAR LOGIN_ID></b></span></div></TMPL_IF>
+    <TMPL_INCLUDE NAME="../_common/login-state.html">
   </header>
   
   <main>


### PR DESCRIPTION
# 主旨

メールアドレスの設定をユーザーに促すように。

# 背景と目的

ゆとシートはメールアドレスを設定せずともアカウントを作成できるが、メールアドレスはサービスから見て唯一のユーザーへの連絡手段である。そのため、メールアドレスが設定されていない場合には、ＩＤを紛失する事態に対して実用的な対処方法がなくなってしまう。

ＩＤの紛失というのは一般的によく起こる事態であり（多くのサービスにおいて、ＩＤを紛失した場合にメールアドレスから探す手段が提供されている）、それに対する備えがない状態が看過されるのは、ユーザーとしても潜在的な不利益が大きいといえる。

上記をかんがみると、メールアドレスを設定せずにアカウントを作成できるとはいえ、（ほぼ）すべての場合においてメールアドレスを設定しておくほうが合理的であると思われる。
（メールアドレスをサーバーに渡したくないというユーザーもあるかもしれないが、メールアドレスは取得が容易かつ他者に提示することを前提とするものであることから、メールアドレスすら渡したくないというのはかなり特殊（異常）な状況であり、その場合ふつうはウェブサービスを利用すべきではないと考えられる）

よって、ユーザーにメールアドレスの設定を促すようにする。

# 具体的な機能

- ログイン中にもかかわらずメールアドレスが設定されていない場合、その旨を画面上で通知し、設定ページに誘導する。
- ログイン中かつメールアドレスが設定されている場合には、メールアドレスが設定されている旨をログインＩＤの表示に併せて表示する。

**メールアドレス設定への誘導**
![image](https://github.com/user-attachments/assets/cb962b20-5fae-4784-b68f-dca0c5c1e198)

**メールアドレスが設定されていることの表示**
![image](https://github.com/user-attachments/assets/c3072c94-a411-4130-806a-c4f732a5a92c)
