### PR TITLE
[SW2.5] 呪歌の「効果発生条件」の入力候補に「なし」を追加

### DIFF
--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -256,7 +256,7 @@ HTML
           <dl class="duration "><dt>時間        <dd>@{[ input 'magicDuration','','','list="list-duration"' ]}</dl>
           <dl class="song     "><dt>歌唱        <dd>@{[ checkbox 'magicSongSing','必要' ]}</dl>
           <dl class="song     "><dt>ペット      <dd>@{[ checkbox 'magicSongPetBird','小鳥' ]}@{[ checkbox 'magicSongPetFrog','蛙' ]}@{[ checkbox 'magicSongPetBug','虫' ]}</dl>
-          <dl class="condition"><dt>条件        <dd>@{[ input 'magicCondition','','','list="list-songpoint"' ]}</dl>
+          <dl class="condition"><dt>条件        <dd>@{[ input 'magicCondition','','','list="list-song-condition"' ]}</dl>
           <dl class="song     "><dt>楽素        <dd>基礎@{[ input 'magicSongBasePoint','','','list="list-songpoint"' ]} 巧奏値@{[ input 'magicSongSetPoint' ]} 追加@{[ input 'magicSongAddPoint','','','list="list-songpoint"' ]}</dl>
           <dl class="rider    "><dt>対応        <dd>@{[ checkbox 'magicMountTypeAnimal','動物' ]}@{[ checkbox 'magicMountTypeCryptid','幻獣' ]}@{[ checkbox 'magicMountTypeMachine','魔動機' ]}</dl>
           <dl class="part     "><dt>適用部位    <dd>@{[ input 'magicApplyPart','','','list="list-part"' ]}</dl>
@@ -584,6 +584,15 @@ print <<"HTML";
     <option value="大">
     <option value="大中小">
     <option value="大（＿個）">
+  </datalist>
+  <datalist id="list-song-condition">
+    <option value="なし">
+    <option value="⤴">
+    <option value="⤵">
+    <option value="♡">
+    <option value="⤴⤵">
+    <option value="⤴♡">
+    <option value="⤵♡">
   </datalist>
   <datalist id="list-songpoint">
     <option value="⤴">


### PR DESCRIPTION
# 変更内容

呪歌の「効果発生条件」の入力候補に「なし」を追加

# 背景と目的

既存の呪歌を見るに、「効果発生条件」が「なし」のものがかなりある。
（『メイガスアーツ』掲載のデータでいうと、全24種中、12種が「効果発生条件：なし」である。実際、「効果発生条件」のある呪歌は運用がむずかしい）

これをふまえると、ユーザーが自作するデータにおいても「効果発生条件」が「なし」とされるケースはそこそこ多いと思われる。
そのようなデータの入力を容易にするために、「効果発生条件」の入力候補に「なし」を追加する。

# 実装

これまで、「効果発生条件」の _datalist_ は「楽素」のそれと共用されていた。
「楽素」の _datalist_ をコピーし、それに「なし」を追加するかたちで、専用の _datalist_ を設けた。