### PR TITLE
Fix: [SW2] 秘伝の「効果」欄で定義リスト記法をもちいると内部の要素が不適切に引き伸ばされる不具合を修正

### DIFF
--- a/_core/skin/sw2/css/arts.css
+++ b/_core/skin/sw2/css/arts.css
@@ -478,7 +478,7 @@ article {
 .data-magic > h3 .s-icon::before {
   color: #fff;
 }
-.data-magic.data-arts dl:not(.summary,.effect) dd {
+.data-magic.data-arts > dl:not(.summary,.effect) dd {
   display: flex;
   flex-direction: column;
   justify-content: space-around;


### PR DESCRIPTION
# 現象

秘伝の「効果」欄で定義リスト記法をもちいると、内部の要素が不適切に引き伸ばされてしまう。
（ふつうに利用しているかぎりでは気づきづらいが、ハイパーリンク記法などを併用すると明白になる）

![image](https://github.com/user-attachments/assets/825a8dbc-957a-4a33-a9a5-2413cf366435)

再現サンプル： https://yutorize.2-d.jp/ytsheet/sw2.5/?id=wlHTVy

```
:ソーサラー技能２レベル| [[【ファイア】>https://example.com/...]]
:ソーサラー技能６レベル| [[【ファイラ】>https://example.com/...]]
:ソーサラー技能８レベル| [[【ファイガ】>https://example.com/...]]
```

# 原因

58bc7977f90b3fa839267a6967bc269f71324807 で追加されたスタイルが意図せず適用されてしまっていた

# 修正方法

子結合子 `>` をもちいて当該スタイルの適用対象を限定する

# 修正後

![image](https://github.com/user-attachments/assets/86ba11da-9615-494b-831e-124373d3c274)
