### PR TITLE
[SW2] 魔法データの名称、ならびに、流派データの秘伝魔法の名称について、神聖魔法の短剣符を隅付き括弧の外に出す

### DIFF
--- a/_core/lib/sw2/list-arts.pl
+++ b/_core/lib/sw2/list-arts.pl
@@ -160,7 +160,11 @@ foreach (@list) {
   }
   
   #名前
-  if($category =~ /magic|school/){ $name = '【'.$name.'】'; }
+  if($category =~ /magic|school/){
+    (my $divineMark, $name) = extractDivineMark $name if $category =~ /magic/ && $sub =~ /神聖魔法/;
+    $name = '【'.$name.'】';
+    $name = $divineMark.$name if defined $divineMark;
+  }
   
   #グループ（分類）
   my $category_text = $category{$category};

--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -285,6 +285,18 @@ sub extractModifications {
   return \@modifications;
 }
 
+### 神聖魔法の短剣符の抽出 --------------------------------------------------
+# (記号, 魔法名) のかたちで返す.
+sub extractDivineMark {
+  my $magicName = shift;
+
+  if ($magicName =~ s/^([†‡])//) {
+    return ($1, $magicName);
+  }
+
+  return (undef, $magicName);
+}
+
 ### バージョンアップデート --------------------------------------------------
 sub data_update_chara {
   my %pc = %{$_[0]};

--- a/_core/lib/sw2/view-arts.pl
+++ b/_core/lib/sw2/view-arts.pl
@@ -176,8 +176,13 @@ $SHEET->param(Tags => \@tags);
   if($pc{magicActionTypeMajor}  ){ $icon .= '<i class="s-icon major"><span class="raw">[主]</span></i>' }
   if($pc{magicActionTypeMinor}  ){ $icon .= '<i class="s-icon minor"><span class="raw">[補]</span></i>' }
   if($pc{magicActionTypeSetup}  ){ $icon .= '<i class="s-icon setup"><span class="raw">[準]</span></i>' }
+
+  my $magicName = $pc{magicName};
+  (my $divineMark, $magicName) = extractDivineMark $magicName if $pc{magicClass} eq '神聖魔法';
+
   $SHEET->param(magicIcon => $icon);
-  $SHEET->param(magicName => stylizeCharacterName $pc{magicName});
+  $SHEET->param(magicName => stylizeCharacterName $magicName);
+  $SHEET->param(magicDivineMark => $divineMark) if defined $divineMark;
   $SHEET->param(magicTarget   => textMagic($pc{magicTarget}));
   $SHEET->param(magicDuration => textMagic($pc{magicDuration}));
 
@@ -348,8 +353,13 @@ foreach my $num (1..$pc{schoolMagicNum}){
   if($pc{'schoolMagic'.$num.'ActionTypeMinor'}){ $icon .= '<i class="s-icon minor">≫</i>' }
   if($pc{'schoolMagic'.$num.'ActionTypeSetup'}){ $icon .= '<i class="s-icon setup">△</i>' }
   $pc{'schoolMagic'.$num.'Effect'} =~ s#<h2>(.+?)</h2>#</dd><dt><span class="center">$1</span></dt><dd class="box">#gi;
+
+  my $schoolMagicName = $pc{'schoolMagic'.$num.'Name'};
+  (my $divineMark, $schoolMagicName) = extractDivineMark $schoolMagicName;
+
   push(@schoolmagics, {
-    "NAME"     => stylizeCharacterName($pc{'schoolMagic'.$num.'Name'}),
+    "NAME"     => stylizeCharacterName($schoolMagicName),
+    "DIVINE_MARK" => $divineMark,
     "LEVEL"    => $pc{'schoolMagic'.$num.'Lv'},
     "ICON"     => $icon,
     "A-COST"   => $pc{'schoolMagic'.$num.'AcquireCost'},

--- a/_core/lib/sw2/view-arts.pl
+++ b/_core/lib/sw2/view-arts.pl
@@ -107,7 +107,7 @@ if($pc{forbidden} && !$pc{yourAuthor}){
 if($pc{category} eq 'magic'){
   if($pc{magicMinor}){ $pc{magicClass} .= ' (小魔法)' }
   $SHEET->param(categoryMagic => 1);
-  $pc{artsName} = '【'.$pc{magicName}.'】';
+  $pc{artsName} = '【'.($pc{magicClass} eq '神聖魔法' ? (extractDivineMark $pc{magicName})[1] : $pc{magicName}).'】';
   $SHEET->param(rawName => $pc{magicName});
 }
 elsif($pc{category} eq 'god'){

--- a/_core/skin/sw2/sheet-arts.html
+++ b/_core/skin/sw2/sheet-arts.html
@@ -101,7 +101,7 @@
         </div>
         <h2><TMPL_VAR magicClass DEFAULT="未分類"></h2>
         <div class="data-magic <TMPL_VAR magicClassEn>">
-          <dl class="name color-set"><dt><TMPL_VAR magicLevel><dd><div><TMPL_VAR magicIcon>【<TMPL_VAR magicName>】</div><small><TMPL_VAR magicNameNotes></small></dl>
+          <dl class="name color-set"><dt><TMPL_VAR magicLevel><dd><div><TMPL_VAR magicIcon><TMPL_VAR magicDivineMark>【<TMPL_VAR magicName>】</div><small><TMPL_VAR magicNameNotes></small></dl>
           <TMPL_IF magicCostOn     ><dl class="cost     "><dt>消費         <dd><TMPL_VAR magicCost></dl></TMPL_IF>
           <TMPL_IF magicTargetOn   ><dl class="target   "><dt>対象         <dd><TMPL_VAR magicTarget></dl></TMPL_IF>
           <TMPL_IF magicRangeOn    ><dl class="range    "><dt>射程/<br>形状<dd><TMPL_VAR magicRange>／<wbr><TMPL_VAR magicForm></dl></TMPL_IF>
@@ -255,7 +255,7 @@
           <TMPL_IF schoolMagicNote><div class="box"><p><TMPL_VAR schoolMagicNote></p></div></TMPL_IF>
           <TMPL_LOOP schoolMagicData>
           <div class="data-magic">
-            <dl class="name    "><dt><TMPL_VAR LEVEL><dd><div><TMPL_VAR ICON>【<TMPL_VAR NAME>】</div></dl>
+            <dl class="name    "><dt><TMPL_VAR LEVEL><dd><div><TMPL_VAR ICON><TMPL_VAR DIVINE_MARK>【<TMPL_VAR NAME>】</div></dl>
             <dl class="a-cost  "><dt><span>必要名誉点</span><dd><TMPL_VAR A-COST></dl>
             <dl class="cost    "><dt>消費      <dd><TMPL_VAR COST></dl>
             <dl class="target  "><dt>対象      <dd><TMPL_VAR TARGET></dl>


### PR DESCRIPTION
# 変更内容

魔法の名称の先頭にある短剣符／二重短剣符を、閲覧時は括弧の外に表記する

# 背景

『メイガスアーツ』において、信仰によって行使できるかどうかが分かれる魔法は、短剣符／二重短剣符によって明確化されるようになった。（⇒同書93頁）
公式文書において、この短剣符／二重短剣符は、名称の隅付き括弧の外側に記述される。（⇒同書95頁、†【バニッシュ】や‡【フィアー】）

基本ルールブック時点では存在しない表現方法ではあるものの、魔法データを自作するような（比較的ヘビーであろう）ユーザーにおいては、『メイガスアーツ』で導入されたこの表現に馴染みがある蓋然性が高いと思われる。

（余談：『2.0』でもこの表現は『ウィザーズトゥーム』から導入されたような気がする。少なくとも『2.0改訂Ⅰ～Ⅲ』では使われていない。改訂前の基本ルールブックがどうだったのかは記憶にない。『カルディアグレイス』巻末の総覧では短剣符表現が採用されている）

よって、上記の表現方法をゆとシート上で再現するために、魔法の名称の先頭にある短剣符／二重短剣符は、隅付き括弧の外側に移して表示する。

# 該当箇所

## 魔法データ

- 個別の魔法データの閲覧画面
- 一覧画面

![image](https://github.com/user-attachments/assets/7d2583c7-188c-4832-85ec-b2cd943218ea)

![image](https://github.com/user-attachments/assets/67c75e5f-59d5-4e76-a8d8-49e51e992a65)


## 秘伝魔法

- 個別の流派データの閲覧画面

![image](https://github.com/user-attachments/assets/cfc2a330-6739-4a3a-9073-edcba7309407)

# 仕様

該当する箇所において、魔法の名称の先頭が短剣符／二重短剣符であれば、それを切り離し、括弧の外側に表示する。

- 魔法データについては、神聖魔法に限定して上記の処理をおこなう。（神聖魔法に限定する必要はないと思うが、いちおう）
- 秘伝魔法については、（魔法系統を判別するすべがないので）常に上記の処理をおこなう。

# 議論

補助動作／戦闘準備で使用できることをあらわす記号と同時に存在するときに、どの順序で表記すべきかが定かでない。（公式文書においてそのような魔法データが示された前例がないため）
とりあえず補助動作／戦闘準備の記号を先に、短剣符／二重短剣符を後に表記するようにした。