### PR TITLE
Fix: [SW2] 流派データの編集画面で流派装備を追加したとき、その直後の時点では `target="_blank"` になっていない不具合を修正

### DIFF
--- a/_core/lib/sw2/edit-arts.js
+++ b/_core/lib/sw2/edit-arts.js
@@ -186,7 +186,7 @@ async function addSchoolItem(){
       let tr = document.createElement('tr');
       tr.setAttribute('class','item-data');
       tr.innerHTML = `
-        <td><a href="${url}">${ruby(data.itemName||'')}</a></td>
+        <td><a href="${url}" target="_blank">${ruby(data.itemName||'')}</a></td>
         <td>${data?.category.replace(/\s+/g, '<hr>') ?? ''}</td>
         <td>${data.summary ||''}</td>
         <td class="button" onclick="delSchoolItem(this,'${url}')">×</td>


### PR DESCRIPTION
[編集画面を開き直す場合には `target` 属性が指定されている](https://github.com/yutorize/ytsheet2/blob/develop/_core/lib/sw2/edit-arts.pl#L357)が、追加した時点では指定されていなかった。