### PR TITLE
Fix: [SW2] 技芸データの「対象」「射程」の入力候補では、「術者」ではなく「自身」とする

### DIFF
--- a/_core/lib/sw2/edit-arts.js
+++ b/_core/lib/sw2/edit-arts.js
@@ -148,11 +148,17 @@ function checkMagicClass(){
   document.querySelector('#data-magic dl.condition dt').textContent = (magic == '呪歌') ? '効果発生条件' : (magic == '陣率') ? '使用条件' : '条件';
 
   const levelInput = document.querySelector('#data-magic dl.level dd input');
+  const targetOptionSelf = document.querySelector('#list-target option.self');
+  const rangeOptionSelf = document.querySelector('#list-range option.self');
   if (magic.length === 2) {
     // 練技、呪歌など
     levelInput.setAttribute('list', 'list-craft-required-level');
+    targetOptionSelf.setAttribute('value', "自身");
+    rangeOptionSelf.setAttribute('value', "自身");
   } else {
     levelInput.removeAttribute('list');
+    targetOptionSelf.setAttribute('value', "術者");
+    rangeOptionSelf.setAttribute('value', "術者");
   }
 }
 function viewMagicInputs(items){

--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -490,7 +490,7 @@ print <<"HTML";
     <option value="人の命脈点">
   </datalist>
   <datalist id="list-target">
-    <option value="術者">
+    <option value="術者" class="self">
     <option value="1体">
     <option value="1体全">
     <option value="1体X">
@@ -515,7 +515,7 @@ print <<"HTML";
     <option value="全エリア(半径30m)／空間">
   </datalist>
   <datalist id="list-range">
-    <option value="術者">
+    <option value="術者" class="self">
     <option value="接触">
     <option value="1(10m)">
     <option value="2(20m)">


### PR DESCRIPTION
# 背景

技芸データの「対象」「射程」の入力候補は、魔法のそれと共有されており、行為者本人をあらわす選択肢が「術者」となっていた。

しかし、「術者」という表現は、魔法においてもちいられるものであり、魔法以外では「自身」と表現するのが通例である。
（『Ⅲ』206頁、賦術データの凡例にともなう規定。操気については明確な規定は存在しないが、実際の操気データ（⇒『アビスブレイカー』20～24頁を見るに、「自身」となっている）

# 変更内容

技芸データの「対象」「射程」の入力候補では、「術者」の代わりに「自身」とする。

# 備考

占瞳においては「自身」ではなく「占者」となる（⇒『カルディアグレイス』35頁）。