### PR TITLE
[SW2] チャットパレットの「追加挿入」の選択肢に「武器攻撃系の先頭」を追加

### DIFF
--- a/_core/lib/junction.pl
+++ b/_core/lib/junction.pl
@@ -4,7 +4,7 @@ use strict;
 use utf8;
 use Encode;
 
-our $ver = "1.27.009";
+our $ver = "1.27.010";
 
 our %in;
 for (param()){ $in{$_} = param($_); }

--- a/_core/lib/sw2/calc-chara.pl
+++ b/_core/lib/sw2/calc-chara.pl
@@ -586,6 +586,11 @@ sub data_calc {
     $acc += $pc{"weapon${_}Acc"}; # 武器の修正値
     ## ダメージ
     my $str = $pc{sttStr} + ($partNum ? $pc{sttPartC} : $pc{sttAddC}+$pc{sttEquipC});
+    if($pc{"weapon${_}Note"} =~ /［巨人化］/){ $str += 12; }
+    if   ($pc{"weapon${_}Note"} =~ /〈レッサー・?アームスフィアⅠ〉/){ $str = 1; }
+    elsif($pc{"weapon${_}Note"} =~ /〈レッサー・?アームスフィアⅡ〉/){ $str = 5; }
+    elsif($pc{"weapon${_}Note"} =~ /〈レッサー・?アームスフィアⅢ〉/){ $str = 10; }
+    elsif($pc{"weapon${_}Note"} =~ /〈アームスフィア〉/){ $str = 20; }
     my $dmg = 0;
     $dmg = $pc{"weapon${_}Dmg"};
     if   ($category eq 'クロスボウ'){
@@ -634,6 +639,7 @@ sub data_calc {
 
     ## 基礎値
     my $agi = $pc{sttAgi} + ($partNum ? $pc{sttPartB} : $pc{sttAddB}+$pc{sttEquipB});
+    if($pc{"defenseTotal${i}Note"} =~ /［巨人化］/){ $agi -= 6; }
     my $eva = $data::class{$class}{evaUnlock}{mod};
     my $def = 0;
     ## 部位（コア含）

--- a/_core/lib/sw2/edit-chara-palette-option.pl
+++ b/_core/lib/sw2/edit-chara-palette-option.pl
@@ -43,7 +43,7 @@ HTML
     foreach ('TMPL',1 .. $pc{chatPaletteInsertNum}){
         $html .= '<template id="palette-insert-template">' if $_ eq 'TMPL';
         $html .= "<li>"
-            . ::selectBox("chatPaletteInsert${_}Position", 'setChatPalette', 'def=|<先頭>','general|<非戦闘系の直後>','common|<一般技能の直後>','feats|<宣言特技の直後>','magic|<魔法系の直後>','attack|<武器攻撃系の直後>','defense|<抵抗回避の直後>')
+            . ::selectBox("chatPaletteInsert${_}Position", 'setChatPalette', 'def=|<先頭>','general|<非戦闘系の直後>','common|<一般技能の直後>','feats|<宣言特技の直後>','magic|<魔法系の直後>','attack_head|<武器攻撃系の先頭>','attack|<武器攻撃系の直後>','defense|<抵抗回避の直後>')
             . "に挿入"
             . "<textarea name=\"chatPaletteInsert${_}\" onchange=\"setChatPalette()\">$pc{'chatPaletteInsert'.$_}</textarea>";
         $html .= '</template>' if $_ eq 'TMPL';

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -1062,8 +1062,10 @@ print <<"HTML";
           <div class="add-del-button"><a onclick="addWeapons();setupBracketInputCompletion()">▼</a><a onclick="delWeapons()">▲</a></div>
           <ul class="annotate">
             <li>Ｃ値は自動計算されません。
-            <li><code>\@防護点+1</code>や<code>\@回避力+1</code>のように記述すると、<span class="text-em">常時</span>有効な上昇効果が自動計算されます。<br>有効な項目は、装飾品欄と同様です。
+            <li>備考欄に<code>\@防護点+1</code>や<code>\@回避力+1</code>のように記述すると、<span class="text-em">常時</span>有効な上昇効果が自動計算されます。<br>有効な項目は、装飾品欄と同様です。
+            <li>備考欄に<code>〈レッサー・アームスフィアⅠ〉</code>のように記述すると、対応した筋力で計算されます。
             <li id="artisan-annotate" @{[ display $pc{masteryArtisan} ]}>備考欄に<code>〈魔器〉</code>と記入すると魔器習熟が反映されます。
+            <li id="giantize-annotate">備考欄に<code>［巨人化］</code>と記述すると、［巨人化］後の筋力で計算されます。
           </ul>
           @{[input('weaponNum','hidden')]}
         </div>
@@ -1179,7 +1181,7 @@ foreach my $num ('TMPL',1 .. $pc{armourNum}) {
                 <td>@{[ input "armour${num}Eva",'number','calcDefense' ]}
                 <td>@{[ input "armour${num}Def",'number','calcDefense' ]}
                 <td>@{[ input "armour${num}Own",'checkbox','calcDefense();calcMobility','disabled' ]}
-                <td>@{[ input "armour${num}Note",'','','onchange="changeEquipMod()"' ]}
+                <td>@{[ input "armour${num}Note",'','','onchange="changeEquipMod();calcDefense()"' ]}
 HTML
   if($num eq 'TMPL'){ print '</template>' }
 }
@@ -1215,7 +1217,7 @@ HTML
   print <<"HTML";
                 <td id="defense-total${i}-eva">0
                 <td id="defense-total${i}-def">0
-                <td colspan="3">@{[input("defenseTotal${i}Note")]}
+                <td colspan="3">@{[ input "defenseTotal${i}Note",'','','onchange="calcDefense()"' ]}
 HTML
   print '</template>' if ($i eq 'TMPL');
 }
@@ -1225,9 +1227,10 @@ print <<"HTML";
           </table>
           <div class="add-del-button"><a onclick="addDefense()">▼</a><a onclick="delDefense()">▲</a></div>
           <ul class="annotate">
-            <li><code>\@敏捷度-6</code>や<code>\@精神抵抗力+2</code>のように記述すると、<span class="text-em">常時</span>有効な上昇効果が自動計算されます。<br>
+            <li>防具の備考欄に<code>\@敏捷度-6</code>や<code>\@精神抵抗力+2</code>のように記述すると、<span class="text-em">常時</span>有効な上昇効果が自動計算されます。<br>
               有効な項目は、装飾品欄と同様です。<br>
               <code>\@</code>による修正は合算のチェックに関わらず計算されるため、予備装備や切り替えが想定されるものは注意してください。<br>
+            <li id="giantize-annotate">合計行の備考欄に<code>［巨人化］</code>と記述すると、［巨人化］後の敏捷度で計算されます。
           </ul>
         </div>
 

--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -524,6 +524,7 @@ sub palettePreset {
               $::pc{'weapon'.$_.'Crit'}.$::pc{'weapon'.$_.'Dmg'} eq '';
       $text .= "###\n" if $bot{TKY};
       $text .= "### ■武器攻撃系\n";
+      $text .= appendPaletteInsert('attack_head');
       $text .= "//命中修正=0\n";
       $text .= "//C修正=0\n";
       $text .= "//追加D修正=0\n";

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -736,6 +736,7 @@ else {
       $pc{'weapon'.$_.'Acc'} = 0;
       $pc{'weapon'.$_.'Dmg'} = 0;
     }
+    $pc{"weapon${_}Note"} =~ s#〈(レッサー・?アームスフィア[ⅠⅡⅢ]|アームスフィア)〉|［巨人化］#<b class="term-em">$&</b>#;
     push(@weapons, {
       NAME     => $pc{'weapon'.$_.'Name'},
       PART     => $pc{'part'.$pc{'weapon'.$_.'Part'}.'Name'},
@@ -886,6 +887,7 @@ else {
 
     if($pc{'armour'.$_.'Type'} =~ /^(鎧|盾|他|龍骸)[0-9]+/ && $count{$1} <= 1){ $pc{'armour'.$_.'Type'} = $1 }
 
+    $pc{"armour${_}Note"} =~ s#〈(レッサー・?アームスフィア[ⅠⅡⅢ]|アームスフィア)〉#<b class="term-em">$&</b>#;
     push(@armours, {
       TYPE => $pc{'armour'.$_.'Type'},
       NAME => $pc{'armour'.$_.'Name'},
@@ -920,6 +922,7 @@ else {
       .($class ? "${class}/" : '')
       .(@ths == @armours ? 'すべての防具・効果' : join('＋', @ths) || '');
     $th =~ s|/$||;
+    $pc{"defenseTotal${i}Note"} =~ s#［巨人化］#<b class="term-em">$&</b>#;
     push(@total, {
       TH   => $th,
       EVA  => $pc{"defenseTotal${i}Eva"},


### PR DESCRIPTION
攻撃に先立って解決すべき処理で利用する想定

<img width="336" height="98" alt="image" src="https://github.com/user-attachments/assets/b491ac5f-fd0d-480a-8765-1b20186ae721" />
