### PR TITLE
[SW2] 【剛力弾】によるダメージ増加を自動計算する

### DIFF
--- a/_core/lib/sw2.0/edit-chara.js
+++ b/_core/lib/sw2.0/edit-chara.js
@@ -483,6 +483,8 @@ function checkCraft() {
     }
   }
   calcFairy();
+
+  document.getElementById('herculean-missile').style.display = crafts['剛力弾'] ? '' : 'none';
 }
 
 // 妖精魔法 ----------------------------------------

--- a/_core/lib/sw2.0/edit-chara.pl
+++ b/_core/lib/sw2.0/edit-chara.pl
@@ -994,6 +994,13 @@ print <<"HTML";
                 <td>―
                 <td>―
                 <td>―
+              <tr id="herculean-missile"@{[ display $pc{herculeanMissile} ]}>
+                <td>【剛力弾】
+                <td>―
+                <td>―
+                <td>―
+                <td>―
+                <td id="herculean-missile-dmg">$pc{herculeanMissile}
               <tr id="parts-enhance"@{[ display $pc{partEnhance} ]}>
                 <td>【部位強化】
                 <td>―

--- a/_core/lib/sw2/calc-chara.pl
+++ b/_core/lib/sw2/calc-chara.pl
@@ -432,6 +432,15 @@ sub data_calc {
       elsif($feat eq '抵抗強化Ⅱ')  { $pc{resistEnhance} = 2; }
     }
   }
+  ### 操気 --------------------------------------------------
+  $pc{herculeanMissile} = 0;
+  foreach my $num (1..$pc{lvDar}){
+    if ($pc{"craftPsychokinesis$num"} =~ /^剛力弾$/) {
+      $pc{herculeanMissile} = 1;
+      $pc{herculeanMissile} += 1 if $pc{lvDar} >= 5;
+      $pc{herculeanMissile} += 1 if $pc{lvDar} >= 10;
+    }
+  }
   ### 魔装 --------------------------------------------------
   foreach my $num (1..$pc{lvPhy}){
     if   ($pc{"craftPotential$num"} =~ /^部位.+強化$/     ){ $pc{partEnhance} += 1 }
@@ -607,6 +616,7 @@ sub data_calc {
       $dmg += $pc{'mastery' . ucfirst($data::weapon_id{ $category }) };
       if($category eq 'ガン（物理）'){ $dmg += $pc{masteryGun}; }
       if($pc{"weapon${_}Note"} =~ /〈魔器〉/){ $dmg += $pc{masteryArtisan}; }
+      $dmg += $pc{herculeanMissile} if $category eq '投擲'; # 【剛力弾】
     }
     else {
       if($category eq '格闘'){ $dmg += $pc{masteryGrapple}; }

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1054,6 +1054,7 @@ function checkFeats(){
 
 // 技芸 ----------------------------------------
 let crafts = {};
+let herculeanMissile = 0;
 function checkCraft() {
   crafts = {};
   for(const key in SET.class){
@@ -1099,6 +1100,27 @@ function checkCraft() {
       }
     }
   }
+
+  {
+    if (crafts['剛力弾']) {
+      herculeanMissile = 1;
+
+      const darkHunterLevel = lv[SET.class['ダークハンター']?.id] ?? 0;
+      if (darkHunterLevel >= 5) {
+        herculeanMissile += 1;
+      }
+      if (darkHunterLevel >= 10) {
+        herculeanMissile += 1;
+      }
+    }
+    else {
+      herculeanMissile = 0;
+    }
+  }
+  document.getElementById('herculean-missile-dmg').textContent = herculeanMissile.toString();
+  document.getElementById('herculean-missile').style.display = crafts['剛力弾'] ? '' : 'none';
+
+  calcWeapon();
 }
 
 // ＨＰＭＰ抵抗力計算 ----------------------------------------
@@ -1540,7 +1562,10 @@ function calcWeapon() {
     // 戦闘特技
     if(!partNum || partNum == form.partCore.value) {
       accBase += feats['命中強化'] || 0;
-      if(category === '投擲') { accBase += feats['スローイング'] ? 1 : 0; }
+      if(category === '投擲') {
+        accBase += feats['スローイング'] ? 1 : 0;
+        dmgBase += crafts['剛力弾'] ? herculeanMissile : 0;
+      }
 
       if(category === 'ガン（物理）') { dmgBase += feats['武器習熟／ガン'] || 0; }
       else if(category) { dmgBase += feats['武器習熟／'+category] || 0; }

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -995,6 +995,13 @@ print <<"HTML";
                 <td>―
                 <td>―
                 <td>―
+              <tr id="herculean-missile"@{[ display $pc{herculeanMissile} ]}>
+                <td>【剛力弾】
+                <td>―
+                <td>―
+                <td>―
+                <td>―
+                <td id="herculean-missile-dmg">$pc{herculeanMissile}
               <tr id="parts-enhance"@{[ display $pc{partEnhance} ]}>
                 <td>【部位強化】
                 <td>―

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -589,7 +589,7 @@ $SHEET->param(MagicPowers => \@magic);
   $SHEET->param(MagicPowerThAct => scalar(@act) >= 3 ? "$act[0]など" : join('/',@act));
 }
 
-### 攻撃技能／特技 --------------------------------------------------
+### 攻撃技能／特技／技芸 --------------------------------------------------
 my $strTotal = $pc{sttStr}+$pc{sttAddC}+$pc{sttEquipC};
 my @atacck;
 if(!$pc{forbiddenMode}){
@@ -647,6 +647,12 @@ if(!$pc{forbiddenMode}){
     push(@atacck, {
       NAME => "《スローイング".($pc{throwing}  >= 2  ? 'Ⅱ' : 'Ⅰ')."》",
       ACC  => 1,
+    } );
+  }
+  if($pc{herculeanMissile}) {
+    push(@atacck, {
+        NAME => "【剛力弾】",
+        DMG  => $pc{herculeanMissile},
     } );
   }
 }


### PR DESCRIPTION
# 変更内容

【剛力弾】によるダメージ増加を自動計算する。

# ルール

> 闇狩が投擲攻撃によって発生させる物理ダメージが＋１点されます。

> ダークハンター技能レベルが５に達すると、ダメージ増分は＋２（中略）になります。

> ダークハンター技能レベルが10に達すると、ダメージ増分は＋３（中略）になります。

（いずれも『アビスブレイカー』21頁より）

「分類：魔神」「分類：アンデッド」に対する追加のダメージ増加は、本件ではひとまず考慮しない。（これを考慮しようがしまいが、自動計算はあったほうがよいため）

# 目的

計算作業を自動化し、省力化し、誤りの可能性を減じる。

# 仕様

操気【剛力弾】を習得している場合、上掲のルールにもとづいて追加ダメージが加算される。

具体的な挙動は《命中強化》《スローイング》【部位強化】などを参考にした。

# コード上のネーミング

【剛力弾】は "herculean missile" とした。

「剛力」に対応する語は herculean とした。
herculean は、ギリシア神話のヘラクレスに由来する語で、「怪力」や「剛力」などの人知を超えた膂力のニュアンスをもつ。
より平易な語としては、 powerful なども考えられる。

「弾」に対応する語は missile とした。
直訳的には bullet になるが、『SW2』において bullet の語は〈弾丸〉やそれをもちいる射撃攻撃と密接に結びついており、ルール上でまったく無関係の【剛力弾】に採用するには不適当に思われる。（また、英語としても、 bullet は銃弾のニュアンスがかなり強い）
代わりとして、普遍的な“飛び道具”のニュアンスをあらわす語として missile を選択した。『SW2』においても妖精魔法【ミサイルプロテクション】が存在することから、“飛び道具”のニュアンスで missile の語をもちいるのは不自然ではないと考えられる。
なお、ほかの案としては、“投石”の意味合いを強調する stone なども考えられる。