### PR TITLE
Fix: [SW2] 名誉点欄の隣に表示される冒険者ランク／バルバロス栄光ランクの星に数字（星の数）が伴わない不具合を修正

### DIFF
--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -1082,11 +1082,13 @@ else {
     ($pc{rank} && $pc{rankBarbaros}) ? "<div class=\"small\">$pc{rank}$pc{rankStar}</div><div class=\"small\">$pc{rankBarbaros}$pc{rankStarBarbaros}</div>"
     : $pc{rank}.$pc{rankStar} || $pc{rankBarbaros}.$pc{rankStarBarbaros} || "―"
   );
+  $SHEET->param(rank => $pc{rank} . $pc{rankStar}) if $pc{rank} =~ /★$/ && $pc{rankStar} >= 2;
   foreach (@set::adventurer_rank){
     my ($name, $num, undef) = @$_;
     if($pc{rank}=~/★$/ && $pc{rankStar} >= 2){ $num += ($pc{rankStar}-1)*500 }
     $SHEET->param(rankHonorValue => $num) if ($pc{rank} eq $name);
   }
+  $SHEET->param(rankBarbaros => $pc{rankBarbaros} . $pc{rankStarBarbaros}) if $pc{rankBarbaros} =~ /★$/ && $pc{rankStarBarbaros} >= 2;
   foreach (@set::barbaros_rank){
     my ($name, $num, undef) = @$_;
     if($pc{rankBarbaros}=~/★$/ && $pc{rankStarBarbaros} >= 2){ $num += ($pc{rankStarBarbaros}-1)*500 }

--- a/_core/lib/sw2/view-chara.pl
+++ b/_core/lib/sw2/view-chara.pl
@@ -1082,13 +1082,13 @@ else {
     ($pc{rank} && $pc{rankBarbaros}) ? "<div class=\"small\">$pc{rank}$pc{rankStar}</div><div class=\"small\">$pc{rankBarbaros}$pc{rankStarBarbaros}</div>"
     : $pc{rank}.$pc{rankStar} || $pc{rankBarbaros}.$pc{rankStarBarbaros} || "―"
   );
-  $SHEET->param(rank => $pc{rank} . $pc{rankStar}) if $pc{rank} =~ /★$/ && $pc{rankStar} >= 2;
+  $SHEET->param(rank => $pc{rank} . $pc{rankStar});
   foreach (@set::adventurer_rank){
     my ($name, $num, undef) = @$_;
     if($pc{rank}=~/★$/ && $pc{rankStar} >= 2){ $num += ($pc{rankStar}-1)*500 }
     $SHEET->param(rankHonorValue => $num) if ($pc{rank} eq $name);
   }
-  $SHEET->param(rankBarbaros => $pc{rankBarbaros} . $pc{rankStarBarbaros}) if $pc{rankBarbaros} =~ /★$/ && $pc{rankStarBarbaros} >= 2;
+  $SHEET->param(rankBarbaros => $pc{rankBarbaros} . $pc{rankStarBarbaros});
   foreach (@set::barbaros_rank){
     my ($name, $num, undef) = @$_;
     if($pc{rankBarbaros}=~/★$/ && $pc{rankStarBarbaros} >= 2){ $num += ($pc{rankStarBarbaros}-1)*500 }


### PR DESCRIPTION
# 現象

名誉点欄の隣に表示されるほうの冒険者ランク／バルバロス栄光ランクでは、星（★）に数字が伴わない。

※シート先頭付近に表示されるほうには、従来から数字が伴っていた。

# 原因

ランク名までしか含まれていないテンプレート変数のみが用いられていた。

# 対処

★２以上のランクなら星の数を合成しておく。