### PR TITLE
[SW2.5] ユニットのステータス項目に妖精魔法の契約属性を追加

### DIFF
--- a/_core/lib/sw2/subroutine-sw2.pl
+++ b/_core/lib/sw2/subroutine-sw2.pl
@@ -75,6 +75,15 @@ sub createUnitStatus {
     );
 
     if (!$::SW2_0) {
+      if ($pc{lvFai}) {
+        my @contractAttributes = ();
+        foreach ([Earth => '土'], [Water => '水'], [Fire => '炎'], [Wind => '風'], [Light => '光'], [Dark => '闇']) {
+          (my $attributeEn, my $attributeJa) = @{$_};
+          next unless $pc{"fairyContract${attributeEn}"};
+          push(@contractAttributes, $attributeJa);
+        }
+        push(@unitStatus, { 契約属性 => join('', @contractAttributes) });
+      }
       if ($pc{lvBar}) {
         push(@unitStatus, { '⤴' => '0' });
         push(@unitStatus, { '⤵' => '0' });


### PR DESCRIPTION
# 変更内容

SW2.5において、ユニットのステータス項目に妖精魔法の契約属性を追加

# 仕様

フェアリーテイマー技能レベルをもつキャラクターにおいては、 `unitStatus` に `契約属性` を追加する。

なお、閲覧画面の表示に合わせて、「水・氷」属性は「水」と表記する。

# 背景

『2.0』においては、妖精魔法の契約（の変更）は、ゲーム内時間を所要して能動的におこなうものであった（⇒『2.0改訂版Ⅰ』138頁、あるいは、『ウィザーズトゥーム』73頁）。

しかし、『2.5』においては、ゲーム内午前６時ごとに半自動的におこなうものである（⇒『2.5Ⅱ』114頁、または、『メイガスアーツ』128頁）。
このことから、『2.5』環境下では、妖精魔法の契約状況はゲームプレイ中にカジュアルに変更されやすい流動的なものであると考えられ、“現状がどうなっているか”を明示して確認しやすくすることの需要が生じる。