### PR TITLE
fix: [SW2.5] スプリガンのフェンサーのキャラクターを作成する際に必筋の計算が未定義の関数を使用しているために動かなくなる

### DIFF
--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -1768,7 +1768,7 @@ function calcArmour(evaAdd,defBase) {
 
     // 最大必筋
     const maxReqd
-     = (giantize && SET.class[className]?.reqdHalf) ? math((reqdStr+12) / 2)
+     = (giantize && SET.class[className]?.reqdHalf) ? Math.ceil((reqdStr+12) / 2)
      : (giantize) ? (reqdStr+12)
      : (SET.class[className]?.reqdHalf) ? reqdStrHalf : reqdStr;
 


### PR DESCRIPTION
未定義の関数を使っている部分があったので、本来使われるべきであろう関数を使うように変更しました。

---

スプリガンかつフェンサー技能で回避を試みようとしているキャラクターについて、
習得していない技能の習得欄が表示される問題が発生するようです。

[事象の再現](https://yutorize.2-d.jp/ytsheet/sw2.5/?mode=convert&url=https%3A%2F%2Fhiyo-hitsu.sakura.ne.jp%2Fytsheets%2Fytsheet2_sw2.5%2Fsw2.5%2F%3Fid%3DZSO3eb)

この問題が発生する際には次のようなログが出力されています。
これによって、途中で動作が止まっているために先述の問題が発生しています。

```
edit-chara.js?1.27.012:1772 Uncaught ReferenceError: math is not defined
    at calcArmour (edit-chara.js?1.27.012:1772:41)
    at calcDefense (edit-chara.js?1.27.012:1735:3)
    at checkFeats (edit-chara.js?1.27.012:1110:3)
    at calcStt (edit-chara.js?1.27.012:593:3)
    at edit-chara.js?1.27.012:96:3
```

原因は以下の部分にあり、未定義の関数 math を使用しているようです。

https://github.com/yutorize/ytsheet2/blob/a797361e720053ec57978f7549d2a68e2aab5d07/_core/lib/sw2/edit-chara.js#L1769-L1773

文脈から Math.ceil を使用するべきと思われます。また、類似のロジックではその様になっています。

https://github.com/yutorize/ytsheet2/blob/a797361e720053ec57978f7549d2a68e2aab5d07/_core/lib/sw2/edit-chara.js#L1594-L1602

本件について、使うべきと思われる関数を使用するように修正し、
自分のゆとシートサーバにデプロイし、動作を確認しました。