### PR TITLE
Fix: [SW2] バトルダンサーの宣言特技枠追加の内容がバトルダンサーでなくともチャットパレットに出力される不具合を修正

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -229,7 +229,8 @@ sub palettePreset {
     # 宣言特技
     require $set::data_feats;
     my @declarationFeats = ();
-    foreach ('1bat', @set::feats_lv) {
+    foreach ($::pc{lvBat} > 0 ? '1bat' : '', @set::feats_lv) {
+      next if $_ eq '';
       my $level = $_;
       last if $level ne '1+' && $level > $::pc{level};
       my $featName = $::pc{"combatFeatsLv${level}"};


### PR DESCRIPTION
# 現象

バトルダンサー技能を習得していないキャラクターであっても、バトルダンサーの「宣言特技枠追加」で習得した戦闘特技（宣言特技）が、チャットパレットに出力されてしまう。

# 再現方法

1. キャラクターデータの作成・編集画面で、バトルダンサー技能を１レベル以上にする
2. 「宣言特技枠追加」で適当な戦闘特技を選択する
3. バトルダンサー技能を習得していない状態にする
4. 保存する
5. チャットパレットを確認する

## 再現サンプル
[このシート](https://yutorize.2-d.jp/ytsheet/sw2.5/?id=yTSHaO)はバトルダンサー技能を習得していない。
<img width="582" height="161" alt="image" src="https://github.com/user-attachments/assets/5822bc80-bc43-40f2-a810-4947b8bb9132" />

しかし、[チャットパレット](https://yutorize.2-d.jp/ytsheet/sw2.5/?id=yTSHaO&mode=palette)には、「宣言特技枠追加」で選択した《斬り返しⅠ》が出力されてしまっている。
```
### ■宣言特技
[宣]《斬り返しⅠ》
[宣]《全力攻撃Ⅰ》
```

# 原因
チャットパレットの当該部分生成時に、バトルダンサーであるか否かを問わず「宣言特技枠追加」の内容を参照してしまっていた。

# 修正方針
「宣言特技枠追加」の内容を参照するのは、バトルダンサー技能である（ `$::pc{lvBat} > 0` ）場合にかぎる。
