### PR TITLE
[SW2] 武器攻撃の追加オプションの「出目修正」を柔軟にする

### DIFF
--- a/_core/lib/sw2/palette-sub.pl
+++ b/_core/lib/sw2/palette-sub.pl
@@ -487,7 +487,9 @@ sub palettePreset {
           $text .= "+{追加D修正}";
           if($::pc{'paletteAttack'.$paNum.'Roll'}){
             $::pc{'paletteAttack'.$paNum.'Roll'} =~ s/^+//;
-            $text .= "$+{クリレイ}\#$::pc{'paletteAttack'.$paNum.'Roll'}";
+            $text .= "$+{クリレイ}";
+            $text .= '#' if $::pc{'paletteAttack'.$paNum.'Roll'} =~ /^\d/;
+            $text .= $::pc{'paletteAttack'.$paNum.'Roll'};
           }
           else {
             $text .= "{出目修正}";


### PR DESCRIPTION
# 変更内容

「武器攻撃の追加オプション」の「出目修正」を柔軟にする

# 背景と目的

「武器攻撃の追加オプション」の「出目修正」は、これまで実質的に（『2.5』の）《必殺攻撃》専用の挙動になっていた。
（「出目修正」に入力されている値を、 `#` の後に続けてコマンド末尾に付加する、という挙動）

しかし、『SW2』において“出目修正”といった場合、《必殺攻撃》とは異なる形式の処理も想定されうる。
たとえば、『ドーデン博物誌』21頁に掲載されている秘伝《岩脈正中撃》は、《必殺攻撃》とは異なる挙動（初回のみ、一方の出目の固定）である。
この《岩脈正中撃》の挙動は、（現状のゆとチャadv.の威力コマンドでは実現不能だが、）「BCDice」においては実現可能であり（例 `k40[10]+13tf6` ）、これを「出目修正」機能で運用したいという需要が存在する。
（それはそれとして、ゆとチャadv.で《岩脈正中撃》を実現する機能は提案しておきました： https://github.com/yutorize/ytchat-adv/pull/121 ）

そのため、「出目修正」機能を、そのような（《必殺攻撃》以外の）用途にも利用できるようにする。

# 仕様

- 「出目修正」に入力されている値が数字から始まる（ `/^\d/` ）場合は、従来と同様の挙動（ `#` の後に続けて入力値を付加する）をとる。
- そうでない場合（＝数字以外から始まる場合）は、 `#` を挟まずに、そのまま入力値を付加する。

# 動作確認用データ
動作確認用に、「武器攻撃の追加オプション」にBCDice用の《岩脈正中撃》を入力してあるキャラクターデータを置いておきます。
https://yutorize.2-d.jp/ytsheet/sw2.5/?id=ysoV5V