### PR TITLE
:zap: 追加: 複数のキャラクター画像を利用できる機能

### DIFF
--- a/_core/lib/ar2e/calc-chara.pl
+++ b/_core/lib/ar2e/calc-chara.pl
@@ -260,7 +260,6 @@ sub data_calc {
   }
   #### 改行を<br>に変換 --------------------------------------------------
   foreach (
-    'words',
     'items',
     'freeNote',
     'freeHistory',
@@ -281,6 +280,7 @@ sub data_calc {
   foreach my $i (1 .. $pc{geisNum}){
     $pc{"geis${i}Note"} =~ s/\r\n?|\n/<br>/g;
   }
+  $pc{'words'.$_} =~ s/\r\n?|\n/<br>/g foreach('', 2 .. ($set::image_maxcount || 1));
   
   #### 保存処理でなければここまで --------------------------------------------------
   if(!$::mode_save){ return %pc; }
@@ -318,15 +318,16 @@ sub data_calc {
   $NL{classTitle}   = substr($NL{classTitle}  , 0, 20).'..' if length($NL{classTitle}  ) > 20;
   $NL{homeArea}  = substr($NL{homeArea} , 0,  30).'..' if length($NL{homeArea} ) >  30;
   $NL{guildName} = substr($NL{guildName}, 0, 108).'..' if length($NL{guildName}) > 108;
-  $::newline = "$pc{id}<>$::file<>".
-               "$pc{birthTime}<>$::now<>$NL{name}<>$NL{playerName}<>$pc{group}<>".
-               "$pc{image}<> $pc{tags} <>$pc{hide}<>".
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{name}<>$NL{playerName}<>$pc{group}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>"
 
-               "$NL{race}<>$NL{gender}<>$NL{age}<>".
-               "$pc{expTotal}<>$pc{level}<>".
-               "$NL{classMain}/$NL{classSupport}/$NL{classTitle}<>".
-               "$NL{homeArea}<> $pc{areaTags} <>$NL{guildName}<>$pc{payment}<>".
-               "$pc{lastSession}<>";
+    . "$NL{race}<>$NL{gender}<>$NL{age}<>"
+    . "$pc{expTotal}<>$pc{level}<>"
+    . "$NL{classMain}/$NL{classSupport}/$NL{classTitle}<>"
+    . "$NL{homeArea}<> $pc{areaTags} <>$NL{guildName}<>$pc{payment}<>"
+    . "$pc{lastSession}<>";
 
   return %pc;
 }

--- a/_core/lib/ar2e/edit-chara.js
+++ b/_core/lib/ar2e/edit-chara.js
@@ -18,7 +18,6 @@ window.onload = function() {
   calcCash();
   changeHandedness();
   
-  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/ar2e/edit-chara.js
+++ b/_core/lib/ar2e/edit-chara.js
@@ -18,7 +18,7 @@ window.onload = function() {
   calcCash();
   changeHandedness();
   
-  imagePosition();
+  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/ar2e/edit-chara.pl
+++ b/_core/lib/ar2e/edit-chara.pl
@@ -115,7 +115,8 @@ $open{skills} = 'open';
 
 ### 改行処理 --------------------------------------------------
 convertEscapedBrToNewlines(\%pc,
-  qw/words items freeNote freeHistory cashbook chatPalette armamentHandRNote armamentHandLNote armamentHeadNote armamentBodyNote armamentSubNote armamentOtherNote armamentTotalNote battleSkillNote battleOtherNote/,
+  qw/items freeNote freeHistory cashbook chatPalette armamentHandRNote armamentHandLNote armamentHeadNote armamentBodyNote armamentSubNote armamentOtherNote armamentTotalNote battleSkillNote battleOtherNote/,
+  ( map { 'words'.$_ } '', 2 .. ($set::image_maxcount || 1) ),
   ( map { "geis${_}Note" } 1..$pc{geisNum} ),
 );
 
@@ -246,7 +247,7 @@ print <<"HTML";
       <dl class="regulation-note"><dt>備考<dd>@{[ input "history0Note" ]}</dl>
     </details>
     <div id="area-status">
-      @{[ renderImageForm($pc{imageURL}) ]}
+      @{[ renderImageForm() ]}
 
       <div id="personal" class="in-toc" data-content-title="種族・年齢・性別">
         <dl class="box select-or-input" id="race">

--- a/_core/lib/blp/calc-chara.pl
+++ b/_core/lib/blp/calc-chara.pl
@@ -45,7 +45,7 @@ sub data_calc {
   #}
 
   #### 改行を<br>に変換 --------------------------------------------------
-  $pc{words}       =~ s/\r\n?|\n/<br>/g;
+  $pc{'words'.$_} =~ s/\r\n?|\n/<br>/g foreach('', 2 .. ($set::image_maxcount || 1));
   $pc{freeNote}    =~ s/\r\n?|\n/<br>/g;
   $pc{freeHistory} =~ s/\r\n?|\n/<br>/g;
   $pc{chatPalette} =~ s/\r\n?|\n/<br>/g;
@@ -79,14 +79,15 @@ sub data_calc {
   $NL{ageApp}  = substr($NL{ageApp} , 0, 20).'..' if length($NL{ageApp} ) > 20;
   $NL{belong}  = substr($pc{belong} , 0, 30).'..' if length($pc{belong} ) > 30;
   $NL{missing} = substr($pc{missing}, 0, 30).'..' if length($pc{missing}) > 30;
-  $::newline = "$pc{id}<>$::file<>".
-               "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>".
-               "$NL{factor}<>$NL{factorCore}<>$NL{factorStyle}<>".
-               "$NL{gender}<>$NL{age}<>$NL{ageApp}<>".
-               "$NL{belong}<>$NL{missing}<>".
-               "$pc{level}<>".
-               
-               "$pc{lastSession}<>$pc{image}<> $pc{tags} <>$pc{hide}<><>";
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>"
+    . "$NL{factor}<>$NL{factorCore}<>$NL{factorStyle}<>"
+    . "$NL{gender}<>$NL{age}<>$NL{ageApp}<>"
+    . "$NL{belong}<>$NL{missing}<>"
+    . "$pc{level}<>"
+    . "$pc{lastSession}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<><>";
 
   return %pc;
 }

--- a/_core/lib/blp/edit-chara.js
+++ b/_core/lib/blp/edit-chara.js
@@ -20,7 +20,7 @@ window.onload = function() {
 
   toggleServant();
   
-  imagePosition();
+  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/blp/edit-chara.js
+++ b/_core/lib/blp/edit-chara.js
@@ -20,7 +20,6 @@ window.onload = function() {
 
   toggleServant();
   
-  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/blp/edit-chara.pl
+++ b/_core/lib/blp/edit-chara.pl
@@ -63,7 +63,8 @@ $pc{artsNum} ||= 3;
 
 ### 改行処理 --------------------------------------------------
 convertEscapedBrToNewlines(\%pc,
-  qw/words scarNote freeNote freeHistory chatPalette/,
+  qw/scarNote freeNote freeHistory chatPalette/,
+  ( map { 'words'.$_ } '', 2 .. ($set::image_maxcount || 1) ),
 );
 
 ### フォーム表示 #####################################################################################
@@ -124,7 +125,7 @@ print <<"HTML";
       <dl class="regulation-note"><dt>備考<dd>@{[ input "history0Note" ]}</dl>
     </details>
     <div id="area-status">
-      @{[ renderImageForm($pc{imageURL}) ]}
+      @{[ renderImageForm() ]}
 
       <div id="factors" class="box">
         <h2 class="in-toc" data-content-title="能力値">練度:<span id="level-value"></span> ／ 能力値</h2>

--- a/_core/lib/config-default.pl
+++ b/_core/lib/config-default.pl
@@ -42,8 +42,7 @@ package set;
  # キャラクター画像のファイルサイズ上限(単位byte)
   our $image_maxsize = 1024 * 1024 * 1;
  # キャラクター画像の保存上限枚数
-  our $image_maxcount = 1;
-
+  our $image_maxcount = 3;
 
 ## ●削除関係
  # データを削除するとき、バックアップも削除 する=1 しない=0

--- a/_core/lib/config-default.pl
+++ b/_core/lib/config-default.pl
@@ -41,6 +41,8 @@ package set;
 ## ●画像関係
  # キャラクター画像のファイルサイズ上限(単位byte)
   our $image_maxsize = 1024 * 1024 * 1;
+ # キャラクター画像の保存上限枚数
+  our $image_maxcount = 1;
 
 
 ## ●削除関係

--- a/_core/lib/delete.pl
+++ b/_core/lib/delete.pl
@@ -20,6 +20,20 @@ if(!$file){ error('404:データが見つかりません。'); }
 my $sheetBaseDir = $user ? "${dataDir}_${user}/" : "${dataDir}anonymous/";
 my $fileDir = $user ? "_${user}/${file}" : "anonymous/${file}";
 
+sub deleteSheetImages {
+  my ($dir, $file) = @_;
+  my $imageMaxCount = $set::image_maxcount || 1;
+  $imageMaxCount = 1 if $imageMaxCount < 1;
+  my $deleted = 0;
+  for my $imageNo (1 .. $imageMaxCount){
+    my $suffix = imageSuffix($imageNo);
+    foreach my $ext (qw(png jpg jpeg gif webp)){
+      $deleted += deleteSheetFile($dir, $file, "image$suffix.$ext") ? 1 : 0;
+    }
+  }
+  return $deleted;
+}
+
 ## キャラシ削除
 if($mode eq 'delete'){
   # 一覧ファイル
@@ -43,10 +57,9 @@ if($mode eq 'delete'){
   });
 
   # 個別ファイル
-  if (deleteSheetFile($sheetBaseDir, $file, 'image.png')) { $message .= '画像(png)を削除しました。<br>'; }
-  if (deleteSheetFile($sheetBaseDir, $file, 'image.jpg')) { $message .= '画像(jpg)を削除しました。<br>'; }
-  if (deleteSheetFile($sheetBaseDir, $file, 'image.gif')) { $message .= '画像(gif)を削除しました。<br>'; }
-  if (deleteSheetFile($sheetBaseDir, $file, 'image.webp')){ $message .= '画像(webp)を削除しました。<br>'; }
+  if (my $deletedImages = deleteSheetImages($sheetBaseDir, $file)) {
+    $message .= "画像を${deletedImages}件削除しました。<br>";
+  }
 
   if($set::del_back){
     if (unlink "${dataDir}${fileDir}.zip")         { $message .= 'シートアーカイブを削除しました。<br>'; }
@@ -83,31 +96,26 @@ if($mode eq 'delete'){
 }
 ## 画像削除
 elsif($mode eq 'img-delete'){
+  my $deletedImages = deleteSheetImages($sheetBaseDir, $file);
+  if($deletedImages){
+    $message .= "キャラクター画像を${deletedImages}件削除しました。<br>";
+  }
+
   # 画像差し替え
-  if($set::beheaded){
-    foreach my $ext (qw(png jpg gif webp)){
-      if (deleteSheetFile($sheetBaseDir, $file, "image.$ext")) {
-        $message .= 'キャラクター画像を削除しました。<br>';
-        if(open(my $BEHEADED, '<', "${set::beheaded}.$ext")){
-          binmode $BEHEADED;
-          my $image = do { local $/; <$BEHEADED> };
-          close($BEHEADED);
-          updateSheetFile($sheetBaseDir, $file, "image.$ext", $image);
-          $message .= '差し替え画像を設定しました。<br>';
-        }
+  if($set::beheaded && $deletedImages){
+    foreach my $ext (qw(png jpg jpeg gif webp)){
+      if(open(my $BEHEADED, '<', "${set::beheaded}.$ext")){
+        binmode $BEHEADED;
+        my $image = do { local $/; <$BEHEADED> };
+        close($BEHEADED);
+        updateSheetFile($sheetBaseDir, $file, "image.$ext", $image);
+        $message .= '差し替え画像を設定しました。<br>';
+        last;
       }
     }
   }
-  # 消すだけ
-  else {
-    if (deleteSheetFile($sheetBaseDir, $file, 'image.png')) { $message .= 'キャラクター画像を削除しました。<br>'; }
-    if (deleteSheetFile($sheetBaseDir, $file, 'image.jpg')) { $message .= 'キャラクター画像を削除しました。<br>'; }
-    if (deleteSheetFile($sheetBaseDir, $file, 'image.gif')) { $message .= 'キャラクター画像を削除しました。<br>'; }
-    if (deleteSheetFile($sheetBaseDir, $file, 'image.webp')){ $message .= 'キャラクター画像を削除しました。<br>'; }
-  }
   $message .= '<a href="./?id='.$::in{id}.'">キャラクターシートを確認</a>';
-  
-  
+
   sysopen (my $FH, $::core_dir.'/data/image-delete.cgi', O_WRONLY | O_APPEND | O_CREAT) or $message .= 'デリートリストが開けませんでした。';
     if($user){ print $FH "$::in{id}<>$user<>$file<>image<>".time."<>\n"; }
     else { print $FH "$::in{id}<>-----<>$file<>image<>".time."<>\n"; }
@@ -115,4 +123,5 @@ elsif($mode eq 'img-delete'){
   
   info('画像の削除',$message);
 }
+
 1;

--- a/_core/lib/dx3/calc-chara.pl
+++ b/_core/lib/dx3/calc-chara.pl
@@ -228,7 +228,7 @@ sub data_calc {
   }
 
   #### 改行を<br>に変換 --------------------------------------------------
-  $pc{words}         =~ s/\r\n?|\n/<br>/g;
+  $pc{'words'.$_} =~ s/\r\n?|\n/<br>/g foreach('', 2 .. ($set::image_maxcount || 1));
   $pc{freeNote}      =~ s/\r\n?|\n/<br>/g;
   $pc{freeHistory}   =~ s/\r\n?|\n/<br>/g;
   $pc{chatPalette}   =~ s/\r\n?|\n/<br>/g;
@@ -286,17 +286,17 @@ sub data_calc {
     $syn = substr($syn, 0, 20).'..' if length($syn) > 20;
     return "その他:$syn";
   }
-  $::newline = "$pc{id}<>$::file<>".
-               "$pc{birthTime}<>$::now<>$NL{name}<>$NL{playerName}<>$pc{group}<>".
-               (130+$pc{expSpent}).
-               "<>$NL{gender}<>$NL{age}<>$NL{sign}<>$NL{blood}<>$NL{works}<>".
-               
-               synCheck($pc{syndrome1}).'/'.
-               synCheck($pc{syndrome2}).'/'.
-               synCheck($pc{syndrome3}).'<>'.
-               join('/',@dloises).'<>'.
-               
-               "$pc{lastSession}<>$pc{image}<> $pc{tags} <>$pc{hide}<>$pc{stage}<>";
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{name}<>$NL{playerName}<>$pc{group}<>"
+    . (130+$pc{expSpent})
+    . "<>$NL{gender}<>$NL{age}<>$NL{sign}<>$NL{blood}<>$NL{works}<>"
+    . synCheck($pc{syndrome1}).'/'
+    . synCheck($pc{syndrome2}).'/'
+    . synCheck($pc{syndrome3}).'<>'
+    . join('/',@dloises).'<>'
+    . "$pc{lastSession}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>$pc{stage}<>";
 
   return %pc;
 }

--- a/_core/lib/dx3/edit-chara.js
+++ b/_core/lib/dx3/edit-chara.js
@@ -22,7 +22,7 @@ window.onload = function() {
   calcMemory();
   refreshByImpulse();
   for(let i = 1; i <= 7; i++){ changeLoisColor(i); }
-  imagePosition();
+  setImagePosition();
   changeColor();
   console.log('=====LOADED=====');
 };

--- a/_core/lib/dx3/edit-chara.js
+++ b/_core/lib/dx3/edit-chara.js
@@ -22,7 +22,6 @@ window.onload = function() {
   calcMemory();
   refreshByImpulse();
   for(let i = 1; i <= 7; i++){ changeLoisColor(i); }
-  setImagePosition();
   changeColor();
   console.log('=====LOADED=====');
 };

--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -120,7 +120,8 @@ if(exists $data::syndrome_status{$pc{syndrome2}}){
 
 ### 改行処理 --------------------------------------------------
 convertEscapedBrToNewlines(\%pc,
-  qw/words freeNote freeHistory chatPalette/,
+  qw/freeNote freeHistory chatPalette/,
+  ( map { 'words'.$_ } '', 2 .. ($set::image_maxcount || 1) ),
   ( map { "combo${_}Note" } 1..$pc{comboNum} ),
   ( map { "weapon${_}Note" } 1..$pc{weaponNum} ),
   ( map { "armor${_}Note" } 1..$pc{armorNum} ),
@@ -200,7 +201,7 @@ print <<"HTML";
     </details>
 
     <div id="area-status">
-      @{[ renderImageForm($pc{imageURL}) ]}
+      @{[ renderImageForm() ]}
 
       <div class="box-union" id="personal">
         <dl class="box"><dt>年齢  <dd>@{[input "age"]}</dl>

--- a/_core/lib/edit.js
+++ b/_core/lib/edit.js
@@ -29,7 +29,9 @@ function formSubmit() {
   if(saving){ return; }
   if(!formCheck()){ return false; }
 
-  saveCurrentImageLayout();
+  if(typeof imageType !== "undefined" && imageType === 'character'){
+    saveCurrentImageLayout();
+  }
 
   const formData = new FormData(form);
   for(const [imageNo, compressedImageFile] of Object.entries(compressedImageFiles)){
@@ -424,19 +426,33 @@ if (document.getElementById('unit-status-optional')) {
 }
 
 // 画像配置 ----------------------------------------
+let imgURL = '';
+window.addEventListener('load', function(e) {
+  if(typeof imageType !== 'undefined'){
+    if(imageType === 'character'){
+      setImagePosition();
+    }
+    else {
+      imgURL = `./?id=${form.id.value}&mode=image&imageNo=1&cache=${form.imageUpdate.value}`;
+      document.getElementById('image').style.backgroundImage = `url(${imgURL})`;
+    }
+  }
+});
+
 // ビューを開く
 function imagePositionView(){
   document.getElementById('image-custom').style.display = 'grid';
   imageDragPointSet();
 }
 function imagePositionClose(){
+  saveCurrentImageLayout();
   document.getElementById('image-custom').style.display = 'none';
 }
 // プレビュー
 function imagePreView(file, imageMaxSize, imageNo = 1){
   if(!file){ return; }
 
-  switchImageLayoutConfig(imageNo);
+  if(imageType === 'character'){ switchImageLayoutConfig(imageNo); }
 
   delete compressedImageFiles[imageNo];
 
@@ -460,6 +476,9 @@ function imageBlobPreview(blob, imageNo = 1){
   }
 
   previewImageURLs[imageNo] = blobURL;
+  if(document.querySelector(`#image-select-buttons img[data-num="${imageNo}"]`)) {
+    document.querySelector(`#image-select-buttons img[data-num="${imageNo}"]`).src = blobURL;
+  }
   setPreviewImage(imageNo);
 }
 // 圧縮
@@ -691,7 +710,6 @@ function setPreviewImage(imageNo) {
   const url = getPreviewImageURL(imageNo);
 
   const backgroundImage = url ? `url("${url}")` : '';
-  console.log(imageNo, url, backgroundImage)
 
   const imageBox = document.getElementById('image');
   if(imageBox){
@@ -705,16 +723,18 @@ function setPreviewImage(imageNo) {
   // imageDragPointSet() が参照する現在画像URL
   imgURL = url || '';
 
-  // 画像がある場合のみ、ドラッグ基準点を再計算
-  if(imageType === 'character' && imgURL){
-    imageDragPointSet();
+  if(imageType === 'character'){
+    if(imgURL){
+      // 画像がある場合のみ、ドラッグ基準点を再計算
+      imageDragPointSet();
+    }
+    // 現在フォームに入っているレイアウト設定をプレビューへ反映
+    imagePosition();
+
+    // 著作権表示・セリフ表示も更新
+    wordsPreView();
   }
 
-  // 現在フォームに入っているレイアウト設定をプレビューへ反映
-  imagePosition();
-
-  // 著作権表示・セリフ表示も更新
-  wordsPreView();
 }
 function saveCurrentImageLayout(){
   const suffix = imageSuffix(editingImageNo);
@@ -750,6 +770,7 @@ function switchImageLayoutConfig(imageNo){
     obj.classList.toggle('selected', obj.dataset.num == imageNo);
   });
 }
+
 // カラーカスタム ----------------------------------------
 function changeColor(){
   let hH = Number(form.colorHeadBgH.value);

--- a/_core/lib/edit.js
+++ b/_core/lib/edit.js
@@ -29,6 +29,8 @@ function formSubmit() {
   if(saving){ return; }
   if(!formCheck()){ return false; }
 
+  saveCurrentImageLayout();
+
   const formData = new FormData(form);
   for(const [imageNo, compressedImageFile] of Object.entries(compressedImageFiles)){
     const suffix = imageNo == '1' ? '' : imageNo;
@@ -434,6 +436,8 @@ function imagePositionClose(){
 function imagePreView(file, imageMaxSize, imageNo = 1){
   if(!file){ return; }
 
+  switchImageLayoutConfig(imageNo);
+
   delete compressedImageFiles[imageNo];
 
   if(file.size > imageMaxSize){
@@ -444,20 +448,21 @@ function imagePreView(file, imageMaxSize, imageNo = 1){
   }
   else {
     delete compressedImageFiles[imageNo];
-    imageBlobPreview(file)
+    imageBlobPreview(file, imageNo)
   }
 }
-function imageBlobPreview(blob){
+function imageBlobPreview(blob, imageNo = 1){
   const blobURL = window.URL.createObjectURL(blob);
-  document.getElementById('image').style.backgroundImage = 'url("'+blobURL+'")';
-  document.querySelectorAll(".image-custom-view").forEach((el) => {
-    el.style.backgroundImage = 'url("'+blobURL+'")';
-  });
-  imgURL = blobURL;
-  if(imageType == 'character'){ imageDragPointSet(); }
+
+  // 古いBlob URLがある場合は破棄
+  if(previewImageURLs[imageNo]){
+    URL.revokeObjectURL(previewImageURLs[imageNo]);
+  }
+
+  previewImageURLs[imageNo] = blobURL;
+  setPreviewImage(imageNo);
 }
 // 圧縮
-
 const compressedImageFiles = {};
 function imageCompressor(data, imageMaxSize, imageNo = 1, compressScale = 1){
   let image = new Image();
@@ -476,7 +481,7 @@ function imageCompressor(data, imageMaxSize, imageNo = 1, compressScale = 1){
           else { alert('画像サイズを既定まで下げることができませんでした。'); }
         }
         else {
-          imageBlobPreview(result);
+          imageBlobPreview(result, imageNo);
           compressedImageFiles[imageNo] = new File([result], 'image.webp', {
             type: result.type || 'image/webp',
             lastModified: Date.now(),
@@ -491,24 +496,24 @@ function imageCompressor(data, imageMaxSize, imageNo = 1, compressScale = 1){
 }
 // パーセンテージゲージ変更
 function imagePercentBarChange(per){
-  form.imagePercent.value = per;
+  form.editingImagePercent.value = per;
   imagePosition();
 }
 // ポジション反映
 function imagePosition(){
-  const bgSize = form.imageFit.options[form.imageFit.selectedIndex].value;
+  const bgSize = form.editingImageFit.value;
   let configVisiblity = 'hidden';
   let backgroundSize = '100%';
   let ogpSize = '100%';
   if(bgSize === 'percentX'){
     configVisiblity = 'visible';
-    backgroundSize = form.imagePercent.value + '%';
-    ogpSize = form.imagePercent.value + '%';
+    backgroundSize = form.editingImagePercent.value + '%';
+    ogpSize = form.editingImagePercent.value + '%';
   }
   else if(bgSize === 'percentY'){
     configVisiblity = 'visible';
-    backgroundSize = 'auto ' + form.imagePercent.value + '%';
-    ogpSize = 'auto ' + (Number(form.imagePercent.value) * 1.2) + '%';
+    backgroundSize = 'auto ' + form.editingImagePercent.value + '%';
+    ogpSize = 'auto ' + (Number(form.editingImagePercent.value) * 1.2) + '%';
   }
   else {
     configVisiblity = 'hidden';
@@ -518,17 +523,22 @@ function imagePosition(){
   document.getElementById("image-percent-config").style.visibility = configVisiblity;
   document.querySelectorAll("#image, :is(#image-custom-frame-M,#image-custom-frame-S) > .image-custom-view").forEach((el) => {
     el.style.backgroundSize = backgroundSize;
-    el.style.backgroundPositionX = form.imagePositionX.value + '%';
-    el.style.backgroundPositionY = form.imagePositionY.value + '%';
+    el.style.backgroundPositionX = form.editingImagePositionX.value + '%';
+    el.style.backgroundPositionY = form.editingImagePositionY.value + '%';
   });
   document.querySelector("#image-custom-frame-O > .image-custom-view").style.backgroundSize = ogpSize;
-  document.querySelector("#image-custom-frame-O > .image-custom-view").style.backgroundPositionX = form.imagePositionX.value + '%';
-  document.querySelector("#image-custom-frame-O > .image-custom-view").style.backgroundPositionY = (Number(form.imagePositionY.value) * 0.9) + '%';
+  document.querySelector("#image-custom-frame-O > .image-custom-view").style.backgroundPositionX = form.editingImagePositionX.value + '%';
+  document.querySelector("#image-custom-frame-O > .image-custom-view").style.backgroundPositionY = (Number(form.editingImagePositionY.value) * 0.9) + '%';
 
-  document.getElementById("image-positionX-view").textContent = form.imagePositionX.value + '%';
-  document.getElementById("image-positionY-view").textContent = form.imagePositionY.value + '%';
+  document.getElementById("image-positionX").value = form.editingImagePositionX.value;
+  document.getElementById("image-positionY").value = form.editingImagePositionY.value;
   
-  document.getElementById("image-percent-bar").value = form.imagePercent.value;
+  document.getElementById("image-percent-bar").value = form.editingImagePercent.value;
+}
+function imagePositionNumberToRange(){
+  form.editingImagePositionX.value = document.getElementById("image-positionX").value;
+  form.editingImagePositionY.value = document.getElementById("image-positionY").value;
+  imagePosition();
 }
 // ドラッグ処理
 let dragFlag = 0;
@@ -550,7 +560,7 @@ function imageDragMove(e){
     const x2 = touches[1].pageX;
     const y2 = touches[1].pageY;
     const distance = Math.sqrt( Math.pow( x2-x1, 2 ) + Math.pow( y2-y1, 2 ) );
-    const obj = form.imagePercent;
+    const obj = form.editingImagePercent;
     if(baseDistance){
       const gap = (distance - baseDistance);
       if     (gap > 0){ obj.value = Number(obj.value)+5; }
@@ -564,9 +574,9 @@ function imageDragMove(e){
   // ドラッグ移動
   else {
     if(dragFlag){
-      const objX = form.imagePositionX;
-      const objY = form.imagePositionY;
-      const objP = form.imagePercent;
+      const objX = form.editingImagePositionX;
+      const objY = form.editingImagePositionY;
+      const objP = form.editingImagePercent;
       const x = e.x || e.changedTouches[0].pageX;
       const y = e.y || e.changedTouches[0].pageY;
       objX.value = Number(objX.value) + (dragPoint.x - x) * pointWidth;
@@ -585,8 +595,8 @@ function imageDragPointSet(){
   let img = new Image();
   img.src = imgURL;
   img.onload = function() {
-    const type = form.imageFit.value;
-    const ratio = Number(form.imagePercent.value) / 100;
+    const type = form.editingImageFit.value;
+    const ratio = Number(form.editingImagePercent.value) / 100;
     const imgWidth  = img.width;
     const imgHeight = img.height;
     const boxWidth  = document.getElementById('image-custom-frame-M').offsetWidth  || 350;
@@ -631,7 +641,7 @@ function imageDragPointSet(){
 }
 // セリフプレビュー
 function wordsPreView(){
-  let words = form.words.value;
+  let words = form.editingWords.value;
   words = words.replace(/[|｜](.+?)《(.+?)》/g, '<ruby><rp>｜</rp>$1<rp>《</rp><rt>$2</rt><rp>》</rp></ruby>')
                .replace(/《《(.+?)》》/g, '<span class="text-em">$1</span>')
                .replace(/“/g, '〝')
@@ -644,14 +654,102 @@ function wordsPreView(){
   const wObj = document.getElementById('words-preview');
   wObj.innerHTML = words;
   
-  wObj.style.left   = form.wordsX.value === '左' ? '0' : '';
-  wObj.style.right  = form.wordsX.value === '右' || !form.wordsX.value ? '0' : '';
-  wObj.style.top    = form.wordsY.value === '上' || !form.wordsY.value ? '0' : '';
-  wObj.style.bottom = form.wordsY.value === '下' ? '0' : '';
+  wObj.style.left   = form.editingWordsX.value === '左' ? '0' : '';
+  wObj.style.right  = form.editingWordsX.value === '右' || !form.editingWordsX.value ? '0' : '';
+  wObj.style.top    = form.editingWordsY.value === '上' || !form.editingWordsY.value ? '0' : '';
+  wObj.style.bottom = form.editingWordsY.value === '下' ? '0' : '';
   
-  document.getElementById('image-copyright-preview').textContent = form.imageCopyright.value;
+  document.getElementById('image-copyright-preview').textContent = form.editingImageCopyright.value;
 }
 
+// 画像プレビュー切替
+const previewImageURLs = {};
+let editingImageNo = Number(form.mainImage?.value || 1);
+
+function setImagePosition() {
+  editingImageNo = Number(form.mainImage?.value || 1);
+  loadImageLayout(editingImageNo);
+  setPreviewImage(editingImageNo);
+  imagePosition();
+  document.querySelectorAll("#image-select-buttons img").forEach(obj => {
+    obj.classList.toggle('selected', obj.dataset.num == editingImageNo);
+  });
+}
+function imageSuffix(imageNo){
+  return imageNo == 1 ? '' : imageNo;
+}
+function getSavedImageURL(imageNo) {
+  if(typeof savedImageURLs === 'undefined'){ return ''; }
+  return savedImageURLs[imageNo] || '';
+}
+function getPreviewImageURL(imageNo) {
+  return previewImageURLs[imageNo] || getSavedImageURL(imageNo) || '';
+}
+function setPreviewImage(imageNo) {
+  imageNo = Number(imageNo || 1);
+
+  const url = getPreviewImageURL(imageNo);
+
+  const backgroundImage = url ? `url("${url}")` : '';
+  console.log(imageNo, url, backgroundImage)
+
+  const imageBox = document.getElementById('image');
+  if(imageBox){
+    imageBox.style.backgroundImage = backgroundImage;
+  }
+
+  document.querySelectorAll('.image-custom-view').forEach((el) => {
+    el.style.backgroundImage = backgroundImage;
+  });
+
+  // imageDragPointSet() が参照する現在画像URL
+  imgURL = url || '';
+
+  // 画像がある場合のみ、ドラッグ基準点を再計算
+  if(imageType === 'character' && imgURL){
+    imageDragPointSet();
+  }
+
+  // 現在フォームに入っているレイアウト設定をプレビューへ反映
+  imagePosition();
+
+  // 著作権表示・セリフ表示も更新
+  wordsPreView();
+}
+function saveCurrentImageLayout(){
+  const suffix = imageSuffix(editingImageNo);
+  form[`imageFit${suffix}`].value          = form.editingImageFit.value;
+  form[`imagePercent${suffix}`].value      = form.editingImagePercent.value;
+  form[`imagePositionX${suffix}`].value    = form.editingImagePositionX.value;
+  form[`imagePositionY${suffix}`].value    = form.editingImagePositionY.value;
+  form[`imageCopyright${suffix}`].value    = form.editingImageCopyright.value;
+  form[`imageCopyrightURL${suffix}`].value = form.editingImageCopyrightURL.value;
+  form[`words${suffix}`].value  = form.editingWords.value;
+  form[`wordsX${suffix}`].value = form.editingWordsX.value;
+  form[`wordsY${suffix}`].value = form.editingWordsY.value;
+}
+function loadImageLayout(imageNo){
+  const suffix = imageSuffix(imageNo);
+  form.editingImageFit.value          = form[`imageFit${suffix}`].value || 'cover';
+  form.editingImagePercent.value      = form[`imagePercent${suffix}`].value || 200;
+  form.editingImagePositionX.value    = form[`imagePositionX${suffix}`].value || 50;
+  form.editingImagePositionY.value    = form[`imagePositionY${suffix}`].value || 50;
+  form.editingImageCopyright.value    = form[`imageCopyright${suffix}`].value || '';
+  form.editingImageCopyrightURL.value = form[`imageCopyrightURL${suffix}`].value || '';
+  form.editingWords.value  = form[`words${suffix}`].value || '';
+  form.editingWordsX.value = form[`wordsX${suffix}`].value || '';
+  form.editingWordsY.value = form[`wordsY${suffix}`].value || '';
+}
+function switchImageLayoutConfig(imageNo){
+  saveCurrentImageLayout();
+
+  editingImageNo = Number(imageNo);
+  loadImageLayout(editingImageNo);
+  setPreviewImage(editingImageNo);  
+  document.querySelectorAll("#image-select-buttons img").forEach(obj => {
+    obj.classList.toggle('selected', obj.dataset.num == imageNo);
+  });
+}
 // カラーカスタム ----------------------------------------
 function changeColor(){
   let hH = Number(form.colorHeadBgH.value);

--- a/_core/lib/edit.js
+++ b/_core/lib/edit.js
@@ -30,8 +30,9 @@ function formSubmit() {
   if(!formCheck()){ return false; }
 
   const formData = new FormData(form);
-  if(compressedImageFile){
-    formData.set('imageFile', compressedImageFile, compressedImageFile.name);
+  for(const [imageNo, compressedImageFile] of Object.entries(compressedImageFiles)){
+    const suffix = imageNo == '1' ? '' : imageNo;
+    formData.set(`imageFile${suffix}`, compressedImageFile, compressedImageFile.name);
   }
 
   for (const key of formData.keys()) {
@@ -164,8 +165,10 @@ function backupFormInputs() {
   delete obj._token;
   delete obj.id;
   delete obj.pass;
-  delete obj.image;
-  delete obj.imageFile;
+  delete obj.mainImage;
+  for(const key of Object.keys(obj)){
+    if(/^imageFile\d*$/.test(key) || /^image(?:Update)?\d*$/.test(key)){ delete obj[key]; }
+  }
   const formDataJSON = JSON.stringify(obj);
   localStorage.setItem('formData-'+sheetType, formDataJSON);
   console.log('backupFormInputs(): formData-'+sheetType)
@@ -339,7 +342,9 @@ function setChatPalette(){
   formData.set("mode", "palette");
   formData.set("editingMode", "1");
   formData.delete("password");
-  formData.delete("imageFile");
+  for(const key of Array.from(formData.keys())){
+    if(/^imageFile\d*$/.test(key)){ formData.delete(key); }
+  }
   formData.delete("unitStatusNum");
   formData.delete("unitStatusNotOutput");
   const action = form.getAttribute("action")
@@ -426,19 +431,19 @@ function imagePositionClose(){
   document.getElementById('image-custom').style.display = 'none';
 }
 // プレビュー
-function imagePreView(file, imageMaxSize){
+function imagePreView(file, imageMaxSize, imageNo = 1){
   if(!file){ return; }
 
-  compressedImageFile = null;
-  compressScale = 1;
+  delete compressedImageFiles[imageNo];
 
   if(file.size > imageMaxSize){
     alert(`ファイルサイズが${ (imageMaxSize >= 1048576) ? (imageMaxSize / 1048576)+'MB' : (imageMaxSize / 1024)+'KB' }を超えているため、自動的に画像形式を変換・縮小されます。元画像が大きいと、変換・縮小処理に時間がかかることがあります。`);
-    form.imageFile.value = '';
-    imageCompressor(file, imageMaxSize);
+    const suffix = imageNo == 1 ? '' : imageNo;
+    form[`imageFile${suffix}`].value = '';
+    imageCompressor(file, imageMaxSize, imageNo);
   }
   else {
-    compressedImageFile = null;
+    delete compressedImageFiles[imageNo];
     imageBlobPreview(file)
   }
 }
@@ -453,9 +458,8 @@ function imageBlobPreview(blob){
 }
 // 圧縮
 
-let compressedImageFile = null;
-let compressScale = 1;
-function imageCompressor(data, imageMaxSize){
+const compressedImageFiles = {};
+function imageCompressor(data, imageMaxSize, imageNo = 1, compressScale = 1){
   let image = new Image();
   let blobURL = URL.createObjectURL(data);
   image.src = blobURL;
@@ -464,16 +468,16 @@ function imageCompressor(data, imageMaxSize){
       quality: 0.9,
       success(result) {
         if(result.size > imageMaxSize){
-          compressScale -= 0.1;
-          if(compressScale > 0){
-            console.log(`画像縮小: ${ compressScale * 100 } %`);
-            imageCompressor(result, imageMaxSize);
+          const nextCompressScale = compressScale - 0.1;
+          if(nextCompressScale > 0){
+            console.log(`画像縮小: ${ nextCompressScale * 100 } %`);
+            imageCompressor(result, imageMaxSize, imageNo, nextCompressScale);
           }
           else { alert('画像サイズを既定まで下げることができませんでした。'); }
         }
         else {
           imageBlobPreview(result);
-          compressedImageFile = new File([result], 'image.webp', {
+          compressedImageFiles[imageNo] = new File([result], 'image.webp', {
             type: result.type || 'image/webp',
             lastModified: Date.now(),
           });
@@ -695,8 +699,10 @@ function exportAsJson() {
   delete o._token;
   delete o.id;
   delete o.pass;
-  delete o.image;
-  delete o.imageFile;
+  delete o.mainImage;
+  for(const key of Object.keys(o)){
+    if(/^imageFile\d*$/.test(key) || /^image(?:Update)?\d*$/.test(key)){ delete o[key]; }
+  }
   const json = JSON.stringify(o);
 
   const jsonUrl = window.URL.createObjectURL(new Blob([json], {type: 'text/json;charset=utf-8;'}));

--- a/_core/lib/edit.pl
+++ b/_core/lib/edit.pl
@@ -240,12 +240,6 @@ sub loadSheetData {
       $message = $pc{updateTime}.' 時点のバックアップデータから編集しています。';
     }
     $pc{mainImage} ||= 1;
-    for my $imageNo (1 .. ($set::image_maxcount || 1)){
-      my $suffix = $imageNo == 1 ? '' : $imageNo;
-      my $update = $pc{"imageUpdate$suffix"};
-      $pc{"imageURL$suffix"} = $pc{"image$suffix"} ? "./?id=$::in{id}&mode=image&imageNo=$imageNo&cache=$update" : '';
-    }
-    $pc{imageURL} = $pc{"imageURL".($pc{mainImage} == 1 ? '' : $pc{mainImage})} || $pc{imageURL};
   }
   elsif($mode eq 'copy'){
     my $datatype = ($::in{log}) ? 'logs' : 'data';
@@ -312,7 +306,7 @@ sub tokenMake {
 sub deleteImageData {
   my ($pc) = @_;
   for my $imageNo (1 .. ($set::image_maxcount || 1)){
-    my $suffix = $imageNo == 1 ? '' : $imageNo;
+    my $suffix = imageSuffix($imageNo);
     delete $pc->{"image$suffix"};
     delete $pc->{"imageUpdate$suffix"};
     delete $pc->{"imageURL$suffix"};
@@ -408,11 +402,6 @@ sub renderEditPageStart {
     $extraJsMid
     <script src="$::core_dir/skin/_common/js/common.js?$::ver"></script>
     <script>const base64Mode = $base64Mode;</script>
-    @{[ $::pc{imageURL} ? qq|<style>
-      #image, .image-custom-view {
-        background-image: url("$::pc{imageURL}");
-      }
-    </style>| : '' ]}
   </head>
   <body id="edit" data-system="$systemId" @{[ $sheetType ? qq|data-sheet-type="$sheetType"| : '' ]}>
     <header>
@@ -600,12 +589,14 @@ sub renderAddDelButtons {
 }
 ### 画像欄 --------------------------------------------------
 sub renderImageForm {
-  my $image_maxsize_view = $set::image_maxsize >= 1048576 ? sprintf("%.3g",$set::image_maxsize/1048576).'MB' : sprintf("%.3g",$set::image_maxsize/1024).'KB';
+  my $imageMaxSize = $set::image_maxsize || 0;
+  my $imageMaxSizeView = $imageMaxSize >= 1048576 ? sprintf("%.3g",$imageMaxSize/1048576).'MB' : sprintf("%.3g",$imageMaxSize/1024).'KB';
+  my $imageMaxCount = $set::image_maxcount || 1;
   $::pc{mainImage} ||= 1;
-  my $mainSuffix = $::pc{mainImage} == 1 ? '' : $::pc{mainImage};
+  my $mainSuffix = imageSuffix($::pc{mainImage});
   my %imageURLs;
   my $imageURLsJS;
-  foreach my $n (1 .. $set::image_maxcount){
+  foreach my $n (1 .. $imageMaxCount){
     my $suffix = ($n == 1) ? '' : $n;
     if($::pc{'image'.$suffix}){
       $imageURLs{$n} = "./?id=$::in{id}&mode=image&imageNo=$n&cache=$::pc{'imageUpdate'.$suffix}";
@@ -627,10 +618,11 @@ sub renderImageForm {
           join '', map {
             my $n = $_;
             my $suffix = ($n == 1) ? '' : $n;
-            input("image$suffix",'hidden') .input("imageUpdate$suffix",'hidden')
-            } 1 .. ($set::image_maxcount || 1)
+            input("image$suffix",'hidden')
+            . input("imageUpdate$suffix",'hidden')
+            } 1 .. $imageMaxCount
           ]}
-        <br>メイン画像：@{[ radios('mainImage', 'setImagePosition', 1 .. ($set::image_maxcount || 1)) ]}
+        <br>メイン画像：@{[ radios('mainImage', 'setImagePosition', 1 .. $imageMaxCount) ]}
       </p>
     </div>
 
@@ -653,17 +645,27 @@ sub renderImageForm {
           @{[
             join '', map {
               my $n = $_;
-              qq#<div><label>画像@{[$n||1]}: <input type="file" accept="image/*" name="imageFile$n" onchange="imagePreView(this.files[0], ($set::image_maxsize || 0), $n)"></label>#
+              qq#<div><label>画像@{[$n||1]}: <input type="file" accept="image/*" name="imageFile$n" onchange="imagePreView(this.files[0], $imageMaxSize, $n)"></label>#
               . checkbox("imageDelete$n","削除")
               . "</div>"
-            } '', 2 .. ($set::image_maxcount || 1)
+            } '', 2 .. $imageMaxCount
           ]}
         <p>
-          ※ ファイルサイズ @{[ $image_maxsize_view ]} までの JPG/PNG/GIF/WebP
+          ※ ファイルサイズ @{[ $imageMaxSizeView ]} までの JPG/PNG/GIF/WebP
           <small>（サイズを超過する場合、自動的にWebP形式に変換し、その上でまだ超過している場合は縮小処理が行われます）</small>
+        </p>
+        <p id="image-select-buttons">
+          @{[
+            join '', map {
+              my $n = $_;
+              my $selected = ($::pc{mainImage} eq $n) ? 'selected' : '';
+              qq#<label onclick="switchImageLayoutConfig($n)"><img src="$imageURLs{$n}" style="width:100px;height:100px;object-fit:contain;" data-num="$n" class="$selected"><span>画像$n<span></label>#
+            } 1 .. $imageMaxCount
+          ]}
         </p>
         <script>
           const imageType = 'character';
+          const imageUpdate = '$::pc{imageUpdate}';
           const savedImageURLs = { $imageURLsJS };
           // ドラッグ＆ドロップで画像アップ
           document.getElementById('image-custom').addEventListener('dragover',function(e){
@@ -680,7 +682,7 @@ sub renderImageForm {
             if(!obj){ return; }
 
             obj.files = e.dataTransfer.files;
-            imagePreView(obj.files[0], imageMaxSize, imageNo);
+            imagePreView(obj.files[0], $imageMaxSize, imageNo);
           });
 
           // ホイールで拡大率調整
@@ -698,7 +700,6 @@ sub renderImageForm {
           });
 
           // ドラッグで位置調整
-          let imgURL = "$imageURLs{$::pc{mainImage}}";
           let pointWidth  = 1;
           let pointHeight = 1;
           mainArea.addEventListener('mousedown' , function (e) { imageDragStart(e); });
@@ -710,15 +711,6 @@ sub renderImageForm {
           mainArea.addEventListener('touchend'  , function (e) { imageDragEnd();    });
         </script>
         <h3>画像レイアウト</h3>
-        <p id="image-select-buttons">
-          @{[
-            join '', map {
-              my $n = $_;
-              my $selected = ($::pc{mainImage} eq $n) ? 'selected' : '';
-              qq#<label onclick="switchImageLayoutConfig($n)"><img src="$imageURLs{$n}" style="width:100px;height:100px;object-fit:contain;" data-num="$n" class="$selected"><span>画像$n<span></label>#
-            } 1 .. ($set::image_maxcount || 1)
-          ]}
-        <p>
         <p>
           <b>縦基準位置</b>:<input type="number" id="image-positionY" step="0.1" min="0" max="100" onchange="imagePositionNumberToRange()">%<br>
           <b>横基準位置</b>:<input type="number" id="image-positionX" step="0.1" min="0" max="100" onchange="imagePositionNumberToRange()">%<br>
@@ -772,7 +764,7 @@ sub renderImageForm {
           . input("words$n",'hidden')
           . input("wordsX$n",'hidden')
           . input("wordsY$n",'hidden')
-        } '',2 .. ($set::image_maxcount || 1)
+        } '',2 .. $imageMaxCount
       ]}
     </div>
   HTML

--- a/_core/lib/edit.pl
+++ b/_core/lib/edit.pl
@@ -239,7 +239,13 @@ sub loadSheetData {
       ($pc{protect}, $pc{forbidden}) = getProtectType("${sheetDir}/data.cgi");
       $message = $pc{updateTime}.' 時点のバックアップデータから編集しています。';
     }
-    $pc{imageURL} = $pc{image} ? "./?id=$::in{id}&mode=image&cache=$pc{imageUpdate}" : '';
+    $pc{mainImage} ||= 1;
+    for my $imageNo (1 .. ($set::image_maxcount || 1)){
+      my $suffix = $imageNo == 1 ? '' : $imageNo;
+      my $update = $pc{"imageUpdate$suffix"};
+      $pc{"imageURL$suffix"} = $pc{"image$suffix"} ? "./?id=$::in{id}&mode=image&imageNo=$imageNo&cache=$update" : '';
+    }
+    $pc{imageURL} = $pc{"imageURL".($pc{mainImage} == 1 ? '' : $pc{mainImage})} || $pc{imageURL};
   }
   elsif($mode eq 'copy'){
     my $datatype = ($::in{log}) ? 'logs' : 'data';
@@ -261,7 +267,7 @@ sub loadSheetData {
       }
     }
 
-    delete $pc{image};
+    deleteImageData(\%pc);
     delete $pc{protect};
 
     $message  = '<div class="data-imported">';
@@ -272,7 +278,7 @@ sub loadSheetData {
   }
   elsif($mode eq 'convert'){
     %pc = %::conv_data;
-    delete $pc{image};
+    deleteImageData(\%pc);
     delete $pc{imageURL};
     delete $pc{protect};
     $_ =~ s/"/&quot;/g foreach(values %pc);
@@ -300,6 +306,18 @@ sub tokenMake {
   close($FH);
 
   return $token;
+}
+
+### 画像データ削除 --------------------------------------------------
+sub deleteImageData {
+  my ($pc) = @_;
+  for my $imageNo (1 .. ($set::image_maxcount || 1)){
+    my $suffix = $imageNo == 1 ? '' : $imageNo;
+    delete $pc->{"image$suffix"};
+    delete $pc->{"imageUpdate$suffix"};
+    delete $pc->{"imageURL$suffix"};
+  }
+  delete $pc->{mainImage};
 }
 
 ### 新規作成系モード判定 --------------------------------------------------
@@ -584,6 +602,7 @@ sub renderAddDelButtons {
 sub renderImageForm {
   my $imgurl = shift;
   my $image_maxsize_view = $set::image_maxsize >= 1048576 ? sprintf("%.3g",$set::image_maxsize/1048576).'MB' : sprintf("%.3g",$set::image_maxsize/1024).'KB';
+  $::pc{mainImage} ||= 1;
   return <<~"HTML";
     <div class="box" id="image" style="max-height:550px;">
       <h2>キャラクター画像</h2>
@@ -591,11 +610,11 @@ sub renderImageForm {
         <a class="button" onclick="imagePositionView();wordsPreView()">画像とセリフの設定</a>
       </p>
       <p>
-        <input type="checkbox" name="imageDelete" value="1"> 画像を削除する
-        @{[ input 'image','hidden' ]}
+        <input type="checkbox" name="imageDelete" value="1"> 画像1を削除する
+        @{[ join '', map { my $n=$_; my $suffix = $n == 1 ? '' : $n; input("image$suffix",'hidden') . input("imageUpdate$suffix",'hidden') } (1 .. ($set::image_maxcount || 1)) ]}
+        <br>メイン画像：@{[ join ' ', map { my $n=$_; qq|<label><input type="radio" name="mainImage" value="$n" |.($::pc{mainImage}==$n?'checked':'').qq|> $n</label>| } (1 .. ($set::image_maxcount || 1)) ]}
       </p>
     </div>
-    @{[ input 'imageUpdate', 'hidden' ]}
 
     <div id="image-custom" style="display:none">
       <div class="image-custom-view-area">
@@ -613,6 +632,7 @@ sub renderImageForm {
           プレビューエリアに画像ファイルをドロップ、<br>
           または
           <input type="file" accept="image/*" name="imageFile" onchange="imagePreView(this.files[0], $set::image_maxsize || 0)"><br>
+          @{[ join '', map { my $n=$_; qq~<label>画像$n：<input type="file" accept="image/*" name="imageFile$n" onchange="imagePreView(this.files[0], $set::image_maxsize || 0, $n)"></label> <label><input type="checkbox" name="imageDelete$n" value="1"> 削除</label><br>~ } (2 .. ($set::image_maxcount || 1)) ]}
           ※ ファイルサイズ @{[ $image_maxsize_view ]} までの JPG/PNG/GIF/WebP
           <small>（サイズを超過する場合、自動的にWebP形式に変換し、その上でまだ超過している場合は縮小処理が行われます）</small>
         </p>

--- a/_core/lib/edit.pl
+++ b/_core/lib/edit.pl
@@ -600,9 +600,22 @@ sub renderAddDelButtons {
 }
 ### 画像欄 --------------------------------------------------
 sub renderImageForm {
-  my $imgurl = shift;
   my $image_maxsize_view = $set::image_maxsize >= 1048576 ? sprintf("%.3g",$set::image_maxsize/1048576).'MB' : sprintf("%.3g",$set::image_maxsize/1024).'KB';
   $::pc{mainImage} ||= 1;
+  my $mainSuffix = $::pc{mainImage} == 1 ? '' : $::pc{mainImage};
+  my %imageURLs;
+  my $imageURLsJS;
+  foreach my $n (1 .. $set::image_maxcount){
+    my $suffix = ($n == 1) ? '' : $n;
+    if($::pc{'image'.$suffix}){
+      $imageURLs{$n} = "./?id=$::in{id}&mode=image&imageNo=$n&cache=$::pc{'imageUpdate'.$suffix}";
+    }
+    else {
+      # 透過1x1画像
+      $imageURLs{$n} = "data:image/gif;base64,R0lGODlhAQABAGAAACH5BAEKAP8ALAAAAAABAAEAAAgEAP8FBAA7";
+    }
+    $imageURLsJS  .= qq|$n: "$imageURLs{$n}",|;
+  }
   return <<~"HTML";
     <div class="box" id="image" style="max-height:550px;">
       <h2>キャラクター画像</h2>
@@ -610,9 +623,14 @@ sub renderImageForm {
         <a class="button" onclick="imagePositionView();wordsPreView()">画像とセリフの設定</a>
       </p>
       <p>
-        <input type="checkbox" name="imageDelete" value="1"> 画像1を削除する
-        @{[ join '', map { my $n=$_; my $suffix = $n == 1 ? '' : $n; input("image$suffix",'hidden') . input("imageUpdate$suffix",'hidden') } (1 .. ($set::image_maxcount || 1)) ]}
-        <br>メイン画像：@{[ join ' ', map { my $n=$_; qq|<label><input type="radio" name="mainImage" value="$n" |.($::pc{mainImage}==$n?'checked':'').qq|> $n</label>| } (1 .. ($set::image_maxcount || 1)) ]}
+        @{[
+          join '', map {
+            my $n = $_;
+            my $suffix = ($n == 1) ? '' : $n;
+            input("image$suffix",'hidden') .input("imageUpdate$suffix",'hidden')
+            } 1 .. ($set::image_maxcount || 1)
+          ]}
+        <br>メイン画像：@{[ radios('mainImage', 'setImagePosition', 1 .. ($set::image_maxcount || 1)) ]}
       </p>
     </div>
 
@@ -621,8 +639,8 @@ sub renderImageForm {
         <div id="image-custom-frame-S" class="image-custom-frame"><div class="image-custom-view"><b>横幅が狭い時</b></div></div>
         <div id="image-custom-frame-O" class="image-custom-frame"><div class="image-custom-view"><b>OGP <small>※シートURLをSNS等に貼った際に表示</small></b></div></div>
         <div id="image-custom-frame-M" class="image-custom-frame"><div class="image-custom-view"><b>標準の比率 <small>※縦横比は適宜変動します</small></b><div class="words" id="words-preview"></div><div id="image-copyright-preview"></div></div>
-          @{[ input "imagePositionY",'range','imagePosition','step="0.001"' ]}
-          @{[ input "imagePositionX",'range','imagePosition','step="0.001"' ]}
+          @{[ input "editingImagePositionY",'range','imagePosition','step="0.001"' ]}
+          @{[ input "editingImagePositionX",'range','imagePosition','step="0.001"' ]}
         </div>
       </div>
       <div class="image-custom-form">
@@ -630,14 +648,23 @@ sub renderImageForm {
         <h3>画像選択</h3>
         <p>
           プレビューエリアに画像ファイルをドロップ、<br>
-          または
-          <input type="file" accept="image/*" name="imageFile" onchange="imagePreView(this.files[0], $set::image_maxsize || 0)"><br>
-          @{[ join '', map { my $n=$_; qq~<label>画像$n：<input type="file" accept="image/*" name="imageFile$n" onchange="imagePreView(this.files[0], $set::image_maxsize || 0, $n)"></label> <label><input type="checkbox" name="imageDelete$n" value="1"> 削除</label><br>~ } (2 .. ($set::image_maxcount || 1)) ]}
+          または画像を選択<br>
+        </p>
+          @{[
+            join '', map {
+              my $n = $_;
+              qq#<div><label>画像@{[$n||1]}: <input type="file" accept="image/*" name="imageFile$n" onchange="imagePreView(this.files[0], ($set::image_maxsize || 0), $n)"></label>#
+              . checkbox("imageDelete$n","削除")
+              . "</div>"
+            } '', 2 .. ($set::image_maxcount || 1)
+          ]}
+        <p>
           ※ ファイルサイズ @{[ $image_maxsize_view ]} までの JPG/PNG/GIF/WebP
           <small>（サイズを超過する場合、自動的にWebP形式に変換し、その上でまだ超過している場合は縮小処理が行われます）</small>
         </p>
         <script>
           const imageType = 'character';
+          const savedImageURLs = { $imageURLsJS };
           // ドラッグ＆ドロップで画像アップ
           document.getElementById('image-custom').addEventListener('dragover',function(e){
             e.preventDefault();
@@ -646,9 +673,14 @@ sub renderImageForm {
             e.preventDefault();
           });
           document.querySelector('.image-custom-view-area').addEventListener('drop', function (e) {
-            const obj = document.querySelector("[name='imageFile']");
+            const imageNo = editingImageNo || Number(form.mainImage?.value || 1);
+            const suffix = imageSuffix(imageNo);
+            const obj = document.querySelector(`[name='imageFile\${suffix}']`);
+
+            if(!obj){ return; }
+
             obj.files = e.dataTransfer.files;
-            imagePreView(obj.files[0], $set::image_maxsize || 0);
+            imagePreView(obj.files[0], imageMaxSize, imageNo);
           });
 
           // ホイールで拡大率調整
@@ -657,7 +689,7 @@ sub renderImageForm {
             e.preventDefault();
           });
           mainArea.addEventListener('wheel', function (e) {
-            const obj = form.imagePercent;
+            const obj = form.editingImagePercent;
             if     (e.deltaY > 0){ obj.value = Number(obj.value)+10 }
             else if(e.deltaY < 0){ obj.value = Number(obj.value)-10 }
             if(obj.value < 0){ obj.value = 0 }
@@ -666,59 +698,82 @@ sub renderImageForm {
           });
 
           // ドラッグで位置調整
-          let imgURL = "${imgurl}";
+          let imgURL = "$imageURLs{$::pc{mainImage}}";
           let pointWidth  = 1;
           let pointHeight = 1;
           mainArea.addEventListener('mousedown' , function (e) { imageDragStart(e); });
           mainArea.addEventListener('mousemove' , function (e) { imageDragMove(e);  });
           mainArea.addEventListener('mouseup'   , function (e) { imageDragEnd();    });
-          mainArea.addEventListener('mouseleave', function (e) { imageDragEnd();   });
+          mainArea.addEventListener('mouseleave', function (e) { imageDragEnd();    });
           mainArea.addEventListener('touchstart', function (e) { imageDragStart(e); });
           mainArea.addEventListener('touchmove' , function (e) { imageDragMove(e);  });
-          mainArea.addEventListener('touchend'  , function (e) { imageDragEnd();   });
+          mainArea.addEventListener('touchend'  , function (e) { imageDragEnd();    });
         </script>
         <h3>画像レイアウト</h3>
+        <p id="image-select-buttons">
+          @{[
+            join '', map {
+              my $n = $_;
+              my $selected = ($::pc{mainImage} eq $n) ? 'selected' : '';
+              qq#<label onclick="switchImageLayoutConfig($n)"><img src="$imageURLs{$n}" style="width:100px;height:100px;object-fit:contain;" data-num="$n" class="$selected"><span>画像$n<span></label>#
+            } 1 .. ($set::image_maxcount || 1)
+          ]}
         <p>
-          <b>縦基準位置</b>:<span id="image-positionY-view"></span> ／
-          <b>横基準位置</b>:<span id="image-positionX-view"></span><br>
+        <p>
+          <b>縦基準位置</b>:<input type="number" id="image-positionY" step="0.1" min="0" max="100" onchange="imagePositionNumberToRange()">%<br>
+          <b>横基準位置</b>:<input type="number" id="image-positionX" step="0.1" min="0" max="100" onchange="imagePositionNumberToRange()">%<br>
         </p>
         <p>
-          <b>表示（トリミング）方式</b>：<br><select name="imageFit" oninput="imageDragPointSet();imagePosition()">
-          <option value="cover"   @{[$::pc{imageFit} eq 'cover'  ?'selected':'']}>自動的に最低限のトリミング（表示域いっぱいに表示）
-          <option value="contain" @{[$::pc{imageFit} eq 'contain'?'selected':'']}>トリミングしない（必ず画像全体を収める）
-          <option value="percentX" @{[$::pc{imageFit} eq 'percentX'?'selected':'']}>任意のトリミング／横幅を基準
-          <option value="percentY" @{[$::pc{imageFit} eq 'percentY'?'selected':'']}>任意のトリミング／縦幅を基準
-          <option value="unset"   @{[$::pc{imageFit} eq 'unset'  ?'selected':'']}>拡大縮小せず表示（ドット絵など向き）
+          <b>表示（トリミング）方式</b>：<br><select name="editingImageFit" oninput="imageDragPointSet();imagePosition()">
+          <option value="cover"    @{[$::pc{editingImageFit} eq 'cover'   ?'selected':'']}>自動的に最低限のトリミング（表示域いっぱいに表示）
+          <option value="contain"  @{[$::pc{editingImageFit} eq 'contain' ?'selected':'']}>トリミングしない（必ず画像全体を収める）
+          <option value="percentX" @{[$::pc{editingImageFit} eq 'percentX'?'selected':'']}>任意のトリミング／横幅を基準
+          <option value="percentY" @{[$::pc{editingImageFit} eq 'percentY'?'selected':'']}>任意のトリミング／縦幅を基準
+          <option value="unset"    @{[$::pc{editingImageFit} eq 'unset'   ?'selected':'']}>拡大縮小せず表示（ドット絵など向き）
           </select><br>
           <small>※いずれの設定でも、クリックすると画像全体が表示されます。</small>
         </p>
         <p id="image-percent-config">
-          <b>拡大率</b>：@{[ input "imagePercent",'number','imageDragPointSet();imagePosition','min="0"  style="width:4em;"' ]}%<br>
+          <b>拡大率</b>：@{[ input "editingImagePercent",'number','imageDragPointSet();imagePosition','min="0"  style="width:4em;"' ]}%<br>
           <input type="range" id="image-percent-bar" min="10" max="1000" oninput="imagePercentBarChange(this.value)" style="width:100%;"><br>
           （100%で幅ピッタリ）<br>
         </p>
         <h3>画像の注釈</h3>
         <p>
           <b>作者名や権利表示：</b><br>
-          @{[ input 'imageCopyright','text ','wordsPreView','placeholder="(C)画像の作者名" style="width:70%;"' ]}<br>
+          @{[ input 'editingImageCopyright','text ','wordsPreView','placeholder="(C)画像の作者名" style="width:70%;"' ]}<br>
         </p>
         <p>
           <b>URL（作者のWebサイトなどあれば）：</b><br>
-          @{[ input 'imageCopyrightURL','url ','wordsPreView','placeholder="https://..." style="width:90%;"' ]}<br>
+          @{[ input 'editingImageCopyrightURL','url ','wordsPreView','placeholder="https://..." style="width:90%;"' ]}<br>
         </p>
         <h3>画像に重ねるセリフ</h3>
         <p>
-          <textarea name="words" style="width:100%;height:3.6em;" onchange="wordsPreView();" placeholder="「任意の台詞」">$::pc{words}</textarea>
+          <textarea name="editingWords" style="width:100%;height:3.6em;" onchange="wordsPreView();" placeholder="「任意の台詞」">$::pc{words}</textarea>
         </p>
         <p>
           <b>セリフの配置</b>：
-          <select name="wordsX" oninput="wordsPreView();">@{[ option 'wordsX','右','左' ]}</select>
-          <select name="wordsY" oninput="wordsPreView();">@{[ option 'wordsY','上','下' ]}</select>
+          <select name="editingWordsX" oninput="wordsPreView();">@{[ option 'editingWordsX','右','左' ]}</select>
+          <select name="editingWordsY" oninput="wordsPreView();">@{[ option 'editingWordsY','上','下' ]}</select>
         </p>
       </div>
       <div class="image-custom-form close-button">
         <a class="button" onclick="imagePositionClose()">画像とセリフの設定を閉じる</a>
       </div>
+      @{[
+        join '', map {
+          my $n = $_;
+          input("imageFit$n",'hidden')
+          . input("imagePercent$n",'hidden')
+          . input("imagePositionX$n",'hidden')
+          . input("imagePositionY$n",'hidden')
+          . input("imageCopyright$n",'hidden')
+          . input("imageCopyrightURL$n",'hidden')
+          . input("words$n",'hidden')
+          . input("wordsX$n",'hidden')
+          . input("wordsY$n",'hidden')
+        } '',2 .. ($set::image_maxcount || 1)
+      ]}
     </div>
   HTML
 }

--- a/_core/lib/gc/calc-chara.pl
+++ b/_core/lib/gc/calc-chara.pl
@@ -105,13 +105,13 @@ sub data_calc {
   }
   #### 改行を<br>に変換 --------------------------------------------------
   foreach (
-    'words',
     'freeNote',
     'freeHistory',
     'chatPalette',
   ){
     $pc{$_} =~ s/\r\n?|\n/<br>/g;
   }
+  $pc{'words'.$_} =~ s/\r\n?|\n/<br>/g foreach('', 2 .. ($set::image_maxcount || 1));
   
   #### 保存処理でなければここまで --------------------------------------------------
   if(!$::mode_save){ return %pc; }
@@ -142,14 +142,15 @@ sub data_calc {
   $NL{age}    = substr($NL{age}   , 0, 20).'..' if length($NL{age}   ) > 20;
   $NL{height} = substr($NL{height}, 0, 20).'..' if length($NL{height}) > 20;
   $NL{weight} = substr($NL{weight}, 0, 20).'..' if length($NL{weight}) > 20;
-  $::newline = "$pc{id}<>$::file<>".
-               "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>".
-               "$pc{image}<> $pc{tags} <>$pc{hide}<>".
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>"
 
-               "$NL{class}<>$NL{style}<>$NL{styleSub}<>$NL{works}<>".
-               "$pc{level}<>$pc{expTotal}<>".
-               "$NL{country}<>$NL{gender}<>$NL{age}<>$NL{height}<>$NL{weight}<>".
-               "$pc{lastSession}<>";
+    . "$NL{class}<>$NL{style}<>$NL{styleSub}<>$NL{works}<>"
+    . "$pc{level}<>$pc{expTotal}<>"
+    . "$NL{country}<>$NL{gender}<>$NL{age}<>$NL{height}<>$NL{weight}<>"
+    . "$pc{lastSession}<>";
 
   return %pc;
 }

--- a/_core/lib/gc/calc-country.pl
+++ b/_core/lib/gc/calc-country.pl
@@ -46,13 +46,13 @@ sub data_calc {
 
   #### 改行を<br>に変換 --------------------------------------------------
   foreach (
-    'words',
     'freeNote',
     'freeHistory',
     'chatPalette',
   ){
     $pc{$_} =~ s/\r\n?|\n/<br>/g;
   }
+  $pc{'words'.$_} =~ s/\r\n?|\n/<br>/g foreach('', 2 .. ($set::image_maxcount || 1));
   
   #### 保存処理でなければここまで --------------------------------------------------
   if(!$::mode_save){ return %pc; }
@@ -72,13 +72,14 @@ sub data_calc {
     $NL{$_} = $pc{$_} =~ s/[|｜]([^|｜]+?)《.+?》/$1/gr;
     $NL{$_} = removeTags unescapeTags $NL{$_} =~ s/^\s|\s$//gr;
   }
-  $::newline = "$pc{id}<>$::file<>".
-               "$pc{birthTime}<>$::now<>$NL{countryName}<>$NL{playerName}<>$pc{group}<>".
-               "$pc{image}<> $pc{tags} <>$pc{hide}<>".
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{countryName}<>$NL{playerName}<>$pc{group}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>"
 
-               "$NL{lordName}<>".
-               "$pc{level}<>$pc{countsTotal}<>$pc{peerage}<>".
-               "$pc{lastSession}<>";
+    . "$NL{lordName}<>"
+    . "$pc{level}<>$pc{countsTotal}<>$pc{peerage}<>"
+    . "$pc{lastSession}<>";
 
   return %pc;
 }

--- a/_core/lib/gc/edit-chara.js
+++ b/_core/lib/gc/edit-chara.js
@@ -24,7 +24,6 @@ window.onload = function() {
   calcItems();
   calcTotalWeight();
   
-  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/gc/edit-chara.js
+++ b/_core/lib/gc/edit-chara.js
@@ -24,7 +24,7 @@ window.onload = function() {
   calcItems();
   calcTotalWeight();
   
-  imagePosition();
+  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/gc/edit-chara.pl
+++ b/_core/lib/gc/edit-chara.pl
@@ -97,7 +97,8 @@ sub displayGrowRow {
 
 ### 改行処理 --------------------------------------------------
 convertEscapedBrToNewlines(\%pc,
-  qw/words freeNote freeHistory chatPalette/,
+  qw/freeNote freeHistory chatPalette/,
+  ( map { 'words'.$_ } '', 2 .. ($set::image_maxcount || 1) ),
 );
 
 ### フォーム表示 #####################################################################################
@@ -1023,7 +1024,7 @@ print <<"HTML";
     </div>
 
     <div id="area-profile">
-      @{[ renderImageForm($pc{imageURL}) ]}
+      @{[ renderImageForm() ]}
       <div class="box-union in-toc" id="personal" data-content-title="所属国・性別・年齢・身長・体重">
         <dl class="box" id="country">
           <dt>所属国

--- a/_core/lib/gc/edit-country.pl
+++ b/_core/lib/gc/edit-country.pl
@@ -73,7 +73,7 @@ foreach (1..$pc{forceNum}){ if($pc{"force${_}Type"}){ $open{forces} = 'open'; la
 
 ### 改行処理 --------------------------------------------------
 convertEscapedBrToNewlines(\%pc,
-  qw/words freeNote freeHistory chatPalette/,
+  qw/freeNote freeHistory chatPalette/,
 );
 
 ### 画像 --------------------------------------------------
@@ -453,10 +453,10 @@ print <<"HTML";
       <p>
         <input type="checkbox" name="imageDelete" value="1"> 画像を削除する
         @{[ input 'image','hidden' ]}
+        @{[ input 'imageUpdate','hidden' ]}
       </p>
     <script>
       const imageType = 'symbol';
-      let imgURL = "$pc{imageURL}";
     </script>
     </div>
 

--- a/_core/lib/gs/calc-chara.pl
+++ b/_core/lib/gs/calc-chara.pl
@@ -217,7 +217,7 @@ sub data_calc {
   }
 
   #### 改行を<br>に変換 --------------------------------------------------
-  $pc{words}         =~ s/\r\n?|\n/<br>/g;
+  $pc{'words'.$_} =~ s/\r\n?|\n/<br>/g foreach('', 2 .. ($set::image_maxcount || 1));
   $pc{items}         =~ s/\r\n?|\n/<br>/g;
   $pc{freeNote}      =~ s/\r\n?|\n/<br>/g;
   $pc{freeHistory}   =~ s/\r\n?|\n/<br>/g;
@@ -257,12 +257,13 @@ sub data_calc {
   foreach my $class (@data::class_list){
     $classlv .= $pc{'lv'.$data::class{$class}{id}}.'/';
   }
-  $::newline = "$pc{id}<>$::file<>".
-               "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>".
-               "$pc{image}<> $pc{tags} <>$pc{hide}<>$pc{lastSession}<>".
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>$pc{lastSession}<>"
 
-               "$pc{expTotal}<>$pc{level}<>$classlv<>".
-               "$NL{race}<>$NL{raceBase}<>$NL{gender}<>$NL{age}<>$NL{rank}<>$NL{faith}<>";
+    . "$pc{expTotal}<>$pc{level}<>$classlv<>"
+    . "$NL{race}<>$NL{raceBase}<>$NL{gender}<>$NL{age}<>$NL{rank}<>$NL{faith}<>";
 
   return %pc;
 }

--- a/_core/lib/gs/edit-chara.js
+++ b/_core/lib/gs/edit-chara.js
@@ -18,7 +18,7 @@ window.onload = function() {
   calcAdvCompleted();
   openCoins();
   
-  imagePosition();
+  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/gs/edit-chara.js
+++ b/_core/lib/gs/edit-chara.js
@@ -18,7 +18,6 @@ window.onload = function() {
   calcAdvCompleted();
   openCoins();
   
-  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/gs/edit-chara.pl
+++ b/_core/lib/gs/edit-chara.pl
@@ -94,7 +94,8 @@ foreach (1..$pc{artsNum }) { if($pc{"arts${_}Name" }) { $open{arts } = 'open'; l
 
 ### 改行処理 --------------------------------------------------
 convertEscapedBrToNewlines(\%pc,
-  qw/words items freeNote freeHistory cashbook chatPalette/,
+  qw/items freeNote freeHistory cashbook chatPalette/,
+  ( map { 'words'.$_ } '', 2 .. ($set::image_maxcount || 1) ),
 );
 
 ### 技能データ各種変換 --------------------------------------------------
@@ -158,7 +159,7 @@ print <<"HTML";
       <dl class="regulation-note"><dt>備考<dd>@{[ input "history0Note" ]}</dl>
     </details>
     <div id="area-status">
-      @{[ renderImageForm($pc{imageURL}) ]}
+      @{[ renderImageForm() ]}
 
       <div id="personal" class="in-toc" data-content-title="種族・年齢・性別">
         <dl class="box" id="race">

--- a/_core/lib/json.pl
+++ b/_core/lib/json.pl
@@ -44,8 +44,16 @@ if($id){
     }
   }
   
-  if($pc{image}){
-    $pc{imageURL} = url()."?id=$id&mode=image&cache=$pc{imageUpdate}";
+  my $imageMaxCount = $pc{imageMaxCount} = $set::image_maxcount || 1;
+  foreach my $n (1 .. $imageMaxCount){
+    my $suffix = imageSuffix($n);
+    $pc{"imageURL$suffix"} = url().qq|?id=$id&mode=image&imageNo=$n&cache=$pc{"imageUpdate$suffix"}| if $pc{"image$suffix"};
+  }
+  if(!$pc{image} && $pc{mainImage} > 1){ # 複数画像未対応verへの対応
+    my $suffix = imageSuffix($pc{mainImage});
+    foreach my $key (qw/image imageUpdate imageURL imageFit imagePercent imagePositionX imagePositionY imageCopyright imageCopyrightURL words wordsX wordsY/){
+      $pc{$key} = $pc{"$key$suffix"};
+    }
   }
 
   $pc{sheetURL} = url()."?id=${id}";

--- a/_core/lib/kiz/calc-chara.pl
+++ b/_core/lib/kiz/calc-chara.pl
@@ -44,7 +44,6 @@ sub data_calc {
 
   #### 改行を<br>に変換 --------------------------------------------------
   foreach (
-    'words',
     'freeNote',
     'freeHistory',
     'chatPalette',
@@ -53,6 +52,7 @@ sub data_calc {
   ){
     $pc{$_} =~ s/\r\n?|\n/<br>/g;
   }
+  $pc{'words'.$_} =~ s/\r\n?|\n/<br>/g foreach('', 2 .. ($set::image_maxcount || 1));
   
   #### 保存処理でなければここまで --------------------------------------------------
   if(!$::mode_save){ return %pc; }
@@ -80,14 +80,15 @@ sub data_calc {
   $NL{gender} = substr($NL{gender}, 0, 20).'..' if length($NL{gender}) > 20;
   $NL{age}    = substr($NL{age}   , 0, 20).'..' if length($NL{age}   ) > 20;
   $NL{belong} = substr($pc{belong}, 0, 30).'..' if length($pc{belong}) > 30;
-  $::newline = "$pc{id}<>$::file<>".
-               "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>".
-               "$pc{image}<> $pc{tags} <>$pc{hide}<>".
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>"
 
-               "$NL{class}<>$NL{negaiOutside}<>$NL{negaiInside}<>".
-               "$NL{gender}<>$NL{age}<>".
-               "$NL{belong}<>$pc{partner2On}<>".
-               "$kizuna_count<>$hibiware_count<>$pc{lastSession}<>";
+    . "$NL{class}<>$NL{negaiOutside}<>$NL{negaiInside}<>"
+    . "$NL{gender}<>$NL{age}<>"
+    . "$NL{belong}<>$pc{partner2On}<>"
+    . "$kizuna_count<>$hibiware_count<>$pc{lastSession}<>";
 
   return %pc;
 }

--- a/_core/lib/kiz/edit-chara.js
+++ b/_core/lib/kiz/edit-chara.js
@@ -15,7 +15,7 @@ window.onload = function() {
   autoInputPartner(1);
   autoInputPartner(2);
   
-  imagePosition();
+  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/kiz/edit-chara.js
+++ b/_core/lib/kiz/edit-chara.js
@@ -15,7 +15,6 @@ window.onload = function() {
   autoInputPartner(1);
   autoInputPartner(2);
   
-  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/kiz/edit-chara.pl
+++ b/_core/lib/kiz/edit-chara.pl
@@ -81,7 +81,8 @@ $pc{kizuatoNum} ||= 2;
 
 ### 改行処理 --------------------------------------------------
 convertEscapedBrToNewlines(\%pc,
-  qw/words freeNote freeHistory chatPalette partner1Memory partner2Memory/,
+  qw/freeNote freeHistory chatPalette partner1Memory partner2Memory/,
+  ( map { 'words'.$_ } '', 2 .. ($set::image_maxcount || 1) ),
 );
 
 ### フォーム表示 #####################################################################################
@@ -136,7 +137,7 @@ print <<"HTML";
       </dl>
     </details>
     <div id="area-status">
-      @{[ renderImageForm($pc{imageURL}) ]}
+      @{[ renderImageForm() ]}
 
       <div id="make-type" class="box">
         @{[ radios 'makeType','changeMakeType','normal=>通常作成','gospel=>ゴスペルバレット作成' ]}

--- a/_core/lib/ms/calc-chara.pl
+++ b/_core/lib/ms/calc-chara.pl
@@ -36,13 +36,13 @@ sub data_calc {
 
   #### 改行を<br>に変換 --------------------------------------------------
   foreach (
-    'words',
     'freeNote',
     'freeHistory',
     'chatPalette',
   ){
     $pc{$_} =~ s/\r\n?|\n/<br>/g;
   }
+  $pc{'words'.$_} =~ s/\r\n?|\n/<br>/g foreach('', 2 .. ($set::image_maxcount || 1));
   
   #### 保存処理でなければここまで --------------------------------------------------
   if(!$::mode_save){ return %pc; }
@@ -71,14 +71,15 @@ sub data_calc {
   $NL{clan}        = substr($NL{clan}       , 0,108).'..' if length($NL{clan}       ) > 108;
   $NL{clanEmotion} = substr($NL{clanEmotion}, 0, 30).'..' if length($NL{clanEmotion}) >  30;
   $NL{address}     = substr($NL{address}    , 0, 30).'..' if length($NL{address}    ) >  30;
-  $::newline = "$pc{id}<>$::file<>".
-               "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>".
-               "$pc{image}<> $pc{tags} <>$pc{hide}<>$pc{lastSession}<>".
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>$pc{lastSession}<>"
 
-               "$pc{level}<>$pc{endurance}<>".
-               "$NL{taxa}<>$NL{home}<>".
-               "$NL{origin}<>$NL{background}<>".
-               "$NL{clan}<>$NL{clanEmotion}<>$NL{address}<>";
+    . "$pc{level}<>$pc{endurance}<>"
+    . "$NL{taxa}<>$NL{home}<>"
+    . "$NL{origin}<>$NL{background}<>"
+    . "$NL{clan}<>$NL{clanEmotion}<>$NL{address}<>";
 
   return %pc;
 }

--- a/_core/lib/ms/calc-clan.pl
+++ b/_core/lib/ms/calc-clan.pl
@@ -52,14 +52,15 @@ sub data_calc {
   $NL{belong} = substr($pc{belong}, 0, 30).'..' if length($pc{belong}) > 30;
   $NL{rule}   = substr($pc{rule}  , 0, 50).'..' if length($pc{rule}  ) > 50;
   $NL{leaderName} = substr($NL{leaderName}, 0, 108).'..' if length($NL{leaderName}) > 108;
-  $::newline = "$pc{id}<>$::file<>".
-               "$pc{birthTime}<>$::now<>$NL{clanName}<>$pc{playerName}<>$pc{group}<>".
-               "$pc{image}<> $pc{tags} <>$pc{hide}<>$pc{lastSession}<>".
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{clanName}<>$pc{playerName}<>$pc{group}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>$pc{lastSession}<>"
 
-               "$pc{level}<>".
-               "$NL{base}<>$NL{belong}<>".
-               "$NL{rule}<>".
-               "$NL{leaderName}<>";
+    . "$pc{level}<>"
+    . "$NL{base}<>$NL{belong}<>"
+    . "$NL{rule}<>"
+    . "$NL{leaderName}<>";
 
   return %pc;
 }

--- a/_core/lib/ms/edit-chara.js
+++ b/_core/lib/ms/edit-chara.js
@@ -11,7 +11,7 @@ window.onload = function() {
   checkMagi();
   calcEndurance();
   
-  imagePosition();
+  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/ms/edit-chara.js
+++ b/_core/lib/ms/edit-chara.js
@@ -11,7 +11,6 @@ window.onload = function() {
   checkMagi();
   calcEndurance();
   
-  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/ms/edit-chara.pl
+++ b/_core/lib/ms/edit-chara.pl
@@ -63,7 +63,8 @@ $pc{paletteTool} ||= 'bcdice';
 
 ### 改行処理 --------------------------------------------------
 convertEscapedBrToNewlines(\%pc,
-  qw/words freeNote freeHistory chatPalette/,
+  qw/freeNote freeHistory chatPalette/,
+  ( map { 'words'.$_ } '', 2 .. ($set::image_maxcount || 1) ),
 );
 
 ### フォーム表示 #####################################################################################
@@ -123,7 +124,7 @@ print <<"HTML";
     -->
 
     <div id="area-status">
-      @{[ renderImageForm($pc{imageURL}) ]}
+      @{[ renderImageForm() ]}
 
       <div id="profile" class="box-union in-toc" data-content-title="キャラクターの背景">
         <dl class="box" id="taxa"        ><dt>分類名<dd>@{[ input 'taxa' ]}</dl>

--- a/_core/lib/ms/edit-clan.pl
+++ b/_core/lib/ms/edit-clan.pl
@@ -143,10 +143,10 @@ print <<"HTML";
         <p>
           <input type="checkbox" name="imageDelete" value="1"> 画像を削除する
           @{[ input 'image','hidden' ]}
+          @{[ input 'imageUpdate','hidden' ]}
         </p>
       <script>
         const imageType = 'symbol';
-        let imgURL = "$pc{imageURL}";
       </script>
       </div>
 

--- a/_core/lib/others.pl
+++ b/_core/lib/others.pl
@@ -55,8 +55,8 @@ elsif($mode eq 'image' || $mode eq 'ogp-image'){
   }
 
   my $imageNo = $::in{imageNo} || $pc{mainImage} || 1;
-  $imageNo = 1 if $imageNo !~ /^\d+$/ || $imageNo < 1 || $imageNo > ($set::image_maxcount || 1);
-  my $suffix = $imageNo == 1 ? '' : $imageNo;
+  $imageNo = 1 if $imageNo !~ /^[0-9]+$/ || $imageNo < 1 || $imageNo > ($set::image_maxcount || 1);
+  my $suffix = imageSuffix($imageNo);
   my $ext = $pc{"image$suffix"};
   
   my %mime = (
@@ -93,6 +93,7 @@ elsif($mode eq 'image' || $mode eq 'ogp-image'){
   if($mode eq 'ogp-image'){
     $pc{src} = $path;
     $pc{imageData} = $imageData;
+    $pc{imageMainSuffix} = $suffix;
     outputOgpImage(%pc);
   }
 
@@ -122,10 +123,12 @@ sub outputOgpImage {
   my (%opt) = @_;
   my $src       = $opt{src};
   my $imageData = $opt{imageData};
-  my $fit       = $opt{imageFit} // 'cover';
-  my $percent   = ($opt{imagePercent} // 100);
-  my $posX      = ($opt{imagePositionX} // '50');
-  my $posY      = ($opt{imagePositionY} // '50');
+
+  my $main      = $opt{imageMainSuffix} // 1;
+  my $fit       = $opt{"imageFit$main"} // 'cover';
+  my $percent   = ($opt{"imagePercent$main"} // 100);
+  my $posX      = ($opt{"imagePositionX$main"} // '50');
+  my $posY      = ($opt{"imagePositionY$main"} // '50');
 
   my $W = 630;
   my $H = 630;

--- a/_core/lib/others.pl
+++ b/_core/lib/others.pl
@@ -51,10 +51,13 @@ elsif($mode eq 'image' || $mode eq 'ogp-image'){
   if(!$file){ error "404:データがありません。" }
   my %pc;
   foreach (readSheetFileLines($datadir, $file, 'data.cgi')){
-    if($_ =~ /^(image.*?)<>(.*?)\n/){ $pc{$1} = $2; }
+    if($_ =~ /^((?:mainImage)|(?:image.*?))<>(.*?)\n/){ $pc{$1} = $2; }
   }
 
-  my $ext = $pc{image};
+  my $imageNo = $::in{imageNo} || $pc{mainImage} || 1;
+  $imageNo = 1 if $imageNo !~ /^\d+$/ || $imageNo < 1 || $imageNo > ($set::image_maxcount || 1);
+  my $suffix = $imageNo == 1 ? '' : $imageNo;
+  my $ext = $pc{"image$suffix"};
   
   my %mime = (
     jpg  => 'image/jpeg',
@@ -64,19 +67,19 @@ elsif($mode eq 'image' || $mode eq 'ogp-image'){
     webp => 'image/webp',
   );
 
-  my $path = "./${datadir}/${file}/image.${ext}";
+  my $path = "./${datadir}/${file}/image$suffix.${ext}";
   my $imageData;
   
   my $imageExists;
   if($ext){
-    $imageData = readSheetFileBinary($datadir, $file, "image.$ext");
+    $imageData = readSheetFileBinary($datadir, $file, "image$suffix.$ext");
     $imageExists = 1 if defined $imageData;
   }
   if(!$imageExists){
     foreach (qw(png jpg jpeg gif webp)) {
-      $imageData = readSheetFileBinary($datadir, $file, "image.$_");
+      $imageData = readSheetFileBinary($datadir, $file, "image$suffix.$_");
       if(defined $imageData) {
-        $path = "./${datadir}/${file}/image.$_";
+        $path = "./${datadir}/${file}/image$suffix.$_";
         $ext = $_;
         $imageExists = 1;
         last;

--- a/_core/lib/save.pl
+++ b/_core/lib/save.pl
@@ -11,13 +11,13 @@ if($::in{base64mode}){
   foreach(keys %::in){
     next if $_ eq 'mode';
     next if !$_;
-    next if $_ =~ 'imageFile';
+    next if $_ =~ /^imageFile\d*$/;
     $::in{$_} = decode('utf8', decode_base64($::in{$_}) );
   }
 }
 else {
   foreach(keys %::in){
-    next if $_ eq 'imageFile';
+    next if $_ =~ /^imageFile\d*$/;
     $::in{$_} = decode('utf8', param($_))
   }
 }
@@ -84,6 +84,7 @@ if ($mode eq 'make'){
 ### データ処理 #################################################################################
 my %pc = %::in;
 delete $pc{imageFile};
+delete @pc{grep { /^imageFile\d+$/ } keys %pc};
 if($main::newId){ $pc{id} = $main::newId; }
 ## 現在時刻
 our $now = time;
@@ -96,7 +97,7 @@ if($mode eq 'make'){
   $pc{birthTime} = $file = $now;
 }
 elsif($mode eq 'save'){
-  $file = (authSheet $pc{id},$pc{pass},$LOGIN_ID)[0];
+  $file = (authSheet($pc{id},$pc{pass},$LOGIN_ID))[0];
   if(!$file){ error('404:シートが存在しないか、編集権限がありません。'); }
 }
 
@@ -126,27 +127,39 @@ if($mode eq 'save' && $pc{protect} ne 'account' && $pc{protectOld} eq 'account')
 %pc = data_calc(\%pc);
 
 ### 画像アップロード --------------------------------------------------
-my $oldext;
-if($pc{imageDelete}){
-  $oldext = $pc{image};
-  $pc{image} = '';
-}
-use MIME::Base64;
-my $imagedata; my $imageflag;
-if($::in{imageFile}){
-  my $mime;
+my $imageMaxCount = $set::image_maxcount || 1;
+$imageMaxCount = 1 if $imageMaxCount < 1;
+my %oldext;
+my %imagedata;
+my %imageflag;
+my %imageUpload;
+my %imageDelete;
+for my $imageNo (1 .. $imageMaxCount){
+  my $suffix = $imageNo == 1 ? '' : $imageNo;
+  my $imageKey = "image$suffix";
+  my $deleteKey = "imageDelete$suffix";
+  my $fileKey = "imageFile$suffix";
+  my $updateKey = "imageUpdate$suffix";
+  if($pc{$deleteKey}){
+    $imageDelete{$imageNo} = 1;
+    $oldext{$imageNo} = $pc{$imageKey};
+    $pc{$imageKey} = '';
+    $pc{mainImage} = '' if ($pc{mainImage} || 1) == $imageNo;
+  }
+  next if !$::in{$fileKey};
 
-  my $imagefile = $::in{imageFile}; # ファイル名の取得
+  my $mime;
+  my $imagefile = $::in{$fileKey}; # ファイル名の取得
   $mime = uploadInfo($imagefile)->{'Content-Type'}; # MIMEタイプの取得
 
   # ファイルの受け取り
   my $buffer;
   while(my $bytesread = read($imagefile, $buffer, 2048)) {
-    $imagedata .= $buffer;
+    $imagedata{$imageNo} .= $buffer;
   }
   # サイズチェック
   my $max_size = ( $set::image_maxsize ? $set::image_maxsize : 1024 * 1024 );
-  if (length($imagedata) <= $max_size){ $imageflag = 1; }
+  if (length($imagedata{$imageNo}) <= $max_size){ $imageflag{$imageNo} = 1; }
 
   # MIME-type -> 拡張子
   my $ext; 
@@ -158,12 +171,26 @@ if($::in{imageFile}){
   elsif ($mime eq "image/webp")  { $ext ="webp"; } #WebP
 
   # 通して良しなら
-  if($imageflag && $ext){
-    $oldext = $pc{image} || $oldext;
-    $pc{image} = $ext;
-    $pc{imageUpdate} = time;
+  if($imageflag{$imageNo} && $ext){
+    $oldext{$imageNo} = $pc{$imageKey} || $oldext{$imageNo};
+    $pc{$imageKey} = $ext;
+    $pc{$updateKey} = time;
+    $imageUpload{$imageNo} = 1;
+    $pc{mainImage} ||= $imageNo;
   }
 }
+$pc{mainImage} = 1 if !$pc{mainImage} || $pc{mainImage} !~ /^\d+$/ || $pc{mainImage} > $imageMaxCount;
+if(!$pc{'image'.($pc{mainImage} == 1 ? '' : $pc{mainImage})}){
+  for my $imageNo (1 .. $imageMaxCount){
+    my $suffix = $imageNo == 1 ? '' : $imageNo;
+    if($pc{"image$suffix"}){ $pc{mainImage} = $imageNo; last; }
+  }
+}
+for my $imageNo (1 .. $imageMaxCount){
+  my $suffix = $imageNo == 1 ? '' : $imageNo;
+  delete $pc{"imageDelete$suffix"};
+}
+
 
 
 ### 保存 #############################################################################################
@@ -188,7 +215,11 @@ my $userDir;
 ## 新規
 if($mode eq 'make'){
   $userDir = appendPassFile($pc{id},$pass,$LOGIN_ID,$pc{protect},$now);
-  dataSave('make', $dataDir, $file, $pc{protect}, $userDir);
+  dataSave('make', $dataDir, $file, $pc{protect}, $userDir, {
+    imageData   => \%imagedata,
+    imageFlag   => \%imageUpload,
+    imageDelete => \%imageDelete,
+  });
 }
 ## 更新
 elsif($mode eq 'save'){
@@ -198,21 +229,30 @@ elsif($mode eq 'save'){
   else {
     $userDir = ($pc{protect} eq 'account' && $LOGIN_ID) ? "_${LOGIN_ID}/" : 'anonymous/';
   }
-  dataSave('save', $dataDir, $file, $pc{protect}, $userDir);
+  dataSave('save', $dataDir, $file, $pc{protect}, $userDir, {
+    imageData   => \%imagedata,
+    imageFlag   => \%imageUpload,
+    imageDelete => \%imageDelete,
+  });
 }
 ### 一覧データ更新 --------------------------------------------------
 updateListFile($newline);
 
 ### 画像アップ更新 --------------------------------------------------
-if($pc{imageDelete} && $oldext){
-  deleteSheetFile("${dataDir}${userDir}", $file, "image.$oldext"); # ファイルを削除
-}
-if($imageflag && $pc{image}){
-  if($oldext && $oldext ne $pc{image}){
-    deleteSheetFile("${dataDir}${userDir}", $file, "image.$oldext"); # 前のファイルを削除
+for my $imageNo (1 .. $imageMaxCount){
+  my $suffix = $imageNo == 1 ? '' : $imageNo;
+  my $imageKey = "image$suffix";
+  if($imageDelete{$imageNo} && $oldext{$imageNo}){
+    deleteSheetFile("${dataDir}${userDir}", $file, "image$suffix.$oldext{$imageNo}"); # ファイルを削除
   }
-  updateSheetFile("${dataDir}${userDir}", $file, "image.$pc{image}", $imagedata);
+  if($imageflag{$imageNo} && $pc{$imageKey}){
+    if($oldext{$imageNo} && $oldext{$imageNo} ne $pc{$imageKey}){
+      deleteSheetFile("${dataDir}${userDir}", $file, "image$suffix.$oldext{$imageNo}"); # 前のファイルを削除
+    }
+    updateSheetFile("${dataDir}${userDir}", $file, "image$suffix.$pc{$imageKey}", $imagedata{$imageNo});
+  }
 }
+
 
 
 
@@ -239,6 +279,10 @@ sub dataSave {
   my $file = shift;
   my $protect = shift;
   my $userDir = shift;
+  my $imageOpt = shift || {};
+  my $archiveImageData   = $imageOpt->{imageData}   || {};
+  my $archiveImageFlag   = $imageOpt->{imageFlag}   || {};
+  my $archiveImageDelete = $imageOpt->{imageDelete} || {};
 
   if (!-d "${dir}${userDir}"){
     mkdir "${dir}${userDir}" or error("500:データディレクトリの作成に失敗しました。");
@@ -356,8 +400,18 @@ sub dataSave {
     'log-list.cgi' => $logListContent,
   );
   foreach my $ext (qw(png jpg jpeg gif webp)){
-    my $image = readSheetFileBinary($dir, $file, "image.$ext");
-    $archive{"image.$ext"} = $image if defined $image;
+    foreach my $imageNo (1 .. ($set::image_maxcount || 1)){
+      my $suffix = $imageNo == 1 ? '' : $imageNo;
+      my $imageKey = "image$suffix";
+      if($archiveImageFlag->{$imageNo}){
+        next if $pc{$imageKey} ne $ext;
+        $archive{"image$suffix.$ext"} = $archiveImageData->{$imageNo};
+        next;
+      }
+      next if $archiveImageDelete->{$imageNo};
+      my $image = readSheetFileBinary($dir, $file, "image$suffix.$ext");
+      $archive{"image$suffix.$ext"} = $image if defined $image;
+    }
   }
   saveSheetArchive($dir, $file, \%archive);
 }

--- a/_core/lib/save.pl
+++ b/_core/lib/save.pl
@@ -11,13 +11,13 @@ if($::in{base64mode}){
   foreach(keys %::in){
     next if $_ eq 'mode';
     next if !$_;
-    next if $_ =~ /^imageFile\d*$/;
+    next if $_ =~ /^imageFile[0-9]*$/;
     $::in{$_} = decode('utf8', decode_base64($::in{$_}) );
   }
 }
 else {
   foreach(keys %::in){
-    next if $_ =~ /^imageFile\d*$/;
+    next if $_ =~ /^imageFile[0-9]*$/;
     $::in{$_} = decode('utf8', param($_))
   }
 }
@@ -84,7 +84,8 @@ if ($mode eq 'make'){
 ### データ処理 #################################################################################
 my %pc = %::in;
 delete $pc{imageFile};
-delete @pc{grep { /^imageFile\d+$/ } keys %pc};
+delete @pc{ grep { /^imageFile[0-9]+$/ } keys %pc };
+delete @pc{ grep { /^editing/ } keys %pc };
 if($main::newId){ $pc{id} = $main::newId; }
 ## 現在時刻
 our $now = time;
@@ -130,9 +131,9 @@ if($mode eq 'save' && $pc{protect} ne 'account' && $pc{protectOld} eq 'account')
 my $imageMaxCount = $set::image_maxcount || 1;
 $imageMaxCount = 1 if $imageMaxCount < 1;
 my %oldext;
-my %imagedata;
-my %imageflag;
-my %imageUpload;
+my %imageData;
+my %imageSizeOk;
+my %imageAccepted;
 my %imageDelete;
 for my $imageNo (1 .. $imageMaxCount){
   my $suffix = $imageNo == 1 ? '' : $imageNo;
@@ -155,11 +156,11 @@ for my $imageNo (1 .. $imageMaxCount){
   # ファイルの受け取り
   my $buffer;
   while(my $bytesread = read($imagefile, $buffer, 2048)) {
-    $imagedata{$imageNo} .= $buffer;
+    $imageData{$imageNo} .= $buffer;
   }
   # サイズチェック
   my $max_size = ( $set::image_maxsize ? $set::image_maxsize : 1024 * 1024 );
-  if (length($imagedata{$imageNo}) <= $max_size){ $imageflag{$imageNo} = 1; }
+  if (length($imageData{$imageNo}) <= $max_size){ $imageSizeOk{$imageNo} = 1; }
 
   # MIME-type -> 拡張子
   my $ext; 
@@ -171,15 +172,15 @@ for my $imageNo (1 .. $imageMaxCount){
   elsif ($mime eq "image/webp")  { $ext ="webp"; } #WebP
 
   # 通して良しなら
-  if($imageflag{$imageNo} && $ext){
+  if($imageSizeOk{$imageNo} && $ext){
     $oldext{$imageNo} = $pc{$imageKey} || $oldext{$imageNo};
     $pc{$imageKey} = $ext;
     $pc{$updateKey} = time;
-    $imageUpload{$imageNo} = 1;
+    $imageAccepted{$imageNo} = 1;
     $pc{mainImage} ||= $imageNo;
   }
 }
-$pc{mainImage} = 1 if !$pc{mainImage} || $pc{mainImage} !~ /^\d+$/ || $pc{mainImage} > $imageMaxCount;
+$pc{mainImage} = 1 if !$pc{mainImage} || $pc{mainImage} !~ /^[0-9]+$/ || $pc{mainImage} > $imageMaxCount;
 if(!$pc{'image'.($pc{mainImage} == 1 ? '' : $pc{mainImage})}){
   for my $imageNo (1 .. $imageMaxCount){
     my $suffix = $imageNo == 1 ? '' : $imageNo;
@@ -216,9 +217,9 @@ my $userDir;
 if($mode eq 'make'){
   $userDir = appendPassFile($pc{id},$pass,$LOGIN_ID,$pc{protect},$now);
   dataSave('make', $dataDir, $file, $pc{protect}, $userDir, {
-    imageData   => \%imagedata,
-    imageFlag   => \%imageUpload,
-    imageDelete => \%imageDelete,
+    imageData     => \%imageData,
+    imageAccepted => \%imageAccepted,
+    imageDelete   => \%imageDelete,
   });
 }
 ## 更新
@@ -230,9 +231,9 @@ elsif($mode eq 'save'){
     $userDir = ($pc{protect} eq 'account' && $LOGIN_ID) ? "_${LOGIN_ID}/" : 'anonymous/';
   }
   dataSave('save', $dataDir, $file, $pc{protect}, $userDir, {
-    imageData   => \%imagedata,
-    imageFlag   => \%imageUpload,
-    imageDelete => \%imageDelete,
+    imageData     => \%imageData,
+    imageAccepted => \%imageAccepted,
+    imageDelete   => \%imageDelete,
   });
 }
 ### 一覧データ更新 --------------------------------------------------
@@ -245,15 +246,13 @@ for my $imageNo (1 .. $imageMaxCount){
   if($imageDelete{$imageNo} && $oldext{$imageNo}){
     deleteSheetFile("${dataDir}${userDir}", $file, "image$suffix.$oldext{$imageNo}"); # ファイルを削除
   }
-  if($imageflag{$imageNo} && $pc{$imageKey}){
+  if($imageSizeOk{$imageNo} && $pc{$imageKey}){
     if($oldext{$imageNo} && $oldext{$imageNo} ne $pc{$imageKey}){
       deleteSheetFile("${dataDir}${userDir}", $file, "image$suffix.$oldext{$imageNo}"); # 前のファイルを削除
     }
-    updateSheetFile("${dataDir}${userDir}", $file, "image$suffix.$pc{$imageKey}", $imagedata{$imageNo});
+    updateSheetFile("${dataDir}${userDir}", $file, "image$suffix.$pc{$imageKey}", $imageData{$imageNo});
   }
 }
-
-
 
 
 ### 保存後処理 ######################################################################################
@@ -270,8 +269,6 @@ else {
 }
 
 
-
-
 ### サブルーチン ###################################################################################
 sub dataSave {
   my $mode = shift;
@@ -280,9 +277,9 @@ sub dataSave {
   my $protect = shift;
   my $userDir = shift;
   my $imageOpt = shift || {};
-  my $archiveImageData   = $imageOpt->{imageData}   || {};
-  my $archiveImageFlag   = $imageOpt->{imageFlag}   || {};
-  my $archiveImageDelete = $imageOpt->{imageDelete} || {};
+  my $archiveImageData     = $imageOpt->{imageData}     || {};
+  my $archiveImageAccepted = $imageOpt->{imageAccepted} || {};
+  my $archiveImageDelete   = $imageOpt->{imageDelete}   || {};
 
   if (!-d "${dir}${userDir}"){
     mkdir "${dir}${userDir}" or error("500:データディレクトリの作成に失敗しました。");
@@ -403,7 +400,7 @@ sub dataSave {
     foreach my $imageNo (1 .. ($set::image_maxcount || 1)){
       my $suffix = $imageNo == 1 ? '' : $imageNo;
       my $imageKey = "image$suffix";
-      if($archiveImageFlag->{$imageNo}){
+      if($archiveImageAccepted->{$imageNo}){
         next if $pc{$imageKey} ne $ext;
         $archive{"image$suffix.$ext"} = $archiveImageData->{$imageNo};
         next;

--- a/_core/lib/save.pl
+++ b/_core/lib/save.pl
@@ -124,9 +124,6 @@ if($mode eq 'save' && $pc{protect} ne 'account' && $pc{protectOld} eq 'account')
   }
 }
 
-## データ計算
-%pc = data_calc(\%pc);
-
 ### 画像アップロード --------------------------------------------------
 my $imageMaxCount = $set::image_maxcount || 1;
 $imageMaxCount = 1 if $imageMaxCount < 1;
@@ -136,7 +133,7 @@ my %imageSizeOk;
 my %imageAccepted;
 my %imageDelete;
 for my $imageNo (1 .. $imageMaxCount){
-  my $suffix = $imageNo == 1 ? '' : $imageNo;
+  my $suffix = imageSuffix($imageNo);
   my $imageKey = "image$suffix";
   my $deleteKey = "imageDelete$suffix";
   my $fileKey = "imageFile$suffix";
@@ -181,17 +178,18 @@ for my $imageNo (1 .. $imageMaxCount){
   }
 }
 $pc{mainImage} = 1 if !$pc{mainImage} || $pc{mainImage} !~ /^[0-9]+$/ || $pc{mainImage} > $imageMaxCount;
-if(!$pc{'image'.($pc{mainImage} == 1 ? '' : $pc{mainImage})}){
+if(!$pc{'image'.imageSuffix($pc{mainImage})}){
   for my $imageNo (1 .. $imageMaxCount){
-    my $suffix = $imageNo == 1 ? '' : $imageNo;
-    if($pc{"image$suffix"}){ $pc{mainImage} = $imageNo; last; }
+    if($pc{'image'.imageSuffix($imageNo)}){ $pc{mainImage} = $imageNo; last; }
   }
 }
 for my $imageNo (1 .. $imageMaxCount){
-  my $suffix = $imageNo == 1 ? '' : $imageNo;
-  delete $pc{"imageDelete$suffix"};
+  delete $pc{'imageDelete'.imageSuffix($imageNo)};
 }
 
+
+## データ計算 --------------------------------------------------
+%pc = data_calc(\%pc);
 
 
 ### 保存 #############################################################################################
@@ -241,7 +239,7 @@ updateListFile($newline);
 
 ### 画像アップ更新 --------------------------------------------------
 for my $imageNo (1 .. $imageMaxCount){
-  my $suffix = $imageNo == 1 ? '' : $imageNo;
+  my $suffix = imageSuffix($imageNo);
   my $imageKey = "image$suffix";
   if($imageDelete{$imageNo} && $oldext{$imageNo}){
     deleteSheetFile("${dataDir}${userDir}", $file, "image$suffix.$oldext{$imageNo}"); # ファイルを削除
@@ -398,7 +396,7 @@ sub dataSave {
   );
   foreach my $ext (qw(png jpg jpeg gif webp)){
     foreach my $imageNo (1 .. ($set::image_maxcount || 1)){
-      my $suffix = $imageNo == 1 ? '' : $imageNo;
+      my $suffix = imageSuffix($imageNo);
       my $imageKey = "image$suffix";
       if($archiveImageAccepted->{$imageNo}){
         next if $pc{$imageKey} ne $ext;

--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -219,7 +219,7 @@ sub zipMemberExists {
 }
 sub isSheetBinaryEntry {
   my $name = shift;
-  return $name =~ /^image\d*\.(?:png|jpe?g|gif|webp)$/i ? 1 : 0;
+  return $name =~ /^image[0-9]*\.(?:png|jpe?g|gif|webp)$/i ? 1 : 0;
 }
 sub readZipMember {
   my ($zipPath, $member, $binary) = @_;

--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -812,6 +812,13 @@ sub convertEscapedBrToNewlines {
     $pc->{$key} =~ s/&lt;br&gt;/\n/g;
   }
 }
+sub convertNewlinesToBrTag {
+  my $pc = shift;
+  for my $key (@_) {
+    next unless defined $pc->{$key};
+    $pc->{$key} =~ s/\r\n?|\n/<br>/g;
+  }
+}
 
 ### エスケープ --------------------------------------------------
 sub escapePcData {
@@ -1336,16 +1343,19 @@ sub importSheetData {
         return $returnError->('403:閲覧・編集に制限がかかっており、コンバートできないデータです。');
       }
     }
-    if($OPT{includeImage} && $pc{image}){
-      $pc{imageURL} = ($OPT{imageUrlBase} || $self)."?id=$id&mode=image&cache=$pc{imageUpdate}";
-      my $imagePath = "${dataDir}${file}/image.$pc{image}";
-      $pc{imagePath} = $imagePath if -f $imagePath;
-      if($::in{mode} eq 'download'){
-        $pc{imageData} = readSheetFileBinary($dataDir, $file, "image.$pc{image}");
+    my $mainSuffix = imageSuffix($pc{mainImage});
+    foreach my $imageNo (1 .. ($set::image_maxcount || 1)){
+      my $suffix = imageSuffix($imageNo);
+      next unless $pc{"image$suffix"};
+      $pc{"imageURL$suffix"} = ($OPT{imageUrlBase} || $self).qq|?id=$id&mode=image&imageNo=$imageNo&cache=$pc{"imageUpdate$suffix"}|;
+      if($OPT{includeImage}){
+        my $imgName = qq|image$suffix.$pc{"image$suffix"}|;
+        my $imagePath = qq|${dataDir}${file}/$imgName|;
+        $pc{"imagePath$suffix"} = $imagePath if -f $imagePath;
+        if($::in{mode} eq 'download'){
+          $pc{"imageData$suffix"} = readSheetFileBinary($dataDir, $file, $imgName);
+        }
       }
-    }
-    elsif(!$OPT{includeImage} && $pc{image}){
-      $pc{imageURL} = $self."?id=$id&mode=image&cache=$pc{imageUpdate}";
     }
     $pc{convertSource} = '同じゆとシートⅡ';
     return %pc;
@@ -1558,5 +1568,10 @@ sub logFileUpdate {
   if($mode eq 'view'){ print "Location:./?id=$::in{id}\n\n"; }
 }
 
+### 画像接尾辞 --------------------------------------------------
+sub imageSuffix {
+  my $imageNo = shift;
+  return $imageNo == 1 ? '' : $imageNo;
+}
 
 1;

--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -219,7 +219,7 @@ sub zipMemberExists {
 }
 sub isSheetBinaryEntry {
   my $name = shift;
-  return $name =~ /^image\.(?:png|jpe?g|gif|webp)$/i ? 1 : 0;
+  return $name =~ /^image\d*\.(?:png|jpe?g|gif|webp)$/i ? 1 : 0;
 }
 sub readZipMember {
   my ($zipPath, $member, $binary) = @_;

--- a/_core/lib/sw2/calc-arts.pl
+++ b/_core/lib/sw2/calc-arts.pl
@@ -93,10 +93,11 @@ sub data_calc {
   $NL{author}  = substr($NL{author} , 0,  25).'..' if length($NL{author} ) >  25;
   $NL{sub}     = substr($NL{sub}    , 0,  40).'..' if length($NL{sub}    ) >  40;
   $NL{summary} = substr($NL{summary}, 0,  35).'..' if length($NL{summary}) >  35;
-  $::newline = "$pc{id}<>$::file<>".
-                "$pc{birthTime}<>$::now<>$NL{name}<>$NL{author}<>".
-                "$pc{category}<>$NL{sub}<>$NL{summary}<>".
-                "$pc{image}<> $pc{tags} <>$pc{hide}<>";
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{name}<>$NL{author}<>"
+    . "$pc{category}<>$NL{sub}<>$NL{summary}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>";
   
   return %pc;
 }

--- a/_core/lib/sw2/calc-chara.pl
+++ b/_core/lib/sw2/calc-chara.pl
@@ -836,7 +836,7 @@ sub data_calc {
   }
 
   #### 改行を<br>に変換 --------------------------------------------------
-  $pc{words}         =~ s/\r\n?|\n/<br>/g;
+  $pc{'words'.$_} =~ s/\r\n?|\n/<br>/g foreach('', 2 .. ($set::image_maxcount || 1));
   $pc{items}         =~ s/\r\n?|\n/<br>/g;
   $pc{freeNote}      =~ s/\r\n?|\n/<br>/g;
   $pc{freeHistory}   =~ s/\r\n?|\n/<br>/g;
@@ -897,11 +897,13 @@ sub data_calc {
   }
   $classlv .= '|'.$freeclass if $freeclass;
 
-  $::newline = "$pc{id}<>$::file<>"
-             . "$pc{birthTime}<>$::now<>$NL{name}<>$NL{playerName}<>$pc{group}<>"
-             . "$pc{expTotal}<>$NL{rank}<>$NL{race}<>$NL{gender}<>$NL{age}<>$NL{faith}<>"
-             . "$classlv<>"
-             . "$pc{lastSession}<>$pc{image}<> $pc{tags} <>$pc{hide}<>$pc{fellowPublic}<>";
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{name}<>$NL{playerName}<>$pc{group}<>"
+    . "$pc{expTotal}<>$NL{rank}<>$NL{race}<>$NL{gender}<>$NL{age}<>$NL{faith}<>"
+    . "$classlv<>$pc{lastSession}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>"
+    . "$pc{fellowPublic}<>";
 
   return %pc;
 }

--- a/_core/lib/sw2/calc-item.pl
+++ b/_core/lib/sw2/calc-item.pl
@@ -34,10 +34,11 @@ sub data_calc {
   $NL{author}  = substr($NL{author} , 0,  25).'..' if length($NL{author} ) >  25;
   $NL{sub}     = substr($NL{sub}    , 0,  40).'..' if length($NL{sub}    ) >  40;
   $NL{summary} = substr($NL{summary}, 0,  35).'..' if length($NL{summary}) >  35;
-  $::newline = "$pc{id}<>$::file<>".
-                "$pc{birthTime}<>$::now<>$NL{itemName}<>$NL{author}<>".
-                "$NL{category}<>$NL{price}<>$NL{age}<>$NL{summary}<>$NL{type}<>".
-                "$pc{image}<> $pc{tags} <>$pc{hide}<>";
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{itemName}<>$NL{author}<>"
+    . "$NL{category}<>$NL{price}<>$NL{age}<>$NL{summary}<>$NL{type}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>";
   
   return %pc;
 }

--- a/_core/lib/sw2/calc-mons.pl
+++ b/_core/lib/sw2/calc-mons.pl
@@ -49,10 +49,12 @@ sub data_calc {
   $NL{weakness}    = substr($NL{weakness}   , 0, 25).'..' if length($NL{weakness}   ) >  25;
   $NL{habitat}     = substr($NL{habitat}    , 0, 35).'..' if length($NL{habitat}    ) >  35;
   $pc{hide} = 'IN' if(!$pc{hide} && $pc{description} =~ /#login-only/i);
-  $::newline = "$pc{id}<>$::file<>".
-                "$pc{birthTime}<>$::now<>$NL{name}<>$pc{author}<>$NL{taxa}<>$NL{lv}<>".
-                "$pc{intellect}<>$pc{perception}<>$NL{disposition}<>$pc{sin}<>$NL{initiative}<>$NL{weakness}<>".
-                "$pc{image}<> $pc{tags} <>$pc{hide}<>$pc{partsNum}<>$NL{habitat}<>$NL{price}<>";
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{name}<>$pc{author}<>$NL{taxa}<>$NL{lv}<>"
+    . "$pc{intellect}<>$pc{perception}<>$NL{disposition}<>$pc{sin}<>$NL{initiative}<>$NL{weakness}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>"
+    . "$pc{partsNum}<>$NL{habitat}<>$NL{price}<>";
   
   return %pc;
 }

--- a/_core/lib/sw2/edit-arts.pl
+++ b/_core/lib/sw2/edit-arts.pl
@@ -176,7 +176,7 @@ print <<"HTML";
     <!-- 神格 -->
     <div class="data-area in-toc" id="data-god" data-content-title="神格の詳細">
       <div class="box input-data">
-        <div id="image" style="">
+        <div id="image">
           <h2>聖印の画像</h2>
           <p>
             プレビューエリアに画像ファイルをドロップ、または
@@ -187,10 +187,10 @@ print <<"HTML";
           <p>
             <input type="checkbox" name="imageDelete" value="1"> 画像を削除する
             @{[ input 'image','hidden' ]}
+            @{[ input 'imageUpdate','hidden' ]}
           </p>
         <script>
           const imageType = 'symbol';
-          let imgURL = "$pc{imageURL}";
         </script>
         </div>
         <dl class="name  "><dt>名称      <dd>@{[ input 'godName','',"setName" ]}</dl>

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -103,7 +103,7 @@ window.onload = function() {
 
   checkStageAll();
   
-  imagePosition();
+  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -103,7 +103,6 @@ window.onload = function() {
 
   checkStageAll();
   
-  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -124,7 +124,8 @@ foreach my $num (1 .. $pc{freeClassNum}){
 
 ### 改行処理 --------------------------------------------------
 convertEscapedBrToNewlines(\%pc,
-  qw/words items freeNote freeHistory cashbook fellowProfile fellowNote chatPalette/,
+  qw/items freeNote freeHistory cashbook fellowProfile fellowNote chatPalette/,
+  ( map { 'words'.$_ } '', 2 .. ($set::image_maxcount || 1) ),
   ( map { 'chatPaletteInsert'.$_ } 1..$pc{chatPaletteInsertNum} ),
   ( map { 'cashbookOther'    .$_ } 1..$pc{cashbookOtherNum} ),
   ( grep {/^fellow[-0-9]+(?:Action|Note)$/} keys %pc ),
@@ -284,7 +285,7 @@ print <<"HTML";
       </ul>
     </details>
     <div id="area-status">
-      @{[ renderImageForm($pc{imageURL}) ]}
+      @{[ renderImageForm() ]}
 
       <div id="personal" class="in-toc" data-content-title="種族・年齢・性別・穢れ・生まれ・信仰">
         <dl class="box" id="race">

--- a/_core/lib/vc/calc-chara.pl
+++ b/_core/lib/vc/calc-chara.pl
@@ -42,13 +42,13 @@ sub data_calc {
   }
   #### 改行を<br>に変換 --------------------------------------------------
   foreach (
-    'words',
     'freeNote',
     'freeHistory',
     'chatPalette',
   ){
     $pc{$_} =~ s/\r\n?|\n/<br>/g;
   }
+  $pc{'words'.$_} =~ s/\r\n?|\n/<br>/g foreach('', 2 .. ($set::image_maxcount || 1));
   
   #### 保存処理でなければここまで --------------------------------------------------
   if(!$::mode_save){ return %pc; }
@@ -77,13 +77,15 @@ sub data_calc {
   $NL{gender} = substr($NL{gender}, 0, 20).'..' if length($NL{gender}) > 20;
   $NL{age}    = substr($NL{age}   , 0, 20).'..' if length($NL{age}   ) > 20;
   $NL{height} = substr($NL{height}, 0, 20).'..' if length($NL{height}) > 20;
-  $::newline = "$pc{id}<>$::file<>".
-               "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>".
-               "$pc{image}<> $pc{tags} <>$pc{hide}<>".
 
-               "$NL{race}<>$NL{class}<>$NL{style1}／$NL{style2}<>".
-               "$pc{level}<>$pc{resultPointsTotal}<>".
-               "$NL{gender}<>$NL{age}<>$NL{height}<>$pc{lastSession}<>";
+  $::newline =
+    "$pc{id}<>$::file<>"
+    . "$pc{birthTime}<>$::now<>$NL{characterName}<>$NL{playerName}<>$pc{group}<>"
+    . $pc{"image".imageSuffix($pc{mainImage})}."<> $pc{tags} <>$pc{hide}<>"
+
+    . "$NL{race}<>$NL{class}<>$NL{style1}／$NL{style2}<>"
+    . "$pc{level}<>$pc{resultPointsTotal}<>"
+    . "$NL{gender}<>$NL{age}<>$NL{height}<>$pc{lastSession}<>";
 
   return %pc;
 }

--- a/_core/lib/vc/edit-chara.js
+++ b/_core/lib/vc/edit-chara.js
@@ -8,7 +8,7 @@ window.onload = function() {
   calcBattle();
   calcResultPoint();
   
-  imagePosition();
+  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/vc/edit-chara.js
+++ b/_core/lib/vc/edit-chara.js
@@ -8,7 +8,6 @@ window.onload = function() {
   calcBattle();
   calcResultPoint();
   
-  setImagePosition();
   changeColor();
 };
 

--- a/_core/lib/vc/edit-chara.pl
+++ b/_core/lib/vc/edit-chara.pl
@@ -76,7 +76,8 @@ $open{skills} = 'open';
 
 ### 改行処理 --------------------------------------------------
 convertEscapedBrToNewlines(\%pc,
-  qw/words freeNote freeHistory chatPalette/,
+  qw/freeNote freeHistory chatPalette/,
+  ( map { 'words'.$_ } '', 2 .. ($set::image_maxcount || 1) ),
 );
 
 ### パラメータ定義 --------------------------------------------------
@@ -121,7 +122,7 @@ print <<"HTML";
     </div>
 
     <div id="area-status">
-      @{[ renderImageForm($pc{imageURL}) ]}
+      @{[ renderImageForm() ]}
 
       <div id="levels">
         <dl class="box">

--- a/_core/lib/view.pl
+++ b/_core/lib/view.pl
@@ -316,16 +316,33 @@ sub loadSheetData {
   }
   
   ## キャラクター画像
-  if($pc{image}){
+  $pc{mainImage} ||= 1;
+  my $mainSuffix = $pc{mainImage} == 1 ? '' : $pc{mainImage};
+  if(!$pc{"image$mainSuffix"}){
+    for my $imageNo (1 .. ($set::image_maxcount || 1)){
+      my $suffix = $imageNo == 1 ? '' : $imageNo;
+      if($pc{"image$suffix"}){ $pc{mainImage} = $imageNo; $mainSuffix = $suffix; last; }
+    }
+  }
+  if($pc{"image$mainSuffix"}){
+    $pc{image} = $pc{"image$mainSuffix"};
+    $pc{imageUpdate} = $pc{"imageUpdate$mainSuffix"};
     if($pc{convertSource}) {
       $pc{imageSrc} = $pc{imageURL};
     }
     else {
-      $pc{imageSrc}    =     "./?id=$::in{id}&mode=image&cache=$pc{imageUpdate}";
-      $pc{imageURL}    = url()."?id=$::in{id}&mode=image&cache=$pc{imageUpdate}";
-      $pc{imageOgpURL} = url()."?id=$::in{id}&mode=ogp-image&cache=$pc{imageUpdate}";
+      $pc{imageSrc}    =     "./?id=$::in{id}&mode=image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
+      $pc{imageURL}    = url()."?id=$::in{id}&mode=image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
+      $pc{imageOgpURL} = url()."?id=$::in{id}&mode=ogp-image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
     }
-    $pc{images} = "'1': \"".($pc{modeDownload} ? sheetImageToBase64($datadir, $file, $pc{image}) : $pc{imageSrc})."\", ";
+    $pc{images} = '';
+    for my $imageNo (1 .. ($set::image_maxcount || 1)){
+      my $suffix = $imageNo == 1 ? '' : $imageNo;
+      next if !$pc{"image$suffix"};
+      my $update = $pc{"imageUpdate$suffix"};
+      my $src = "./?id=$::in{id}&mode=image&imageNo=$imageNo&cache=$update";
+      $pc{images} .= "'$imageNo': \"".($pc{modeDownload} ? sheetImageToBase64($datadir, $file, $pc{"image$suffix"}, $suffix) : $src)."\", ";
+    }
     
     if($pc{imageFit} eq 'percentY'){
       $pc{imageFit} = 'auto '.$pc{imagePercent}.'%';
@@ -592,10 +609,11 @@ sub styleToHtml {
 }
 use MIME::Base64;
 sub sheetImageToBase64 {
-  my ($dir, $file, $ext) = @_;
-  my $binary = readSheetFileBinary($dir, $file, "image.$ext");
+  my ($dir, $file, $ext, $suffix) = @_;
+  $suffix //= '';
+  my $binary = readSheetFileBinary($dir, $file, "image$suffix.$ext");
   return binaryToImageBase64($binary, $ext) if defined $binary;
-  return urlToBase64("${dir}${file}/image.$ext", $ext);
+  return urlToBase64("${dir}${file}/image$suffix.$ext", $ext);
 }
 sub binaryToImageBase64 {
   my ($binary, $ext) = @_;

--- a/_core/lib/view.pl
+++ b/_core/lib/view.pl
@@ -252,6 +252,13 @@ sub setupPartnerDataCommon {
     }
   }
   foreach my $num (1 .. $OPT{max}){
+    if($pc->{"p${num}_mainImage"} > 1){
+      my $suffix = imageSuffix($pc->{"p${num}_mainImage"});
+      foreach my $key (qw/image imageUpdate imageURL imagePath imageData imageFit imagePercent imagePositionX imagePositionY imageCopyright imageCopyrightURL words wordsX wordsY/){
+        $pc->{"p${num}_$key"} = $pc->{"p${num}_$key$suffix"};
+      }
+    }
+
     next if !$pc->{"p${num}_imageURL"};
     $pc->{"p${num}_imageSrc"} = $pc->{"p${num}_imageURL"};
     $pc->{images} .= "'p${num}': \"".($pc->{modeDownload} ? partnerImageToBase64($pc, $num) : $pc->{"p${num}_imageURL"})."\", ";
@@ -314,30 +321,21 @@ sub loadSheetData {
   if($::in{mode} eq 'download'){
     $pc{modeDownload} = 1;
   }
-  
+
   ## キャラクター画像
   $pc{mainImage} ||= 1;
-  my $mainSuffix = $pc{mainImage} == 1 ? '' : $pc{mainImage};
-  if(!$pc{"image$mainSuffix"}){
-    foreach my $imageNo (1 .. ($set::image_maxcount || 1)){
-      my $suffix = $imageNo == 1 ? '' : $imageNo;
-      if($pc{"image$suffix"}){ $pc{mainImage} = $imageNo; $mainSuffix = $suffix; last; }
-    }
-  }
-  if($pc{convertSource} && $pc{image}){
-    $pc{imageSrc} = $pc{imageURL};
-  }
-  else {
+  if($pc{ver} || !$pc{convertSource}) {
     $pc{images} = '';
     $pc{imageLayouts} = '';
     my %layouts;
-    foreach my $imageNo (1 .. ($set::image_maxcount || 1)){
-      my $suffix = $imageNo == 1 ? '' : $imageNo;
+    my $maxCount = $pc{imageMaxCount} || $set::image_maxcount || 1;
+    foreach my $imageNo (1 .. $maxCount){
+      my $suffix = imageSuffix($imageNo);
       next unless $pc{"image$suffix"};
-      
+
       my $update = $pc{"imageUpdate$suffix"};
-      my $src = "./?id=$::in{id}&mode=image&imageNo=$imageNo&cache=$update";
-      
+      my $src = $pc{convertSource} ? $pc{"imageURL$suffix"} : "./?id=$::in{id}&mode=image&imageNo=$imageNo&cache=$update";
+
       if($pc{"imageFit$suffix"} eq 'percentY'){
         $pc{"imageFit$suffix"} = 'auto '.$pc{"imagePercent$suffix"}.'%';
       }
@@ -347,7 +345,7 @@ sub loadSheetData {
       elsif(!$pc{"imageFit$suffix"}){
         $pc{"imageFit$suffix"} = 'cover';
       }
-      
+
       if($pc{"imageCopyrightURL$suffix"}){
         $pc{"imageCopyright$suffix"} = qq|<a href="$pc{"imageCopyrightURL$suffix"}" target="_blank">|
           . (unescapeTags($pc{"imageCopyright$suffix"}) || $pc{"imageCopyrightURL$suffix"})
@@ -372,9 +370,19 @@ sub loadSheetData {
     }
     $pc{imageLayouts} = %layouts ? JSON::PP->new->canonical(1)->encode(\%layouts) : "{}";
 
-    $pc{imageSrc}    =     "./?id=$::in{id}&mode=image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
-    $pc{imageURL}    = url()."?id=$::in{id}&mode=image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
-    $pc{imageOgpURL} = url()."?id=$::in{id}&mode=ogp-image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
+
+    my $mainSuffix = imageSuffix($pc{mainImage});
+    if(!$pc{"image$mainSuffix"}){
+      foreach my $imageNo (1 .. $maxCount){
+        my $suffix = imageSuffix($imageNo);
+        if($pc{"image$suffix"}){
+          $pc{mainImage} = $imageNo;
+          $mainSuffix = $suffix;
+          last;
+        }
+      }
+    }
+    $pc{image} = $pc{"image$mainSuffix"};
     $pc{imageFit} = $pc{"imageFit$mainSuffix"};
     $pc{imagePositionX} = $pc{"imagePositionX$mainSuffix"};
     $pc{imagePositionY} = $pc{"imagePositionY$mainSuffix"};
@@ -382,6 +390,21 @@ sub loadSheetData {
     $pc{words} = $pc{"words$mainSuffix"};
     $pc{wordsX} = $pc{"wordsX$mainSuffix"};
     $pc{wordsY} = $pc{"wordsY$mainSuffix"};
+
+    if($pc{image}) {
+      if($pc{convertSource}) {
+        $pc{imageSrc} = $pc{"imageURL$mainSuffix"};
+      }
+      else {
+        $pc{imageSrc}    =     qq|./?id=$::in{id}&mode=image&imageNo=$pc{mainImage}&cache=$pc{"imageUpdate$mainSuffix"}|;
+        $pc{imageURL}    = url().qq|?id=$::in{id}&mode=image&imageNo=$pc{mainImage}&cache=$pc{"imageUpdate$mainSuffix"}|;
+        $pc{imageOgpURL} = url().qq|?id=$::in{id}&mode=ogp-image&imageNo=$pc{mainImage}&cache=$pc{"imageUpdate$mainSuffix"}|;
+      }
+    }
+  }
+  elsif($pc{convertSource}) {
+    $pc{imageSrc} = $pc{imageURL};
+    $pc{images} = qq|1: "$pc{imageURL}"|;
   }
 
   ## 

--- a/_core/lib/view.pl
+++ b/_core/lib/view.pl
@@ -319,43 +319,69 @@ sub loadSheetData {
   $pc{mainImage} ||= 1;
   my $mainSuffix = $pc{mainImage} == 1 ? '' : $pc{mainImage};
   if(!$pc{"image$mainSuffix"}){
-    for my $imageNo (1 .. ($set::image_maxcount || 1)){
+    foreach my $imageNo (1 .. ($set::image_maxcount || 1)){
       my $suffix = $imageNo == 1 ? '' : $imageNo;
       if($pc{"image$suffix"}){ $pc{mainImage} = $imageNo; $mainSuffix = $suffix; last; }
     }
   }
-  if($pc{"image$mainSuffix"}){
-    $pc{image} = $pc{"image$mainSuffix"};
-    $pc{imageUpdate} = $pc{"imageUpdate$mainSuffix"};
-    if($pc{convertSource}) {
-      $pc{imageSrc} = $pc{imageURL};
-    }
-    else {
-      $pc{imageSrc}    =     "./?id=$::in{id}&mode=image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
-      $pc{imageURL}    = url()."?id=$::in{id}&mode=image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
-      $pc{imageOgpURL} = url()."?id=$::in{id}&mode=ogp-image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
-    }
+  if($pc{convertSource} && $pc{image}){
+    $pc{imageSrc} = $pc{imageURL};
+  }
+  else {
     $pc{images} = '';
-    for my $imageNo (1 .. ($set::image_maxcount || 1)){
+    $pc{imageLayouts} = '';
+    my %layouts;
+    foreach my $imageNo (1 .. ($set::image_maxcount || 1)){
       my $suffix = $imageNo == 1 ? '' : $imageNo;
-      next if !$pc{"image$suffix"};
+      next unless $pc{"image$suffix"};
+      
       my $update = $pc{"imageUpdate$suffix"};
       my $src = "./?id=$::in{id}&mode=image&imageNo=$imageNo&cache=$update";
-      $pc{images} .= "'$imageNo': \"".($pc{modeDownload} ? sheetImageToBase64($datadir, $file, $pc{"image$suffix"}, $suffix) : $src)."\", ";
+      
+      if($pc{"imageFit$suffix"} eq 'percentY'){
+        $pc{"imageFit$suffix"} = 'auto '.$pc{"imagePercent$suffix"}.'%';
+      }
+      elsif($pc{"imageFit$suffix"} =~ /^percentX?$/){
+        $pc{"imageFit$suffix"} = $pc{"imagePercent$suffix"}.'%';
+      }
+      elsif(!$pc{"imageFit$suffix"}){
+        $pc{"imageFit$suffix"} = 'cover';
+      }
+      
+      if($pc{"imageCopyrightURL$suffix"}){
+        $pc{"imageCopyright$suffix"} = qq|<a href="$pc{"imageCopyrightURL$suffix"}" target="_blank">|
+          . (unescapeTags($pc{"imageCopyright$suffix"}) || $pc{"imageCopyrightURL$suffix"})
+          . "</a>";
+      }
+      else { $pc{"imageCopyright$suffix"} = unescapeTags($pc{"imageCopyright$suffix"}) }
+
+      $pc{images} .= qq|$imageNo: "|.($pc{modeDownload} ? sheetImageToBase64($datadir, $file, $pc{"image$suffix"}, $suffix) : $src).'", ';
+      my @words = renderWords(
+        unescapeTags($pc{"words$suffix"}),
+        $pc{"wordsX$suffix"},
+        $pc{"wordsY$suffix"}
+      );
+      $layouts{$imageNo} = {
+        fit => $pc{"imageFit$suffix"},
+        X => $pc{"imagePositionX$suffix"}."%",
+        Y => $pc{"imagePositionY$suffix"}."%",
+        words  => ($words[0] || ''),
+        wordsPosition => join(';', $words[1],$words[2]),
+        copyright => ($pc{"imageCopyright$suffix"} || ''),
+      };
     }
-    
-    if($pc{imageFit} eq 'percentY'){
-      $pc{imageFit} = 'auto '.$pc{imagePercent}.'%';
-    }
-    elsif($pc{imageFit} =~ /^percentX?$/){
-      $pc{imageFit} = $pc{imagePercent}.'%';
-    }
-    
-    ## 権利表記
-    if($pc{imageCopyrightURL}){
-      $pc{imageCopyright} = "<a href=\"$pc{imageCopyrightURL}\" target=\"_blank\">".(unescapeTags($pc{imageCopyright})||$pc{imageCopyrightURL})."</a>";
-    }
-    else { $pc{imageCopyright} = unescapeTags($pc{imageCopyright}) }
+    $pc{imageLayouts} = %layouts ? JSON::PP->new->canonical(1)->encode(\%layouts) : "{}";
+
+    $pc{imageSrc}    =     "./?id=$::in{id}&mode=image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
+    $pc{imageURL}    = url()."?id=$::in{id}&mode=image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
+    $pc{imageOgpURL} = url()."?id=$::in{id}&mode=ogp-image&imageNo=$pc{mainImage}&cache=$pc{imageUpdate}";
+    $pc{imageFit} = $pc{"imageFit$mainSuffix"};
+    $pc{imagePositionX} = $pc{"imagePositionX$mainSuffix"};
+    $pc{imagePositionY} = $pc{"imagePositionY$mainSuffix"};
+    $pc{imageCopyright} = $pc{"imageCopyright$mainSuffix"};
+    $pc{words} = $pc{"words$mainSuffix"};
+    $pc{wordsX} = $pc{"wordsX$mainSuffix"};
+    $pc{wordsY} = $pc{"wordsY$mainSuffix"};
   }
 
   ## 

--- a/_core/skin/_common/css/edit.css
+++ b/_core/skin/_common/css/edit.css
@@ -1184,12 +1184,12 @@ input[type="submit"]:hover {
   pointer-events: none;
   user-select: none;
 }
-.image-custom-view-area > div.image-custom-frame input[name="imagePositionX"] {
+.image-custom-view-area > div.image-custom-frame input[name="editingImagePositionX"] {
   position: absolute;
   bottom: -1.5em;
   width: 100%;
 }
-.image-custom-view-area > div.image-custom-frame input[name="imagePositionY"] {
+.image-custom-view-area > div.image-custom-frame input[name="editingImagePositionY"] {
   position: absolute;
   top: 50%;
   right: calc(-567px /2 - 1em);
@@ -1228,6 +1228,37 @@ input[type="submit"]:hover {
 .image-custom-form p select,
 .image-custom-form p textarea {
   padding: .2em .5em;
+}
+.image-custom-form div:has(input[type="file"]) {
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  align-items: center;
+  gap: .5em;
+  padding: 0 .5em .2em;
+  .check-button {
+    height: max-content;
+  }
+}
+#image-select-buttons label {
+  display: inline-block;
+  margin: 0 3px;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 5px;
+  cursor: pointer;
+  > img {
+    width: 100px;
+    height: 100px;
+  }
+  &:has(.selected) {
+    outline-width: 1px;
+    outline-style: solid;
+    outline-offset: 1px;
+  }
+  > span {
+    display: block;
+    text-align: center;
+  }
 }
 #words-preview {
   position: absolute;
@@ -1295,7 +1326,7 @@ input[type="submit"]:hover {
     grid-template-columns: 1fr 35vw 1fr;
   }
   .image-custom-view-area > div#image-custom-frame-M { height: 56.7vw; }
-  .image-custom-view-area > div.image-custom-frame input[name="imagePositionY"] {
+  .image-custom-view-area > div.image-custom-frame input[name="editingImagePositionY"] {
     right: calc(-56.7vw /2 - 1em);
     width: 56.7vw;
   }
@@ -1318,7 +1349,7 @@ input[type="submit"]:hover {
     grid-template-rows: 1fr max-content 1fr;
   }
   .image-custom-view-area > div#image-custom-frame-M { grid-column: 2; grid-row: 2 / span 1; height: 46vh; }
-  .image-custom-view-area > div.image-custom-frame input[name="imagePositionY"] {
+  .image-custom-view-area > div.image-custom-frame input[name="editingImagePositionY"] {
     right: calc(-46vh /2 - 1em);
     width: 46vh;
   }

--- a/_core/skin/_common/css/sheet.css
+++ b/_core/skin/_common/css/sheet.css
@@ -916,6 +916,57 @@ textarea::placeholder {
 
 /* // Image
 ---------------------------------------------------------------------------------------------------- */
+#image {
+  position: relative;
+  > :is(.image, .image-none) {
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+
+    opacity: 1;
+    transition: opacity 0.5s ease;
+    transition-behavior: allow-discrete;
+    &.next {
+      z-index: 1;
+
+      opacity: 1;
+      @starting-style {
+        opacity: 0;
+      }
+    }
+  }
+
+  > :is(.prev-button, .next-button) {
+    display: none;
+    #image:hover & { display: block; }
+    position: absolute;
+    z-index: 3;
+    top: 0;
+    bottom: 0;
+    margin: auto 0;
+    width: 2em;
+    height: 2em;
+    padding-top: .1em;
+    text-align: center;
+    place-content: center;
+    border-radius: 50%;
+    background-color: #777a;
+    color: #fff;
+    line-height: 1;
+    font-size: 1.5em;
+    cursor: pointer;
+    
+    &.prev-button { left : 1px; padding-right: .1em; }
+    &.next-button { right: 1px; padding-left : .1em; }
+
+    &::before {
+      font-family: "Material Symbols Outlined";
+      font-weight: bold;
+    }
+    &.prev-button::before { content: "\e2ea"; }
+    &.next-button::before { content: "\e5e1"; }
+  }
+}
 .image {
   overflow: hidden;
   background-size: cover;
@@ -931,28 +982,29 @@ textarea::placeholder {
   position: relative;
 
   image-rendering: -webkit-optimize-contrast;
-}
-.image div[onclick] {
-  flex-grow: 1;
-  width: 100%;
-  cursor: pointer;
-  position: relative;
-}
-.image p.image-copyright {
-  padding: 0 5px;
-  font-size: 86%;
-  color: #fff;
-  text-shadow: 
-    #000  .1rem .1rem, #000 -.1rem -.1rem,
-    #000 -.1rem .1rem, #000  .1rem -.1rem,
-    #000  .0rem .1rem, #000  .0rem -.1rem,
-    #000 -.1rem .0rem, #000  .1rem  .0rem,
-    #000 0 0 .3rem, #000 0 0 .3rem, #000 0 0 .3rem;
-  word-break: break-all;
 
-  & a,
-  & i::before {
-    color: #fff !important;
+  > div[onclick] {
+    flex-grow: 1;
+    width: 100%;
+    cursor: pointer;
+    position: relative;
+  }
+  > p.image-copyright {
+    padding: 0 5px;
+    font-size: 86%;
+    color: #fff;
+    text-shadow: 
+      #000  .1rem .1rem, #000 -.1rem -.1rem,
+      #000 -.1rem .1rem, #000  .1rem -.1rem,
+      #000  .0rem .1rem, #000  .0rem -.1rem,
+      #000 -.1rem .0rem, #000  .1rem  .0rem,
+      #000 0 0 .3rem, #000 0 0 .3rem, #000 0 0 .3rem;
+    word-break: break-all;
+
+    & a,
+    & i::before {
+      color: #fff !important;
+    }
   }
 }
 

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -43,7 +43,6 @@ function changeImage(direction = 0){
     selectedImage = selected;
     
     const imageArea = document.querySelector('#image');
-    const current = imageArea.querySelector('.image.current');
     let next = document.createElement('div');
     next.classList.add('image','next');
     next.style.backgroundImage    = `url(${images[selected]})`;
@@ -54,19 +53,29 @@ function changeImage(direction = 0){
         <p class="words" style="${imageLayouts[selected].wordsPosition}">${imageLayouts[selected].words}</p>
       </div>
       <p class="image-copyright">${imageLayouts[selected].copyright}</p>`;
-    current.addEventListener('transitionend', () => {
-      current.remove();
-    });
     next.addEventListener('transitionend', () => {
+      document.querySelectorAll('#image .image.current').forEach(el => {
+        el.remove();
+      });
       next.classList.replace('next','current');
     });
-    imageArea.append(next);
+    const img = new Image();
+    img.src = images[selected];
+    img.addEventListener('load', () => {
+      imageArea.prepend(next);
+      document.querySelectorAll('#image .image.current').forEach(el => {
+        el.style.opacity = 0;
+      });
+    });
 
-    current.style.opacity = 0;
   }
 }
 function getImageId(direction = 0) {
-  const ids = Object.keys(images).map(Number).sort((a, b) => a - b);
+  const ids =
+    Object.keys(images)
+    .filter(key => /^[0-9]+$/.test(key))
+    .map(Number)
+    .sort((a, b) => a - b);
   const index = ids.indexOf(Number(selectedImage));
 
   if (index === -1) return selectedImage;

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -1,5 +1,6 @@
 // 開閉系 ----------------------------------------
-async function popImage(id) {
+// 画像
+async function popImage(id = 1) {
   let imageBox = document.getElementById("image-box") || null;
   if(!imageBox){
     imageBox = document.createElement('div');
@@ -12,7 +13,6 @@ async function popImage(id) {
     await new Promise((r) => setTimeout(r, 1));
   }
   if(typeof images !== 'undefined'){
-    id ||= 1;
     document.getElementById('image-box-image').src = images[id];
   }
   imageBox.style.bottom = 0;
@@ -25,6 +25,55 @@ function closeImage() {
     imageBox.style.bottom = '-100vh';
   },200);
 }
+window.addEventListener('DOMContentLoaded', ()=>{
+  if(imageLayouts && Object.keys(imageLayouts).length > 1){
+    let prev = document.createElement('span');
+    prev.classList.add('prev-button');
+    prev.addEventListener('click', () => { changeImage(-1) });
+    let next = document.createElement('span');
+    next.classList.add('next-button');
+    next.addEventListener('click', () => { changeImage(1) });
+    document.getElementById('image').append(prev, next);
+  }
+});
+function changeImage(direction = 0){
+  const selected = getImageId(direction);
+
+  if(images.hasOwnProperty(selected)){
+    selectedImage = selected;
+    
+    const imageArea = document.querySelector('#image');
+    const current = imageArea.querySelector('.image.current');
+    let next = document.createElement('div');
+    next.classList.add('image','next');
+    next.style.backgroundImage    = `url(${images[selected]})`;
+    next.style.backgroundSize     = imageLayouts[selected].fit;
+    next.style.backgroundPosition = `${imageLayouts[selected].X} ${imageLayouts[selected].Y}`;
+    next.innerHTML = `
+      <div onclick="popImage('${selected}')">
+        <p class="words" style="${imageLayouts[selected].wordsPosition}">${imageLayouts[selected].words}</p>
+      </div>
+      <p class="image-copyright">${imageLayouts[selected].copyright}</p>`;
+    current.addEventListener('transitionend', () => {
+      current.remove();
+    });
+    next.addEventListener('transitionend', () => {
+      next.classList.replace('next','current');
+    });
+    imageArea.append(next);
+
+    current.style.opacity = 0;
+  }
+}
+function getImageId(direction = 0) {
+  const ids = Object.keys(images).map(Number).sort((a, b) => a - b);
+  const index = ids.indexOf(Number(selectedImage));
+
+  if (index === -1) return selectedImage;
+
+  return ids[(index + direction + ids.length) % ids.length];
+}
+// 他
 function closeTextareaForCopy() {
   document.getElementById('copyText-box').remove();
   document.getElementById('copyText-box-textarea').remove();

--- a/_core/skin/_common/sheet-head.html
+++ b/_core/skin/_common/sheet-head.html
@@ -29,6 +29,8 @@
   const generateType = '<TMPL_VAR generateType>';
   const defaultImage = '<TMPL_VAR defaultImage>';
   const images = { <TMPL_VAR images /> };
+  const imageLayouts = <TMPL_VAR imageLayouts />;
+  let selectedImage = '<TMPL_VAR mainImage>';
 
   <!-- TMPL_IF error -->
   window.onload = function() {
@@ -42,7 +44,7 @@
   <!-- TMPL_IF modeDownload -->
   document.addEventListener('DOMContentLoaded', () => {
     if(document.getElementById('image')){
-      document.getElementById('image').style.backgroundImage = `url(${images['1']})`;
+      document.getElementById('image').style.backgroundImage = `url(${images['<TMPL_VAR mainImage DEFAULT=1>']})`;
     }
   });
   <!-- /TMPL_IF -->

--- a/_core/skin/_common/sheet-head.html
+++ b/_core/skin/_common/sheet-head.html
@@ -29,7 +29,7 @@
   const generateType = '<TMPL_VAR generateType>';
   const defaultImage = '<TMPL_VAR defaultImage>';
   const images = { <TMPL_VAR images /> };
-  const imageLayouts = <TMPL_VAR imageLayouts />;
+  const imageLayouts = <TMPL_VAR imageLayouts DEFAULT="{}" />;
   let selectedImage = '<TMPL_VAR mainImage>';
 
   <!-- TMPL_IF error -->
@@ -43,8 +43,8 @@
   <!-- /TMPL_IF -->
   <!-- TMPL_IF modeDownload -->
   document.addEventListener('DOMContentLoaded', () => {
-    if(document.getElementById('image')){
-      document.getElementById('image').style.backgroundImage = `url(${images['<TMPL_VAR mainImage DEFAULT=1>']})`;
+    if(document.querySelector('#image .image.current')){
+      document.querySelector('#image .image.current').style.backgroundImage = `url(${images['<TMPL_VAR mainImage DEFAULT=1>']})`;
     }
   });
   <!-- /TMPL_IF -->

--- a/_core/skin/ar2e/css/chara.css
+++ b/_core/skin/ar2e/css/chara.css
@@ -76,7 +76,6 @@
       "STT   STT  STT  STT"
     ;
   }
-  #image-none,
   #image     { grid-area: IMG; }
   #personal  { grid-area: PER; }
   #classes   { grid-area: CLS; }

--- a/_core/skin/ar2e/sheet-chara.html
+++ b/_core/skin/ar2e/sheet-chara.html
@@ -97,14 +97,20 @@
       </div>
       <div class="column column-status"><!-- COLUMN -->
       <div id="area-status">
-        <TMPL_IF image>
-        <div id="image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-        <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        <p class="image-copyright"><TMPL_VAR imageCopyright></p>
-        </div>
+        <div id="image"><TMPL_IF image>
+          <div class="image current" style="
+            background-image: url(<TMPL_VAR imageSrc>);
+            background-size:<TMPL_VAR imageFit>;
+            background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;
+          ">
+            <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)">
+              <p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p>
+            </div>
+            <p class="image-copyright"><TMPL_VAR imageCopyright></p>
+          </div>
         <TMPL_ELSE>
-        <div id="image-none" class="image-none" data-title="AR&#13;&#10;2E"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        </TMPL_IF>
+          <div class="image-none" data-title="AR&#13;&#10;2E"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+        </TMPL_IF></div>
 
         <div class="box-union" id="classes">
           <dl class="box" id="class-main">

--- a/_core/skin/blp/css/chara.css
+++ b/_core/skin/blp/css/chara.css
@@ -64,7 +64,6 @@
       "SCR SCR"
     ;
   }
-  #image-none,
   #image      { grid-area: IMG; }
   #personal   { grid-area: PER; }
   #factors    { grid-area: FAC; }

--- a/_core/skin/blp/sheet-chara.html
+++ b/_core/skin/blp/sheet-chara.html
@@ -140,14 +140,20 @@
       </div>
       <div class="column column-status"><!-- COLUMN -->
       <div id="area-status">
-        <TMPL_IF image> 
-        <div id="image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-        <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        <p class="image-copyright"><TMPL_VAR imageCopyright></p>
-        </div>
+        <div id="image"><TMPL_IF image>
+          <div class="image current" style="
+            background-image: url(<TMPL_VAR imageSrc>);
+            background-size:<TMPL_VAR imageFit>;
+            background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;
+          ">
+            <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)">
+              <p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p>
+            </div>
+            <p class="image-copyright"><TMPL_VAR imageCopyright></p>
+          </div>
         <TMPL_ELSE>
-        <div id="image-none" class="image-none" data-title="BLP"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        </TMPL_IF>
+          <div class="image-none" data-title="BLP"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+        </TMPL_IF></div>
 
         <div id="factors" class="box-union">
           <dl class="box" id="factor">

--- a/_core/skin/dx3/css/chara.css
+++ b/_core/skin/dx3/css/chara.css
@@ -65,7 +65,6 @@
       "LFP LFP LFP"
     ;
   }
-  #image-none,
   #image      { grid-area: IMG; }
   #personal   { grid-area: PER; }
   #sub-status { grid-area: STT; }

--- a/_core/skin/dx3/sheet-chara.html
+++ b/_core/skin/dx3/sheet-chara.html
@@ -97,14 +97,20 @@
       </div>
       <div class="column column-status"><!-- COLUMN -->
       <div id="area-status">
-        <TMPL_IF image> 
-        <div id="image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-        <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        <p class="image-copyright"><TMPL_VAR imageCopyright></p>
-        </div>
+        <div id="image"><TMPL_IF image>
+          <div class="image current" style="
+            background-image: url(<TMPL_VAR imageSrc>);
+            background-size:<TMPL_VAR imageFit>;
+            background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;
+          ">
+            <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)">
+              <p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p>
+            </div>
+            <p class="image-copyright"><TMPL_VAR imageCopyright></p>
+          </div>
         <TMPL_ELSE>
-        <div id="image-none" class="image-none" data-title="DX&#13;&#10;3rd"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        </TMPL_IF>
+          <div class="image-none" data-title="DX&#13;&#10;3rd"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+        </TMPL_IF></div>
 
         <div id="personal" class="box-union">
           <dl class="box"><dt>年齢<dd><TMPL_VAR age></dl>

--- a/_core/skin/gc/css/chara.css
+++ b/_core/skin/gc/css/chara.css
@@ -63,7 +63,6 @@
     ;
   }
 
-  #image-none,
   #image    { grid-area: IMG; max-height: 56.7rem; }
   #class-and-style
             { grid-area: CLS; }

--- a/_core/skin/gc/css/country.css
+++ b/_core/skin/gc/css/country.css
@@ -70,9 +70,10 @@
   #resources  { grid-area: RSC; }
 }
 /* Image */
-#image     { aspect-ratio: 1 / 1; }
-.image-none {
+#image {
+  aspect-ratio: 1 / 1;
   container-type: size;
+  align-self: start;
 }
 .image-none::after {
   font-size: 17cqw;

--- a/_core/skin/gc/css/country.css
+++ b/_core/skin/gc/css/country.css
@@ -64,19 +64,17 @@
     ;
   }
 
-  #image-none,
   #image      { grid-area: IMG; }
   #profile    { grid-area: PRF; }
   #members    { grid-area: MEM; }
   #resources  { grid-area: RSC; }
 }
 /* Image */
-#image-none,
 #image     { aspect-ratio: 1 / 1; }
-#image-none {
+.image-none {
   container-type: size;
 }
-#image-none::after {
+.image-none::after {
   font-size: 17cqw;
   line-height: 1;
   letter-spacing: -.1em;

--- a/_core/skin/gc/sheet-chara.html
+++ b/_core/skin/gc/sheet-chara.html
@@ -190,14 +190,20 @@
       </div>
       <div class="column column-status"><!-- COLUMN -->
         <div id="area-profile">
-          <TMPL_IF image>
-          <div id="image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-          <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-          <p class="image-copyright"><TMPL_VAR imageCopyright></p>
-          </div>
+          <div id="image"><TMPL_IF image>
+            <div class="image current" style="
+              background-image: url(<TMPL_VAR imageSrc>);
+              background-size:<TMPL_VAR imageFit>;
+              background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;
+            ">
+              <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)">
+                <p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p>
+              </div>
+              <p class="image-copyright"><TMPL_VAR imageCopyright></p>
+            </div>
           <TMPL_ELSE>
-          <div id="image-none" class="image-none" data-title="GRANCREST"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-          </TMPL_IF>
+            <div class="image-none" data-title="GRANCREST"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+          </TMPL_IF></div>
           
           <div class="box-union" id="personal">
             <dl class="box" id="country">

--- a/_core/skin/gc/sheet-country.html
+++ b/_core/skin/gc/sheet-country.html
@@ -97,14 +97,20 @@
       </div>
       <div class="column column-status"><!-- COLUMN -->
         <div id="area-profile">
-          <TMPL_IF image>
-          <div id="image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-          <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-          <p class="image-copyright"><TMPL_VAR imageCopyright></p>
-          </div>
+          <div id="image"><TMPL_IF image>
+            <div class="image current" style="
+              background-image: url(<TMPL_VAR imageSrc>);
+              background-size:<TMPL_VAR imageFit>;
+              background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;
+            ">
+              <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)">
+                <p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p>
+              </div>
+              <p class="image-copyright"><TMPL_VAR imageCopyright></p>
+            </div>
           <TMPL_ELSE>
-          <div id="image-none" class="image-none" data-title="GRANCREST"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-          </TMPL_IF>
+            <div class="image-none" data-title="GRANCREST"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+          </TMPL_IF></div>
           
           <div class="box-union" id="profile">
             <dl class="box" id="lord">

--- a/_core/skin/gs/css/chara.css
+++ b/_core/skin/gs/css/chara.css
@@ -98,7 +98,6 @@
       "STT STT STT STT"
     ;
   }
-  #image-none,
   #image     { grid-area: IMG; }
   #personal  { grid-area: PER; }
   #ability   { grid-area: ABL; }

--- a/_core/skin/gs/sheet-chara.html
+++ b/_core/skin/gs/sheet-chara.html
@@ -98,14 +98,20 @@
       </div>
       <div class="column" id="column-status"><!-- COLUMN -->
       <div id="area-status">
-        <TMPL_IF image>
-        <div id="image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-        <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        <p class="image-copyright"><TMPL_VAR imageCopyright></p>
-        </div>
+        <div id="image"><TMPL_IF image>
+          <div class="image current" style="
+            background-image: url(<TMPL_VAR imageSrc>);
+            background-size:<TMPL_VAR imageFit>;
+            background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;
+          ">
+            <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)">
+              <p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p>
+            </div>
+            <p class="image-copyright"><TMPL_VAR imageCopyright></p>
+          </div>
         <TMPL_ELSE>
-        <div id="image-none" class="image-none" data-title="GOBLIN&#13;&#10;SLAYER!"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        </TMPL_IF>
+          <div class="image-none" data-title="GOBLIN&#13;&#10;SLAYER!"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+        </TMPL_IF></div>
 
         <div id="personal">
           <dl class="box <TMPL_IF raceBase>has-base-race</TMPL_IF>" id="race">

--- a/_core/skin/kiz/css/chara.css
+++ b/_core/skin/kiz/css/chara.css
@@ -69,7 +69,6 @@
       "PER IMG"
     ;
   }
-  #image-none,
   #image      { grid-area: IMG; }
   #classes    { grid-area: CLS; }
   #hitogara   { grid-area: PER; }

--- a/_core/skin/kiz/sheet-chara.html
+++ b/_core/skin/kiz/sheet-chara.html
@@ -140,14 +140,20 @@
       </div>
       <div class="column column-status"><!-- COLUMN -->
       <div id="area-status">
-        <TMPL_IF image> 
-        <div id="image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-        <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        <p class="image-copyright"><TMPL_VAR imageCopyright></p>
-        </div>
+        <div id="image"><TMPL_IF image>
+          <div class="image current" style="
+            background-image: url(<TMPL_VAR imageSrc>);
+            background-size:<TMPL_VAR imageFit>;
+            background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;
+          ">
+            <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)">
+              <p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p>
+            </div>
+            <p class="image-copyright"><TMPL_VAR imageCopyright></p>
+          </div>
         <TMPL_ELSE>
-        <div id="image-none" class="image-none" data-title="KIZ"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        </TMPL_IF>
+          <div class="image-none" data-title="KIZ"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+        </TMPL_IF></div>
 
         <div id="classes" class="box-union">
           <dl class="box" id="class">

--- a/_core/skin/ms/css/chara.css
+++ b/_core/skin/ms/css/chara.css
@@ -121,7 +121,6 @@ h1#character-name:not(:has(ruby)) {
     "MAG MAG MAG"
     ;
   }
-  #image-none,
   #image      { grid-area: IMG; }
   #profile    { grid-area: PRF; }
   #level      { grid-area: LVL; }

--- a/_core/skin/ms/css/clan.css
+++ b/_core/skin/ms/css/clan.css
@@ -110,9 +110,10 @@ h1#character-name:not(:has(ruby)) {
 }
 
 /* Image */
-.image, .image-none {
+#image {
   aspect-ratio: 1 / 1;
   container-type: inline-size;
+  align-self: start;
 }
 .image-none::after {
   font-family: 'Montserrat','Impact';

--- a/_core/skin/ms/css/clan.css
+++ b/_core/skin/ms/css/clan.css
@@ -96,7 +96,6 @@ h1#character-name:not(:has(ruby)) {
     "MAG MAG MAG"
     ;
   }
-  #image-none,
   #image      { grid-area: IMG; }
   #profile    { grid-area: PRF; }
   #level      { grid-area: LVL; }

--- a/_core/skin/ms/sheet-chara.html
+++ b/_core/skin/ms/sheet-chara.html
@@ -99,14 +99,20 @@
       </div>
       <div class="column column-status"><!-- COLUMN -->
       <div id="area-status">
-        <TMPL_IF image> 
-        <div id="image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-        <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        <p class="image-copyright"><TMPL_VAR imageCopyright></p>
-        </div>
+        <div id="image"><TMPL_IF image>
+          <div class="image current" style="
+            background-image: url(<TMPL_VAR imageSrc>);
+            background-size:<TMPL_VAR imageFit>;
+            background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;
+          ">
+            <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)">
+              <p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p>
+            </div>
+            <p class="image-copyright"><TMPL_VAR imageCopyright></p>
+          </div>
         <TMPL_ELSE>
-        <div id="image-none" class="image-none" data-title="MAMONO&#13;&#10;SCRAMBLE"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        </TMPL_IF>
+          <div class="image-none" data-title="MAMONO&#13;&#10;SCRAMBLE"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+        </TMPL_IF></div>
 
         <section class="box-union" id="profile">
           <dl class="box" id="taxa"        ><dt>分類名<dd><TMPL_VAR taxa></dl>

--- a/_core/skin/ms/sheet-clan.html
+++ b/_core/skin/ms/sheet-clan.html
@@ -99,14 +99,20 @@
       </div>
       <div class="column column-status"><!-- COLUMN -->
       <div id="area-status">
-        <TMPL_IF image> 
-        <div id="image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-        <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        <p class="image-copyright"><TMPL_VAR imageCopyright></p>
-        </div>
+        <div id="image"><TMPL_IF image>
+          <div class="image current" style="
+            background-image: url(<TMPL_VAR imageSrc>);
+            background-size:<TMPL_VAR imageFit>;
+            background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;
+          ">
+            <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)">
+              <p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p>
+            </div>
+            <p class="image-copyright"><TMPL_VAR imageCopyright></p>
+          </div>
         <TMPL_ELSE>
-        <div id="image-none" class="image-none" data-title="MAMONO&#13;&#10;SCRAMBLE"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        </TMPL_IF>
+          <div class="image-none" data-title="MAMONO&#13;&#10;SCRAMBLE"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+        </TMPL_IF></div>
 
         <dl class="box" id="level">
           <dt>強度

--- a/_core/skin/sw2/css/chara.css
+++ b/_core/skin/sw2/css/chara.css
@@ -102,7 +102,6 @@ header nav ul li.character-format {
       "EXP  LVL  sSTT IMG"
     ;
   }
-  #image-none,
   #image     { grid-area: IMG; }
   #personal  { grid-area: PER; }
   #status    { grid-area: STT; }

--- a/_core/skin/sw2/sheet-chara.html
+++ b/_core/skin/sw2/sheet-chara.html
@@ -96,14 +96,20 @@
       </div>
       <div class="column column-status"><!-- COLUMN -->
       <div id="area-status">
-        <TMPL_IF image>
-        <div id="image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-        <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        <p class="image-copyright"><TMPL_VAR imageCopyright></p>
-        </div>
+        <div id="image"><TMPL_IF image>
+          <div class="image current" style="
+            background-image: url(<TMPL_VAR imageSrc>);
+            background-size:<TMPL_VAR imageFit>;
+            background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;
+          ">
+            <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)">
+              <p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p>
+            </div>
+            <p class="image-copyright"><TMPL_VAR imageCopyright></p>
+          </div>
         <TMPL_ELSE>
-        <div id="image-none" class="image-none" data-title="SW&#13;&#10;<TMPL_IF modeZero>2.0<TMPL_ELSE>2.5</TMPL_IF>"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        </TMPL_IF>
+          <div class="image-none" data-title="SW&#13;&#10;<TMPL_IF modeZero>2.0<TMPL_ELSE>2.5</TMPL_IF>"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+        </TMPL_IF></div>
 
         <div id="personal">
           <dl class="box" id="race">
@@ -732,7 +738,7 @@
       <div id="personal-area">
       <TMPL_IF image> 
       <div id="f-image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-      <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+      <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
       <p class="image-copyright"><TMPL_VAR imageCopyright></p>
       </div>
       <TMPL_ELSE>

--- a/_core/skin/vc/css/chara.css
+++ b/_core/skin/vc/css/chara.css
@@ -67,8 +67,7 @@
     ;
   }
 }
-#image-none,
-#image     { grid-area: IMG; max-height: 56.7rem; }
+#image       { grid-area: IMG; max-height: 56.7rem; }
 #levels      { grid-area: LVL; }
 #personal    { grid-area: PER; }
 #appearance  { grid-area: APP; }

--- a/_core/skin/vc/sheet-chara.html
+++ b/_core/skin/vc/sheet-chara.html
@@ -97,14 +97,20 @@
       </div>
       <div class="column column-status"><!-- COLUMN -->
       <div id="area-status">
-        <TMPL_IF image>
-        <div id="image" class="image" style="background-image: url(<TMPL_VAR imageSrc>);background-size:<TMPL_VAR imageFit>;background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;">
-        <div onclick="popImage()"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        <p class="image-copyright"><TMPL_VAR imageCopyright></p>
-        </div>
+        <div id="image"><TMPL_IF image>
+          <div class="image current" style="
+            background-image: url(<TMPL_VAR imageSrc>);
+            background-size:<TMPL_VAR imageFit>;
+            background-position:<TMPL_VAR imagePositionX>% <TMPL_VAR imagePositionY>%;
+          ">
+            <div onclick="popImage(<TMPL_VAR mainImage DEFAULT=1>)">
+              <p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p>
+            </div>
+            <p class="image-copyright"><TMPL_VAR imageCopyright></p>
+          </div>
         <TMPL_ELSE>
-        <div id="image-none" class="image-none" data-title="VC"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
-        </TMPL_IF>
+          <div class="image-none" data-title="VC"><p class="words" style="<TMPL_VAR wordsX><TMPL_VAR wordsY>"><TMPL_VAR words></p></div>
+        </TMPL_IF></div>
         
         <div id="levels">
           <dl class="box" id="result-points">


### PR DESCRIPTION
### Motivation
- Allow sheets to store multiple images per character and let users choose which image is the main display image. 
- Preserve existing behavior for single-image installations by defaulting to one image and remaining backward-compatible. 
- Provide per-image upload, deletion, compression and archival so images can be managed independently. 

### Description
- Add new configuration `image_maxcount` with a default of `1` in `config-default.pl` to control maximum stored images per sheet. 
- Update front-end (`_core/lib/edit.js`) to support multiple image inputs, per-image compression and previews by tracking `compressedImageFiles` and passing `imageNo` through image handlers, backup, form submission and JSON export. 
- Extend backend read/write paths to use suffixed filenames (e.g. `image2.jpg`) and to accept `imageNo` parameters when redirecting or serving images in `_core/lib/others.pl`, `_core/lib/subroutine.pl`, and `_core/lib/view.pl`. 
- Update save flow in `_core/lib/save.pl` to handle multiple incoming `imageFileN` fields, per-image deletion flags, per-image update timestamps, to maintain `mainImage` selection, and to pass image data into `dataSave`. 
- Add `deleteImageData` helper in `_core/lib/edit.pl` to simplify removal of image-related keys and update `renderImageForm` to render multiple file inputs and a radio UI for `mainImage`. 
- Change `dataSave` to archive/read image files with numeric suffixes, include uploaded image data in archives, and to delete/replace the correct suffixed files on updates. 

### Testing
- Ran `perl -c` (syntax checks) on modified Perl modules and they completed successfully. 
- Performed a static JavaScript syntax check on `_core/lib/edit.js` with `node --check` and it reported no syntax errors. 
- No additional automated integration tests were included in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e65a66f34832781f0a4fd87c5fc8f)