### PR TITLE
🐛 修正: text-shadow がある要素について {{  }} で透明にしようとすると text-shadow が透明にならない

### DIFF
--- a/_core/lib/subroutine.pl
+++ b/_core/lib/subroutine.pl
@@ -898,7 +898,7 @@ sub unescapeTags {
   $text =~ s/''(.+?)''/<b>$1<\/b>/gi;  # 太字
   $text =~ s/%%(.+?)%%/<span class="strike">$1<\/span>/gi;  # 打ち消し線
   $text =~ s/__(.+?)__/<span class="underline">$1<\/span>/gi;  # 下線
-  $text =~ s/\{\{(.+?)\}\}/<span style="color:transparent">$1<\/span>/gi;  # 透明
+  $text =~ s/\{\{(.+?)\}\}/<span style="color:transparent; text-shadow:none;">$1<\/span>/gi;  # 透明
   $text =~ s/[|｜]([^|｜\n]+?)《(.+?)》/<ruby><rp>｜<\/rp>$1<rp>《<\/rp><rt>$2<\/rt><rp>》<\/rp><\/ruby>/gi; # なろう式ルビ
   $text =~ s/《《(.+?)》》/<span class="text-em">$1<\/span>/gi; # カクヨム式傍点
 
@@ -1438,7 +1438,7 @@ sub renderTextRule {
       <dl><dt>下線  <dd><code>__テキスト__</code>：<span class="underline">テキスト</span></dl>
       <dl><dt>ルビ  <dd><code>|テキスト《てきすと》</code>：<ruby>テキスト<rt>てきすと</rt></ruby></dl>
       <dl><dt>傍点  <dd><code>《《テキスト》》</code>：<span class="text-em">テキスト</span></dl>
-      <dl><dt>透明  <dd><code>{{テキスト}}</code>：<span style="color:transparent">テキスト</span>（ドラッグ反転で見える）</dl>
+      <dl><dt>透明  <dd><code>{{テキスト}}</code>：<span style="color:transparent; text-shadow:none;">テキスト</span>（ドラッグ反転で見える）</dl>
       <dl><dt>リンク<dd><code>[[テキスト>URL]]</code></dl>
       <dl><dt>他のシートへのリンク<dd><code>[テキスト#シートのID]</code></dl>
       @{[ defined(&renderAddTextRule) ? &renderAddTextRule() : '' ]}


### PR DESCRIPTION
# 概要
text-shadow がある要素について、文字を透明にしようとすると
text-shadow が残るため、文字列が浮かび上がって表示され続けます。

テキストをなんらか隠したいという意図で実装されている機能であろうことから、
text-shadow も消すように修正する提案です。
# 実例
https://yutorize.work/ytsheet/sw2.5/?id=KO1Ut2
（キャラクター名、自由記入の表、容姿・経歴・その他メモ欄が該当）
# 動作確認
[自鯖にて動作確認済](https://hiyo-hitsu.sakura.ne.jp/ytsheets/ytsheet2_sw2.5/sw2.5/?id=TBdoJL)
# 懸念・相談
## class の方がいいかも
複数の要素に影響を与えようとするため、
これを機に style ではなく class として記載して
CSS にまとめ直したほうがいいかもしれません。
## 利用している人がいるかも？
白く浮かび上がるのがややかっこいい説はあるため、
これを問題ではなく仕様であるとして利用している人がいるかもしれません